### PR TITLE
Update to lexer 0.3.10 with better error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Guy Bedford",
   "license": "MIT",
   "devDependencies": {
-    "es-module-lexer": "^0.3.10",
+    "es-module-lexer": "^0.3.11",
     "esm": "^3.2.25",
     "kleur": "^2.0.2",
     "mocha": "^5.2.0",

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -214,6 +214,7 @@ function getOrCreateLoad (url, source) {
     }
     catch (e) {
       console.warn(e);
+      console.warn(e.idx);
       load.a = [[], []];
     }
     load.S = source;


### PR DESCRIPTION
This includes another lexer update that will now show the source name, line and column of the error for parser errors as warnings in the console, while failing gracefully (eg a module with no imports that fails parsing can continue to be loaded).