### PR TITLE
Add a primary entry point for this package being used as an ES module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prepublishOnly": "npm run build && npm run min"
   },
   "type": "module",
+  "module": "dist/es-modules-shims.js",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
This package can also be used as an ES module [which are always `defer`ed](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-type).

Also see: [ECMAScript modules in browsers](https://jakearchibald.com/2017/es-modules-in-browsers/)

Benefits:
This allows CDNs which only support ES modules to host this package. ([Pika](//pika.dev))