### PR TITLE
Optimize sourcemap detection

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -114,7 +114,7 @@ export function resolveIfNotPlainOrUrl (relUrl, parentUrl) {
  *
  */
 
-function resolveUrl (relUrl, parentUrl) {
+export function resolveUrl (relUrl, parentUrl) {
   return resolveIfNotPlainOrUrl(relUrl, parentUrl) ||
       relUrl.indexOf(':') !== -1 && relUrl ||
       resolveIfNotPlainOrUrl('./' + relUrl, parentUrl);

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -1,4 +1,4 @@
-import { baseUrl as pageBaseUrl, parseImportMap, resolveImportMap, createBlob } from './common.js';
+import { baseUrl as pageBaseUrl, parseImportMap, resolveImportMap, createBlob, resolveURL } from './common.js';
 import analyzeModuleSyntax from '../node_modules/es-module-lexer/lexer.js';
 import { WorkerShim } from './worker-shims.js';
 
@@ -135,7 +135,7 @@ async function resolveDeps (load, seen) {
   const lastNonEmptyLine = resolvedSource.slice(resolvedSource.trimEnd().lastIndexOf('\n') + 1);
   let sourceMappingURL;
   if (lastNonEmptyLine.startsWith('//# sourceMappingURL='))
-    sourceMappingURL = new URL(lastNonEmptyLine.slice(21), load.r).href;
+    sourceMappingURL = resolveURL(lastNonEmptyLine.slice(21), load.r);
   load.b = createBlob(resolvedSource + (sourceMappingURL ? '\n//# sourceMappingURL=' + sourceMappingURL : '') + '\n//# sourceURL=' + load.r);
   load.S = undefined;
 }

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -134,7 +134,7 @@ async function resolveDeps (load, seen) {
 
   const lastNonEmptyLine = resolvedSource.slice(resolvedSource.trimEnd().lastIndexOf('\n') + 1);
   let sourceMappingURL;
-  if (lastNonEmptyLine.startsWith('\/\/# sourceMappingURL='))
+  if (lastNonEmptyLine.startsWith('//# sourceMappingURL='))
     sourceMappingURL = new URL(lastNonEmptyLine.slice(21), load.r).href;
   load.b = createBlob(resolvedSource + (sourceMappingURL ? '\n//# sourceMappingURL=' + sourceMappingURL : '') + '\n//# sourceURL=' + load.r);
   load.S = undefined;

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -132,8 +132,11 @@ async function resolveDeps (load, seen) {
     resolvedSource += source.slice(lastIndex);
   }
 
-  resolvedSource = resolvedSource.replace(/\/\/# sourceMappingURL=(.*)\s*$/, (match, url) => match.replace(url, new URL(url, load.r)));
-  load.b = createBlob(resolvedSource + '\n//# sourceURL=' + load.r);
+  const lastNonEmptyLine = resolvedSource.slice(resolvedSource.trimEnd().lastIndexOf('\n') + 1);
+  let sourceMappingURL;
+  if (lastNonEmptyLine.startsWith('\/\/# sourceMappingURL='))
+    sourceMappingURL = new URL(lastNonEmptyLine.slice(21), load.r).href;
+  load.b = createBlob(resolvedSource + (sourceMappingURL ? '\n//# sourceMappingURL=' + sourceMappingURL : '') + '\n//# sourceURL=' + load.r);
   load.S = undefined;
 }
 

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -1,4 +1,4 @@
-import { baseUrl as pageBaseUrl, parseImportMap, resolveImportMap, createBlob, resolveURL } from './common.js';
+import { baseUrl as pageBaseUrl, parseImportMap, resolveImportMap, createBlob, resolveUrl } from './common.js';
 import analyzeModuleSyntax from '../node_modules/es-module-lexer/lexer.js';
 import { WorkerShim } from './worker-shims.js';
 
@@ -135,7 +135,7 @@ async function resolveDeps (load, seen) {
   const lastNonEmptyLine = resolvedSource.slice(resolvedSource.trimEnd().lastIndexOf('\n') + 1);
   let sourceMappingURL;
   if (lastNonEmptyLine.startsWith('//# sourceMappingURL='))
-    sourceMappingURL = resolveURL(lastNonEmptyLine.slice(21), load.r);
+    sourceMappingURL = resolveUrl(lastNonEmptyLine.slice(21), load.r);
   load.b = createBlob(resolvedSource + (sourceMappingURL ? '\n//# sourceMappingURL=' + sourceMappingURL : '') + '\n//# sourceURL=' + load.r);
   load.S = undefined;
 }


### PR DESCRIPTION
This provides a lastIndex optimization for the regex approach. The remaining `new URL` call is still quite expensive and would benefit from using the internal resolver too.

If the URL implementation can be fixed, that gets the time down to about 0.1ms per 500KiB over 1ms per 500KiB, but without that the improvement to ~0.7ms doesn't yet seem worthwhile.