### PR TITLE
Only processScripts on first top-level load

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -13,12 +13,16 @@ async function loadAll (load, seen) {
 }
 
 let waitingForImportMapsInterval;
+let firstTopLevelProcess = true;
 async function topLevelLoad (url, source) {
   if (waitingForImportMapsInterval > 0) {
     clearTimeout(waitingForImportMapsInterval);
     waitingForImportMapsInterval = 0;
   }
-  processScripts();
+  if (firstTopLevelProcess) {
+    firstTopLevelProcess = false;
+    processScripts();
+  }
   await importMapPromise;
   await init;
   const load = getOrCreateLoad(url, source);


### PR DESCRIPTION
Fixes https://github.com/guybedford/es-module-shims/issues/86 in ensuring no recursion is possible during the loading phase.