### PR TITLE
Implement json modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,17 @@ To load code dynamically (say from the browser console), `importShim` can be cal
 importShim('/path/to/module.js').then(x => console.log(x));
 ```
 
+### JSON Modules
+
+To load [JSON Modules](https://github.com/whatwg/html/pull/4407), import any file with a `.json` file extension:
+
+```js
+import json from './test.json';
+```
+
 ### Web Assembly
 
-To load Web Assembly, just import it:
+To load [Web Assembly Modules](https://github.com/webassembly/esm-integration), import a module with a `.wasm` file extension:
 
 ```js
 import { fn } from './test.wasm';

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -207,6 +207,8 @@ function getOrCreateLoad (url, source) {
       }
 
       source = await res.text();
+      if (res.url.endsWith('.json'))
+        source = `export default JSON.parse(${JSON.stringify(source)})`;
     }
     load.a = analyzeModuleSyntax(source);
     if (load.a[2])

--- a/test/browser-modules.js
+++ b/test/browser-modules.js
@@ -40,6 +40,26 @@ suite('Basic loading tests', () => {
       throw new Error('Supposed to throw');
   });
 
+  test('should import json', async function () {
+    var m = await importShim('./fixtures/json.json');
+    assert.equal(m.default.json, 'module');
+  });
+
+  test('should throw json parse errors', async function () {
+    try {
+      await importShim('./fixtures/json-error.json');
+    }
+    catch (e) {
+      assert(e instanceof SyntaxError);
+    }
+    try {
+      await importShim('./fixtures/json-error.json');
+    }
+    catch (e) {
+      assert(e instanceof SyntaxError);
+    }
+  });
+
   test('should resolve various import syntax', async function () {
     var m = await importShim('./fixtures/es-modules/import.js');
     assert.equal(typeof m.a, 'function');

--- a/test/fixtures/json-error.json
+++ b/test/fixtures/json-error.json
@@ -1,0 +1,3 @@
+{
+  "json": "module
+}

--- a/test/fixtures/json.json
+++ b/test/fixtures/json.json
@@ -1,0 +1,3 @@
+{
+  "json": "module"
+}


### PR DESCRIPTION
This implements loading of json modules, as in the WhatWG spec.

Again, we use file extensions as the signifier, which while not strictly spec compliant is a good enough heuristic for the polyfill.