### PR TITLE
Fixes source mapping in Firefox.

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -132,6 +132,7 @@ async function resolveDeps (load, seen) {
     resolvedSource += source.slice(lastIndex);
   }
 
+  resolvedSource = resolvedSource.replace(/\/\/# sourceMappingURL=(.*)\s*$/, (match, url) => match.replace(url, new URL(url, load.r)));
   load.b = createBlob(resolvedSource + '\n//# sourceURL=' + load.r);
   load.S = undefined;
 }


### PR DESCRIPTION
I made this change locally per recommendation in #4 and it seems to resolve the problem.  I also tested in Chrome, which appeared to work for me.

Breakpoints in Firefox still don't work from within source maps, but I think that is a Firefox bug, not an issue with this library.

I recommend having either CI or another human manually test this change.  I have no idea what I'm doing and just took the code referenced in #4 and pasted it verbatim.

Fixes #4