### PR TITLE
support non-relative URLs with protocol

### DIFF
--- a/dist/es-module-shims.js
+++ b/dist/es-module-shims.js
@@ -156,10 +156,14 @@
     }
   }
 
+  const protocolre = /^[a-z][a-z0-9.+-]*\:/i;
   function resolveImportMap (id, parentUrl, importMap) {
     const urlResolved = resolveIfNotPlainOrUrl(id, parentUrl);
-    if (urlResolved)
+    if (urlResolved){
       id = urlResolved;
+    } else if (protocolre.test(id)) { // non-relative URL with protocol
+      return id;
+    }
     const scopeName = getMatch(parentUrl, importMap.scopes);
     if (scopeName) {
       const scopePackages = importMap.scopes[scopeName];

--- a/src/common.js
+++ b/src/common.js
@@ -12,17 +12,12 @@ if (typeof location !== 'undefined') {
 }
 
 const backslashRegEx = /\\/g;
-const protocolre = /^[a-z][a-z0-9.+-]*\:/i
 export function resolveIfNotPlainOrUrl (relUrl, parentUrl) {
   if (relUrl.indexOf('\\') !== -1)
     relUrl = relUrl.replace(backslashRegEx, '/');
   // protocol-relative
   if (relUrl[0] === '/' && relUrl[1] === '/') {
     return parentUrl.slice(0, parentUrl.indexOf(':') + 1) + relUrl;
-  }
-  // non-relative URL with protocol
-  else if (protocolre.test(relUrl)) {
-    return relUrl;
   }
   // relative-url
   else if (relUrl[0] === '.' && (relUrl[1] === '/' || relUrl[1] === '.' && (relUrl[2] === '/' || relUrl.length === 2 && (relUrl += '/')) ||
@@ -162,10 +157,14 @@ function applyPackages (id, packages, baseUrl) {
   }
 }
 
+const protocolre = /^[a-z][a-z0-9.+-]*\:/i;
 export function resolveImportMap (id, parentUrl, importMap) {
   const urlResolved = resolveIfNotPlainOrUrl(id, parentUrl);
-  if (urlResolved)
+  if (urlResolved){
     id = urlResolved;
+  } else if (protocolre.test(id)) { // non-relative URL with protocol
+    return id;
+  }
   const scopeName = getMatch(parentUrl, importMap.scopes);
   if (scopeName) {
     const scopePackages = importMap.scopes[scopeName];

--- a/src/common.js
+++ b/src/common.js
@@ -19,6 +19,10 @@ export function resolveIfNotPlainOrUrl (relUrl, parentUrl) {
   if (relUrl[0] === '/' && relUrl[1] === '/') {
     return parentUrl.slice(0, parentUrl.indexOf(':') + 1) + relUrl;
   }
+  // non-relative URL with protocol
+  else if (relUrl.indexOf('://') > 1) {
+    return relUrl;
+  }
   // relative-url
   else if (relUrl[0] === '.' && (relUrl[1] === '/' || relUrl[1] === '.' && (relUrl[2] === '/' || relUrl.length === 2 && (relUrl += '/')) ||
       relUrl.length === 1  && (relUrl += '/')) ||

--- a/src/common.js
+++ b/src/common.js
@@ -12,6 +12,7 @@ if (typeof location !== 'undefined') {
 }
 
 const backslashRegEx = /\\/g;
+const protocolre = /^[a-z][a-z0-9.+-]*\:/i
 export function resolveIfNotPlainOrUrl (relUrl, parentUrl) {
   if (relUrl.indexOf('\\') !== -1)
     relUrl = relUrl.replace(backslashRegEx, '/');
@@ -20,7 +21,7 @@ export function resolveIfNotPlainOrUrl (relUrl, parentUrl) {
     return parentUrl.slice(0, parentUrl.indexOf(':') + 1) + relUrl;
   }
   // non-relative URL with protocol
-  else if (relUrl.indexOf('://') > 1) {
+  else if (protocolre.test(relUrl)) {
     return relUrl;
   }
   // relative-url

--- a/test/browser-modules.js
+++ b/test/browser-modules.js
@@ -54,7 +54,19 @@ suite('Basic loading tests', () => {
     var m = await importShim('./fixtures/es-modules/moduleName.js');
     assert.equal(m.name, new URL('./fixtures/es-modules/moduleName.js', baseURL).href);
   });
+
+  test('Should import a module via a full url, without scheme', async function () {
+    var m = await importShim('//unpkg.com/lit-html@1.0.0/lit-html.js');
+    assert(m);
+    assert(m.html);
   });
+
+  test('Should import a module via a full url, with scheme', async function () {
+    var m = await importShim('https://unpkg.com/lit-html@1.0.0/lit-html.js');
+    assert(m);
+    assert(m.html);
+  });
+});
 
 suite('Circular dependencies', function() {
   test('should resolve circular dependencies', async function () {

--- a/test/browser-modules.js
+++ b/test/browser-modules.js
@@ -55,16 +55,22 @@ suite('Basic loading tests', () => {
     assert.equal(m.name, new URL('./fixtures/es-modules/moduleName.js', baseURL).href);
   });
 
-  test('Should import a module via a full url, without scheme', async function () {
-    var m = await importShim('//unpkg.com/lit-html@1.0.0/lit-html.js');
+  test('Should import a module via a full url, with scheme', async function () {
+    const url = window.location.href.replace('/test.html', '/fixtures/es-modules/no-imports.js');
+    assert.equal(url.slice(0, 4), 'http');
+    var m = await importShim(url);
     assert(m);
-    assert(m.html);
+    assert.equal(m.asdf, 'asdf');
   });
 
-  test('Should import a module via a full url, with scheme', async function () {
-    var m = await importShim('https://unpkg.com/lit-html@1.0.0/lit-html.js');
+  test('Should import a module via a full url, without scheme', async function () {
+    const url = window.location.href
+      .replace('/test.html', '/fixtures/es-modules/no-imports.js')
+      .replace(/^http(s)?:/, '');
+    assert.equal(url.slice(0, 2), '//');
+    var m = await importShim(url);
     assert(m);
-    assert(m.html);
+    assert.equal(m.asdf, 'asdf');
   });
 
   test('Should import a module via data url', async function () {

--- a/test/browser-modules.js
+++ b/test/browser-modules.js
@@ -66,6 +66,20 @@ suite('Basic loading tests', () => {
     assert(m);
     assert(m.html);
   });
+
+  test('Should import a module via data url', async function () {
+    var m = await importShim('data:text/plain;charset=utf-8;base64,ZXhwb3J0IHZhciBhc2RmID0gJ2FzZGYnOw0KZXhwb3J0IHZhciBvYmogPSB7fTs=');
+    assert(m);
+    assert.equal(m.asdf, 'asdf');
+  });
+
+  test('Should import a module via blob', async function () {
+    const code = await (await fetch('./fixtures/es-modules/no-imports.js')).text();
+    const blob = new Blob([code], { type: 'application/javascript' });
+    var m = await importShim(URL.createObjectURL(blob));
+    assert(m);
+    assert.equal(m.asdf, 'asdf');
+  });
 });
 
 suite('Circular dependencies', function() {


### PR DESCRIPTION
Potential fix for #6 

* Supports `http(s):`, `data:`, and `blob:` urls.
* Adds tests for `http(s):`, `data:`, and `blob:` urls.