### PR TITLE
Add test for execution order

### DIFF
--- a/test/browser-modules.js
+++ b/test/browser-modules.js
@@ -49,7 +49,7 @@ suite('Basic loading tests', () => {
   test('should import json', async function () {
     var m = await importShim('./fixtures/json.json');
     assert.equal(m.default.json, 'module');
-  }); 
+  });
 
   test('should throw json parse errors', async function () {
     try {
@@ -176,6 +176,16 @@ suite('Loading order', function() {
 
   test('should load in order (_h)', async function () {
     await assertLoadOrder('_h.js', ['i', 'a', 'h']);
+  });
+});
+
+suite('Execution order', function () {
+  test('should execute in order', async function () {
+    window.executionOrder = [];
+    await importShim('./fixtures/es-modules/execution-order.js');
+    assert.equal(executionOrder[0], 'a');
+    assert.equal(executionOrder[1], 'b');
+    assert.equal(executionOrder[2], 'c');
   });
 });
 

--- a/test/fixtures/es-modules/execution-order-a.js
+++ b/test/fixtures/es-modules/execution-order-a.js
@@ -1,0 +1,1 @@
+window.executionOrder.push('a');

--- a/test/fixtures/es-modules/execution-order-b.js
+++ b/test/fixtures/es-modules/execution-order-b.js
@@ -1,0 +1,1 @@
+window.executionOrder.push('b');

--- a/test/fixtures/es-modules/execution-order-c.js
+++ b/test/fixtures/es-modules/execution-order-c.js
@@ -1,0 +1,1 @@
+window.executionOrder.push('c');

--- a/test/fixtures/es-modules/execution-order.js
+++ b/test/fixtures/es-modules/execution-order.js
@@ -1,0 +1,3 @@
+import './execution-order-a.js';
+import './execution-order-b.js';
+import './execution-order-c.js';


### PR DESCRIPTION
On Edge modules are not executed in the original order they are imported with. This is a problem when code needs to rely on the side-effects of a module.

I added a test which fails randomly on Edge. I spent some time debugging this, I couldn't see a clear cause why it's not executed in the right order.