### PR TITLE
Support text/javascript MIME

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -210,6 +210,8 @@ function getOrCreateLoad (url, source) {
         case 'text/css':
           source = `const s=new CSSStyleSheet();s.replaceSync(${JSON.stringify(await res.text())});export default s`;
         break;
+
+        case 'text/javascript':
         case 'application/javascript':
           source = await res.text();
         break;


### PR DESCRIPTION
Extends the MIME checking to support `text/javascript`.

Resolves #52.