### PR TITLE
Strict content-type checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ importShim('/path/to/module.js').then(x => console.log(x));
 
 ### JSON Modules
 
-To load [JSON Modules](https://github.com/whatwg/html/pull/4407), import any file with a `.json` file extension:
+To load [JSON Modules](https://github.com/whatwg/html/pull/4407), import any JSON file served with `application/json`:
 
 ```js
 import json from './test.json';
@@ -79,7 +79,7 @@ import json from './test.json';
 
 ### CSS Modules
 
-To load [CSS Modules](https://github.com/w3c/webcomponents/blob/gh-pages/proposals/css-modules-v1-explainer.md), import any file with a `.css` file extension:
+To load [CSS Modules](https://github.com/w3c/webcomponents/blob/gh-pages/proposals/css-modules-v1-explainer.md), import any file with served with `text/css`:
 
 ```js
 import css from './style.css';
@@ -92,7 +92,7 @@ For other browsers a [polyfill](https://github.com/calebdwilliams/construct-styl
 
 ### Web Assembly
 
-To load [Web Assembly Modules](https://github.com/webassembly/esm-integration), import a module with a `.wasm` file extension:
+To load [Web Assembly Modules](https://github.com/webassembly/esm-integration), import a module served with `application/wasm`:
 
 ```js
 import { fn } from './test.wasm';
@@ -101,6 +101,8 @@ import { fn } from './test.wasm';
 Web Assembly imports are in turn supported.
 
 Import map support is provided both for mapping into Web Assembly URLs, as well as mapping import specifiers to JS or WebAssembly from within WASM.
+
+> Note some servers don't yet support serving `.wasm` files as `application/wasm` by default, in which case an invalid content type error will be thrown. The `application/wasm` MIME type is necessary for loading Web Assembly in line with the specification for browser modules.
 
 ### Module Workers
 

--- a/test/browser-modules.js
+++ b/test/browser-modules.js
@@ -115,7 +115,7 @@ suite('Basic loading tests', () => {
   });
 
   test('Should import a module via data url', async function () {
-    var m = await importShim('data:text/plain;charset=utf-8;base64,ZXhwb3J0IHZhciBhc2RmID0gJ2FzZGYnOw0KZXhwb3J0IHZhciBvYmogPSB7fTs=');
+    var m = await importShim('data:application/javascript;charset=utf-8;base64,ZXhwb3J0IHZhciBhc2RmID0gJ2FzZGYnOw0KZXhwb3J0IHZhciBvYmogPSB7fTs=');
     assert(m);
     assert.equal(m.asdf, 'asdf');
   });


### PR DESCRIPTION
This provides strict Content-Type checking for all module types, aligning with the modules specification properly.

This is important to be correct semantically over using file extensions.

Resolves #42.