### PR TITLE
support fallback imports from import map

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -123,9 +123,11 @@ function resolvePackages(pkgs) {
   for (var p in pkgs) {
     var value = pkgs[p];
     // TODO package fallback support
-    if (typeof value !== 'string')
-      continue;
-    outPkgs[resolveIfNotPlainOrUrl(p) || p] = value;
+    if (typeof value !== 'string') {
+      outPkgs[resolveIfNotPlainOrUrl(p) || p] = value.filter(v => !v.startsWith('std:'))[0];
+    } else {
+      outPkgs[resolveIfNotPlainOrUrl(p) || p] = value;
+    }
   }
   return outPkgs;
 }

--- a/src/common.js
+++ b/src/common.js
@@ -123,11 +123,10 @@ function resolvePackages(pkgs) {
   for (var p in pkgs) {
     var value = pkgs[p];
     // TODO package fallback support
-    if (typeof value !== 'string') {
-      outPkgs[resolveIfNotPlainOrUrl(p) || p] = value.filter(v => !v.startsWith('std:'))[0];
-    } else {
+    if (Array.isArray(value))
+      value = value.find(v => !v.startsWith('std:'));
+    if (typeof value === 'string')
       outPkgs[resolveIfNotPlainOrUrl(p) || p] = value;
-    }
   }
   return outPkgs;
 }

--- a/src/common.js
+++ b/src/common.js
@@ -172,7 +172,7 @@ function applyPackages (id, packages, baseUrl) {
 
 const protocolre = /^[a-z][a-z0-9.+-]*\:/i;
 export function resolveImportMap (id, parentUrl, importMap) {
-  const urlResolved = resolveIfNotPlainOrUrl(id, parentUrl);
+  const urlResolved = resolveIfNotPlainOrUrl(id, parentUrl) || id.indexOf(':') !== -1 && id;
   if (urlResolved){
     id = urlResolved;
   } else if (protocolre.test(id)) { // non-relative URL with protocol

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -165,11 +165,6 @@ function getOrCreateLoad (url, source) {
     s: undefined,
   };
 
-  if(url.startsWith('std:')) {
-    load.u = importShim.map.imports[url]
-    url = importShim.map.imports[url]
-  }
-
   load.f = (async () => {
     if (!source) {
       const res = await fetch(url);

--- a/test/browser-modules.js
+++ b/test/browser-modules.js
@@ -5,6 +5,12 @@ suite('Basic loading tests', () => {
     assert.equal(m.asdf, 'asdf');
   });
 
+  test('Should import the fallback for a built-in module', async function () {
+    var m = await importShim('std:built-in');
+    assert(m);
+    assert.equal(m.fallback, 'fallback');
+  });
+
   test('Should import a module cached', async function () {
     var m1 = await importShim('./fixtures/es-modules/no-imports.js');
     var m2 = await importShim('./fixtures/es-modules/no-imports.js');

--- a/test/fixtures/es-modules/built-in-fallback.js
+++ b/test/fixtures/es-modules/built-in-fallback.js
@@ -1,0 +1,1 @@
+export var fallback = 'fallback';

--- a/test/test.html
+++ b/test/test.html
@@ -6,7 +6,8 @@
   "imports": {
     "test": "/test/fixtures/es-modules/es6-file.js",
     "test/": "/test/fixtures/",
-    "example": "/test/fixtures/wasm/example.js"
+    "example": "/test/fixtures/wasm/example.js",
+    "std:built-in": ["std:built-in", "/test/fixtures/es-modules/built-in-fallback.js"]
   },
   "scopes": {
     "/": {


### PR DESCRIPTION
Regarding this issue: https://github.com/guybedford/es-module-shims/issues/19 Would this suffice to support fallbacks for now? This should always resolve the fallback instead of the built-in module, as you suggested in that issue. Please let me know your thoughts on this :-) Would happily take some pointers