### PR TITLE
fix importing modules with path segments

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -25,6 +25,8 @@ if (typeof document !== 'undefined') {
 
 const backslashRegEx = /\\/g;
 export function resolveIfNotPlainOrUrl (relUrl, parentUrl) {
+  // strip off any trailing query params or hashes
+  parentUrl = parentUrl && parentUrl.split('#')[0].split('?')[0];
   if (relUrl.indexOf('\\') !== -1)
     relUrl = relUrl.replace(backslashRegEx, '/');
   // protocol-relative

--- a/test/browser-modules.js
+++ b/test/browser-modules.js
@@ -112,6 +112,12 @@ suite('Basic loading tests', () => {
     assert(m);
     assert.equal(m.asdf, 'asdf');
   });
+
+  test('Should import a module with query parameters with path segments', async function () {
+    var m = await importShim('./fixtures/es-modules/query-param-a.js?foo=/foo/bar/');
+    assert(m);
+    assert.equal(m.a, 'ab');
+  });
 });
 
 suite('Circular dependencies', function() {

--- a/test/fixtures/es-modules/query-param-a.js
+++ b/test/fixtures/es-modules/query-param-a.js
@@ -1,0 +1,3 @@
+import { b } from './query-param-b.js';
+
+export const a = 'a' + b;

--- a/test/fixtures/es-modules/query-param-b.js
+++ b/test/fixtures/es-modules/query-param-b.js
@@ -1,0 +1,1 @@
+export const b = 'b';


### PR DESCRIPTION
When you import a module with query parameters or hashes it incorrectly imports dependencies as it's trying to join the paths including the query parameters and hashes. Stripping them before resolving, just like with the page base path, fixes this.