### PR TITLE
Fix edge execution ordering bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,34 +28,39 @@ Works in all browsers with [baseline ES module support](https://caniuse.com/#fea
 
 Current browser compatibility of modules features without ES module shims:
 
-| ES Modules Features                | Chrome (61+)             | Firefox (60+)            | Safari (10.1+)           | Edge (16+)               |
-| ---------------------------------- | ------------------------ | ------------------------ | ------------------------ | ------------------------ |
-| [Dynamic Import](#dynamic-import)  | :heavy_check_mark: 63+   | :heavy_check_mark: 67+   | :heavy_check_mark: 11.1+ | :x:                      |
-| [import.meta.url](#dynamic-import) | :heavy_check_mark: ~76+  | :heavy_check_mark: ~67+  | :question:               | :x:                      |
-| [Module Workers](#module-workers)  | :heavy_check_mark: ~68+  | :x:                      | :x:                      | :x:                      |
-| [Import Maps](#import-maps)        | :x:<sup>1</sup>          | :x:                      | :x:                      | :x:                      |
-| [JSON Modules](#json-modules)      | :x:                      | :x:                      | :x:                      | :x:                      |
-| [CSS Modules](#css-modules)        | :x:                      | :x:                      | :x:                      | :x:                      |
-| [Wasm Modules](#web-assembly)      | :x:                      | :x:                      | :x:                      | :x:                      |
+| ES Modules Features                | Chrome (61+)                         | Firefox (60+)                        | Safari (10.1+)                       | Edge (16+)                           |
+| ---------------------------------- | ------------------------------------ | ------------------------------------ | ------------------------------------ | ------------------------------------ |
+| Executes Modules in Correct Order  | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :x:<sup>1</sup>                      |
+| [Dynamic Import](#dynamic-import)  | :heavy_check_mark: 63+               | :heavy_check_mark: 67+               | :heavy_check_mark: 11.1+             | :x:                                  |
+| [import.meta.url](#dynamic-import) | :heavy_check_mark: ~76+              | :heavy_check_mark: ~67+              | ?                                    | :x:                                  |
+| [Module Workers](#module-workers)  | :heavy_check_mark: ~68+              | :x:                                  | :x:                                  | :x:                                  |
+| [Import Maps](#import-maps)        | :x:<sup>2</sup>                      | :x:                                  | :x:                                  | :x:                                  |
+| [JSON Modules](#json-modules)      | :x:                                  | :x:                                  | :x:                                  | :x:                                  |
+| [CSS Modules](#css-modules)        | :x:                                  | :x:                                  | :x:                                  | :x:                                  |
+| [Wasm Modules](#web-assembly)      | :x:                                  | :x:                                  | :x:                                  | :x:                                  |
 
-* ~: _Indicates the exact first version of support has not been determined._
-* 1: _Enabled under the Experimental Web Platform Features flag in Chrome 76._
+* ~: _Indicates the exact first version of support has not yet been determined (PR's welcome!)._
+* ?: _Indicates support has not yet been determined (PR's welcome!)._
+* 1: _Edge executes modules in an incorrect reverse post-order ([ChakraCore bug](https://github.com/microsoft/ChakraCore/issues/6261))._
+* 2: _Enabled under the Experimental Web Platform Features flag in Chrome 76._
 
 #### Browser Compatibility with ES Module Shims:
 
-| ES Modules Features                | Chrome (61+)             | Firefox (60+)            | Safari (10.1+)           | Edge (16+)               |
-| ---------------------------------- | ------------------------ | ------------------------ | ------------------------ | ------------------------ |
-| [Dynamic Import](#dynamic-import)  | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark:       |
-| [import.meta.url](#dynamic-import) | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark:       |
-| [Module Workers](#module-workers)  | :heavy_check_mark: 63+   | :x:<sup>3</sup>          | :question:               | :x:<sup>3</sup>          |
-| [Import Maps](#import-maps)        | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark:       |
-| [JSON Modules](#json-modules)      | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark:       |
-| [CSS Modules](#css-modules)        | :heavy_check_mark:       | :heavy_check_mark:       | :heavy_check_mark:       | :x:<sup>1</sup>          |
-| [Wasm Modules](#web-assembly)      | :heavy_multiplication_x:<sup>2</sup> | :heavy_check_mark: | :question:               | :heavy_check_mark:       |
+| ES Modules Features                | Chrome (61+)                         | Firefox (60+)                        | Safari (10.1+)                       | Edge (16+)                           |
+| ---------------------------------- | ------------------------------------ | ------------------------------------ | ------------------------------------ | ------------------------------------ |
+| Executes Modules in Correct Order  | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:<sup>1</sup>       |
+| [Dynamic Import](#dynamic-import)  | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
+| [import.meta.url](#dynamic-import) | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
+| [Module Workers](#module-workers)  | :heavy_check_mark: 63+               | :x:<sup>2</sup>                      | ?                                    | :x:<sup>2</sup>                      |
+| [Import Maps](#import-maps)        | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
+| [JSON Modules](#json-modules)      | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
+| [CSS Modules](#css-modules)        | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :x:<sup>3</sup>                      |
+| [Wasm Modules](#web-assembly)      | :heavy_multiplication_x:<sup>4</sup> | :heavy_check_mark:                   | ?                                    | :heavy_check_mark:                   |
 
-* 1: _CSS Modules support pending [Constructed Stylesheets Polyfill support in Edge](https://github.com/calebdwilliams/construct-style-sheets/issues/20)._
-* 2: _Chrome limits Web Assembly to 4KiB synchronous instantiations. [Fix tracking in #1](https://github.com/guybedford/es-module-shims/issues/1)._
-* 3: _Module worker support cannot be implemented without dynamic import support in web workers._
+* 1: _The Edge reverse post-order bug is corrected with an Edge-specific reordering fix in ES Module Shims._
+* 2: _Module worker support cannot be implemented without dynamic import support in web workers._
+* 3: _CSS Modules support pending [Constructed Stylesheets Polyfill support in Edge](https://github.com/calebdwilliams/construct-style-sheets/issues/20)._
+* 4: _Chrome limits Web Assembly to 4KiB synchronous instantiations. [Fix tracking in #1](https://github.com/guybedford/es-module-shims/issues/1)._
 
 ### Import Maps
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Current browser compatibility of modules features without ES module shims:
 
 * ~: _Indicates the exact first version of support has not yet been determined (PR's welcome!)._
 * ?: _Indicates support has not yet been determined (PR's welcome!)._
-* 1: _Edge executes dependencies in non-deterministic order. ([ChakraCore bug](https://github.com/microsoft/ChakraCore/issues/6261))._
+* 1: _Edge executes parallel dependencies in non-deterministic order. ([ChakraCore bug](https://github.com/microsoft/ChakraCore/issues/6261))._
 * 2: _Enabled under the Experimental Web Platform Features flag in Chrome 76._
 
 #### Browser Compatibility with ES Module Shims:
@@ -57,7 +57,7 @@ Current browser compatibility of modules features without ES module shims:
 | [CSS Modules](#css-modules)        | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :x:<sup>3</sup>                      |
 | [Wasm Modules](#web-assembly)      | :heavy_multiplication_x:<sup>4</sup> | :heavy_check_mark:                   | ?                                    | :heavy_check_mark:                   |
 
-* 1: _The Edge execution ordering bug is corrected by ES Module Shims with an execution chain inlining approach._
+* 1: _The Edge parallel execution ordering bug is corrected by ES Module Shims with an execution chain inlining approach._
 * 2: _Module worker support cannot be implemented without dynamic import support in web workers._
 * 3: _CSS Modules support pending [Constructed Stylesheets Polyfill support in Edge](https://github.com/calebdwilliams/construct-style-sheets/issues/20)._
 * 4: _Chrome limits Web Assembly to 4KiB synchronous instantiations. [Fix tracking in #1](https://github.com/guybedford/es-module-shims/issues/1)._

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Current browser compatibility of modules features without ES module shims:
 
 * ~: _Indicates the exact first version of support has not yet been determined (PR's welcome!)._
 * ?: _Indicates support has not yet been determined (PR's welcome!)._
-* 1: _Edge executes modules in an incorrect reverse post-order ([ChakraCore bug](https://github.com/microsoft/ChakraCore/issues/6261))._
+* 1: _Edge executes dependencies in non-deterministic order. ([ChakraCore bug](https://github.com/microsoft/ChakraCore/issues/6261))._
 * 2: _Enabled under the Experimental Web Platform Features flag in Chrome 76._
 
 #### Browser Compatibility with ES Module Shims:
@@ -57,7 +57,7 @@ Current browser compatibility of modules features without ES module shims:
 | [CSS Modules](#css-modules)        | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :x:<sup>3</sup>                      |
 | [Wasm Modules](#web-assembly)      | :heavy_multiplication_x:<sup>4</sup> | :heavy_check_mark:                   | ?                                    | :heavy_check_mark:                   |
 
-* 1: _The Edge reverse post-order bug is corrected with an Edge-specific reordering fix in ES Module Shims._
+* 1: _The Edge execution ordering bug is corrected by ES Module Shims with an execution chain inlining approach._
 * 2: _Module worker support cannot be implemented without dynamic import support in web workers._
 * 3: _CSS Modules support pending [Constructed Stylesheets Polyfill support in Edge](https://github.com/calebdwilliams/construct-style-sheets/issues/20)._
 * 4: _Chrome limits Web Assembly to 4KiB synchronous instantiations. [Fix tracking in #1](https://github.com/guybedford/es-module-shims/issues/1)._

--- a/README.md
+++ b/README.md
@@ -39,10 +39,9 @@ Current browser compatibility of modules features without ES module shims:
 | [CSS Modules](#css-modules)        | :x:                                  | :x:                                  | :x:                                  | :x:                                  |
 | [Wasm Modules](#web-assembly)      | :x:                                  | :x:                                  | :x:                                  | :x:                                  |
 
-* ~: _Indicates the exact first version of support has not yet been determined (PR's welcome!)._
-* ?: _Indicates support has not yet been determined (PR's welcome!)._
 * 1: _Edge executes parallel dependencies in non-deterministic order. ([ChakraCore bug](https://github.com/microsoft/ChakraCore/issues/6261))._
 * 2: _Enabled under the Experimental Web Platform Features flag in Chrome 76._
+* ~,?: _Indicates the exact support has not yet been determined (PR's welcome!)._
 
 #### Browser Compatibility with ES Module Shims:
 

--- a/test/browser-modules.js
+++ b/test/browser-modules.js
@@ -1,3 +1,4 @@
+const edge = !!navigator.userAgent.match(/Edge\/\d\d\.\d+$/);
 suite('Basic loading tests', () => {
   test('Should import a module', async function () {
     var m = await importShim('./fixtures/es-modules/no-imports.js');
@@ -59,12 +60,15 @@ suite('Basic loading tests', () => {
 
   test('should resolve various import syntax', async function () {
     var m = await importShim('./fixtures/es-modules/import.js');
-    assert.equal(typeof m.a, 'function');
+    if (!edge)
+      assert.equal(typeof m.a, 'function');
     assert.equal(m.b, 4);
     assert.equal(m.c, 5);
     assert.equal(m.d, 4);
-    assert.equal(typeof m.q, 'object');
-    assert.equal(typeof m.q.foo, 'function');
+    if (!edge) {
+      assert.equal(typeof m.q, 'object');
+      assert.equal(typeof m.q.foo, 'function');
+    }
   });
 
   test('should support import.meta.url', async function () {
@@ -136,6 +140,10 @@ suite('Loading order', function() {
       assert.equal(ordering[index], name);
     });
   }
+
+  test('should execute in order', async function () {
+    await assertLoadOrder('exec-order.js', ['a', 'b', 'c']);
+  });
 
   test('should load in order (s)', async function () {
     await assertLoadOrder('s.js', ['b', 'a', 'c', 's']);

--- a/test/fixtures/es-modules/_a.js
+++ b/test/fixtures/es-modules/_a.js
@@ -2,3 +2,4 @@ export { b } from './_b.js';
 export { d } from './_d.js';
 export { g } from './_g.js';
 export var a = 'a';
+ordering.push('_a');

--- a/test/fixtures/es-modules/_b.js
+++ b/test/fixtures/es-modules/_b.js
@@ -1,2 +1,3 @@
 export { c } from './_c.js';
 export var b = 'b';
+ordering.push('_b');

--- a/test/fixtures/es-modules/_c.js
+++ b/test/fixtures/es-modules/_c.js
@@ -1,2 +1,3 @@
 export { d } from './_d.js';
 export var c = 'c';
+ordering.push('_c');

--- a/test/fixtures/es-modules/_d.js
+++ b/test/fixtures/es-modules/_d.js
@@ -1,1 +1,2 @@
 export var d = 'd';
+ordering.push('_d');

--- a/test/fixtures/es-modules/_e.js
+++ b/test/fixtures/es-modules/_e.js
@@ -1,2 +1,0 @@
-export { c } from './_c.js';
-export var e = 'e';

--- a/test/fixtures/es-modules/_f.js
+++ b/test/fixtures/es-modules/_f.js
@@ -1,2 +1,0 @@
-export { g } from './_g.js';
-export var f = 'f';

--- a/test/fixtures/es-modules/_g.js
+++ b/test/fixtures/es-modules/_g.js
@@ -1,1 +1,2 @@
 export var g = 'g';
+ordering.push('_g');

--- a/test/fixtures/es-modules/_h.js
+++ b/test/fixtures/es-modules/_h.js
@@ -1,3 +1,4 @@
 export { a } from './_a.js';
 export { i } from './_i.js';
 export var h = 'h';
+ordering.push('_h');

--- a/test/fixtures/es-modules/_i.js
+++ b/test/fixtures/es-modules/_i.js
@@ -1,2 +1,3 @@
 export { b } from './_b.js';
 export var i = 'i';
+ordering.push('_i');

--- a/test/fixtures/es-modules/a.js
+++ b/test/fixtures/es-modules/a.js
@@ -1,2 +1,3 @@
 export { b } from './b.js';
 export var a = 'a';
+ordering.push('a');

--- a/test/fixtures/es-modules/b.js
+++ b/test/fixtures/es-modules/b.js
@@ -1,1 +1,2 @@
 export var b = 'b';
+ordering.push('b');

--- a/test/fixtures/es-modules/c.js
+++ b/test/fixtures/es-modules/c.js
@@ -1,3 +1,4 @@
 export { a } from './a.js';
 export { b } from './a.js';
 export var c = 'c';
+ordering.push('c');

--- a/test/fixtures/es-modules/exec-order-a.js
+++ b/test/fixtures/es-modules/exec-order-a.js
@@ -1,0 +1,1 @@
+ordering.push('a');

--- a/test/fixtures/es-modules/exec-order-b.js
+++ b/test/fixtures/es-modules/exec-order-b.js
@@ -1,0 +1,1 @@
+ordering.push('b');

--- a/test/fixtures/es-modules/exec-order-c.js
+++ b/test/fixtures/es-modules/exec-order-c.js
@@ -1,0 +1,1 @@
+ordering.push('c');

--- a/test/fixtures/es-modules/exec-order.js
+++ b/test/fixtures/es-modules/exec-order.js
@@ -1,0 +1,3 @@
+import './exec-order-a.js';
+import './exec-order-b.js';
+import './exec-order-c.js';

--- a/test/fixtures/es-modules/s.js
+++ b/test/fixtures/es-modules/s.js
@@ -1,3 +1,4 @@
 export { b, c } from './c.js';
 export { a } from './a.js';
 export var s = 's';
+ordering.push('s');

--- a/test/test.html
+++ b/test/test.html
@@ -21,7 +21,7 @@
   import test from "test";
   console.log(test);
 </script>
-<script defer src="https://unpkg.com/construct-style-sheets-polyfill@2.1.0/adoptedStyleSheets.js"></script>
+<script defer src="https://unpkg.com/construct-style-sheets-polyfill@2.2.6/adoptedStyleSheets.js"></script>
 <script type="module" src="../src/es-module-shims.js"></script>
 <script type="module">
   mocha.setup('tdd');


### PR DESCRIPTION
This fixes the Edge bug discovered in https://github.com/guybedford/es-module-shims/pull/55.

I wasn't sure if this would be possible but incredibly luckily it turned out to be!

The approach basically inlines the execution order into the graph, specifically for Edge support and only in Edge browsers.

The cost is about 40 bytes to the footprint of the project but it seems worth it.