### PR TITLE
sourceMappingURL replacement may be easily broken by extra line breaks

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -114,8 +114,8 @@ function resolveDeps (load, seen) {
     resolvedSource += source.slice(lastIndex);
   }
 
-  const lastNonEmptyLine = resolvedSource.slice(resolvedSource.lastIndexOf('\n') + 1);
-  load.b = lastLoad = createBlob(resolvedSource + (lastNonEmptyLine.startsWith('//# sourceMappingURL=') ? '\n//# sourceMappingURL=' + resolveUrl(lastNonEmptyLine.slice(21), load.r) : '') + '\n//# sourceURL=' + load.r);
+  const sourceMappingIndex = resolvedSource.lastIndexOf('//# sourceMappingURL=');
+  load.b = lastLoad = createBlob(resolvedSource + (sourceMappingIndex > -1 ? '\n//# sourceMappingURL=' + resolveUrl(resolvedSource.slice(sourceMappingIndex + 21), load.r) : '') + '\n//# sourceURL=' + load.r);
   load.S = undefined;
 }
 

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -114,8 +114,14 @@ function resolveDeps (load, seen) {
     resolvedSource += source.slice(lastIndex);
   }
 
+  let sourceMappingResolved = '';
   const sourceMappingIndex = resolvedSource.lastIndexOf('//# sourceMappingURL=');
-  load.b = lastLoad = createBlob(resolvedSource + (sourceMappingIndex > -1 ? '\n//# sourceMappingURL=' + resolveUrl(resolvedSource.slice(sourceMappingIndex + 21), load.r) : '') + '\n//# sourceURL=' + load.r);
+  if (sourceMappingIndex > -1) {
+    const sourceMappingEnd = resolvedSource.indexOf('\n',sourceMappingIndex);
+    const sourceMapping = resolvedSource.slice(sourceMappingIndex, sourceMappingEnd > -1 ? sourceMappingEnd : undefined);
+    sourceMappingResolved = `\n//# sourceMappingURL=` + resolveUrl(sourceMapping.slice(21), load.r);
+  }
+  load.b = lastLoad = createBlob(resolvedSource + sourceMappingResolved + '\n//# sourceURL=' + load.r);
   load.S = undefined;
 }
 


### PR DESCRIPTION
...this improves detection. Admittedly, this doesn't exactly meet source map standard (which claims that `//# sourceMappingURL` must be "at the end of the file", but at least this meets browsers' behavior (checked with Firefox and Chrome) - they have no problems attempting to load source map even if mapping is in the middle of the file.

The basic idea is to pick last `//# sourceMappingURL=` from the file and then treat anything after `=` and until line feed or end of file as URL. This last part matches browsers' behavior as well.

Based on last discussion in this issue: https://github.com/guybedford/es-module-shims/issues/4