### PR TITLE
Upgrade to latest Wasm es-module-lexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ Due to the use of a tiny [Web Assembly JS tokenizer for ES module syntax only](h
 
 Works in all browsers with [baseline ES module support](https://caniuse.com/#feat=es6-module).
 
-For support in Microsoft Edge, a [TextEncoder polyfill](https://github.com/anonyco/FastestSmallestTextEncoderDecoder) needs to be included in the environment.
-
 ### Import Maps
 
 > It is also possible to ship import maps directly in Chrome (without using this project!) through the [Chrome Origin Trial](https://developers.chrome.com/origintrials/#/view_trial/3175037737296199681). The hope is for this project to eventually become a true polyfill for import maps in older browsers, but this will only happen once the spec is implemented in more than one browser and demonstrated to be stable.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 But a lot of the useful features of modules come from new specifications which either aren't implemented yet, or are only available in some browsers.
 
-_It turns out that we can actually polyfill most of the newer modules specifications on top of these baseline implementations in a performant 4KB shim._
+_It turns out that we can actually polyfill most of the newer modules specifications on top of these baseline implementations in a performant 7KB shim._
 
 This includes support for:
 
@@ -20,7 +20,7 @@ Because we are still using the native module loader the edge cases work out comp
 * Dynamic import expressions (`import('src/' + varname')`)
 * Circular references, with the execption that live bindings are disabled for the first unexecuted circular parent.
 
-Due to the use of a dedicated JS tokenizer for ES module syntax only, with very simple rewriting rules, transformation is instant.
+Due to the use of a tiny [Web Assembly JS tokenizer for ES module syntax only](https://github.com/guybedford/es-module-lexer), with very simple rewriting rules, transformation is instant.
 
 ### Import Maps
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## ES Module Shims
 
-[85% of desktop users](https://caniuse.com/#feat=es6-module) are now running browsers with baseline support for ES modules.
+[85% of users](https://caniuse.com/#feat=es6-module) are now running browsers with baseline support for ES modules.
 
 But a lot of the useful features of modules come from new specifications which either aren't implemented yet, or are only available in some browsers.
 
@@ -21,6 +21,12 @@ Because we are still using the native module loader the edge cases work out comp
 * Circular references, with the execption that live bindings are disabled for the first unexecuted circular parent.
 
 Due to the use of a tiny [Web Assembly JS tokenizer for ES module syntax only](https://github.com/guybedford/es-module-lexer), with very simple rewriting rules, transformation is instant.
+
+### Browser Support
+
+Works in all browsers with [baseline ES module support](https://caniuse.com/#feat=es6-module).
+
+For support in Microsoft Edge, a [TextEncoder polyfill](https://github.com/anonyco/FastestSmallestTextEncoderDecoder) needs to be included in the environment.
 
 ### Import Maps
 

--- a/README.md
+++ b/README.md
@@ -107,13 +107,12 @@ This matches the specification for ES module workers, supporting all features of
 
 ## Implementation Details
 
-### Tokenizer Rewriting
+### Import Rewriting
 
-* Tokenizing handles the full language grammar including nested template strings, comments, regexes and division operator ambiguity based on backtracking.
-* Rewriting is based on fetching the sources, turning them into BlobURLs and executing up the graph.
-* When executing a circular reference A -> B -> A, a shell module technique is used to "shim" the circular reference into an acyclic graph. As a result, live bindings for the circular parent A are not supported, and instead the bindings are captured immediately after the execution of A.
-* The approach will only work in browsers supporting ES modules.
+* Sources are fetched, import specifiers are rewritten to reference exact URLs, and then executed as BlobURLs through the whole module graph.
 * CSP is not supported as we're using fetch and modular evaluation.
+* The [tokenizer](https://github.com/guybedford/es-module-lexer) handles the full language grammar including nested template strings, comments, regexes and division operator ambiguity based on backtracking.
+* When executing a circular reference A -> B -> A, a shell module technique is used to "shim" the circular reference into an acyclic graph. As a result, live bindings for the circular parent A are not supported, and instead the bindings are captured immediately after the execution of A.
 
 ### Import Maps
 * The import maps specification is under active development and will change, all of the current specification features are implemented, but the edge cases are not currently fully handled. These will be refined as the specification and reference implementation continue to develop.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Guy Bedford",
   "license": "MIT",
   "devDependencies": {
-    "es-module-lexer": "^0.3.3",
+    "es-module-lexer": "^0.3.4",
     "esm": "^3.2.25",
     "kleur": "^2.0.2",
     "mocha": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Guy Bedford",
   "license": "MIT",
   "devDependencies": {
-    "es-module-lexer": "^0.3.2",
+    "es-module-lexer": "^0.3.3",
     "esm": "^3.2.25",
     "kleur": "^2.0.2",
     "mocha": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Guy Bedford",
   "license": "MIT",
   "devDependencies": {
-    "es-module-lexer": "^0.3.4",
+    "es-module-lexer": "^0.3.5",
     "esm": "^3.2.25",
     "kleur": "^2.0.2",
     "mocha": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Guy Bedford",
   "license": "MIT",
   "devDependencies": {
-    "es-module-lexer": "^0.3.5",
+    "es-module-lexer": "^0.3.6",
     "esm": "^3.2.25",
     "kleur": "^2.0.2",
     "mocha": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Guy Bedford",
   "license": "MIT",
   "devDependencies": {
-    "es-module-lexer": "^0.3.6",
+    "es-module-lexer": "^0.3.7",
     "esm": "^3.2.25",
     "kleur": "^2.0.2",
     "mocha": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Guy Bedford",
   "license": "MIT",
   "devDependencies": {
-    "es-module-lexer": "^0.1.2",
+    "es-module-lexer": "^0.3.1",
     "esm": "^3.2.25",
     "kleur": "^2.0.2",
     "mocha": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Guy Bedford",
   "license": "MIT",
   "devDependencies": {
-    "es-module-lexer": "^0.3.1",
+    "es-module-lexer": "^0.3.2",
     "esm": "^3.2.25",
     "kleur": "^2.0.2",
     "mocha": "^5.2.0",

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -1,5 +1,5 @@
 import { baseUrl as pageBaseUrl, parseImportMap, resolveImportMap, createBlob, resolveUrl } from './common.js';
-import analyzeModuleSyntax from '../node_modules/es-module-lexer/lexer.js';
+import { init, parse } from '../node_modules/es-module-lexer/dist/lexer.js';
 import { WorkerShim } from './worker-shims.js';
 
 let id = 0;
@@ -40,6 +40,7 @@ async function loadAll (load, loaded) {
 }
 
 async function topLevelLoad (url, source) {
+  await init;
   const load = getOrCreateLoad(url, source);
   await loadAll(load, {});
   resolveDeps(load, {});
@@ -206,7 +207,7 @@ function getOrCreateLoad (url, source) {
       if (res.url.endsWith('.json'))
         source = `export default JSON.parse(${JSON.stringify(source)})`;
     }
-    load.a = analyzeModuleSyntax(source);
+    load.a = parse(source);
     load.S = source;
     return load.a[0].filter(d => d.d === -1).map(d => source.slice(d.s, d.e));
   })();

--- a/test/perf.html
+++ b/test/perf.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<script type="module" src="../src/es-module-shims.js"></script>
+<script type="module">
+  console.time('Angular Load');
+  importShim('https://dev.jspm.io/angular').then(babel => {
+    console.timeEnd('Angular Load');
+    console.log(babel.default);
+  });
+</script>


### PR DESCRIPTION
This upgrades to the latest es-module-lexer, which now uses Web Assembly for the analysis. We still retain a single-file .js build at the cost of an extra 2KiB, but the win is 6x improvement in cold start performance, which improves the performance from over 100ms for multiple megabytes of JS analysis to down to under 50ms!