### PR TITLE
Expose resolve and resolveImportMap and global importShimOptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 package-lock.json
 .vscode
+.idea

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "rollup ./src/es-module-shims.js -f iife -o dist/es-module-shims.js --banner \"/* ES Module Shims 0.5.0 */\"",
     "min": "cd dist && terser es-module-shims.js -c passes=2 -m --source-map --comments \"/ES Module Shims/\" -o es-module-shims.min.js",
     "footprint": "npm run build && npm run min && cat dist/es-module-shims.min.js | gzip -9f | wc -c",
-    "prepublishOnly": "npm run build && npm run min"
+    "prepublishOnly": "npm run build && npm run min",
+    "start": "http-server -d -o test"
   },
   "type": "module",
   "files": [
@@ -17,10 +18,8 @@
   "license": "MIT",
   "devDependencies": {
     "es-module-lexer": "^0.3.25",
-    "esm": "^3.2.25",
-    "kleur": "^2.0.2",
+    "http-server": "^0.12.3",
     "mocha": "^6.2.0",
-    "pretty-ms": "^3.2.0",
     "rollup": "^2.17.0",
     "terser": "^4.8.0"
   },

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -43,12 +43,12 @@ async function topLevelLoad (url, source) {
 }
 
 async function importShimFn (id, parentUrl) {
-  return topLevelLoad(importShim.resolveImport(id, parentUrl || pageBaseUrl));
+  return topLevelLoad(importShim.resolveImport(id, parentUrl || pageBaseUrl, importMap));
 }
 
 async function importMetaResolve (id, parentUrl = this.url) {
   await importMapPromise;
-  return importShim.resolveImport(id, `${parentUrl}`);
+  return importShim.resolveImport(id, `${parentUrl}`, importMap);
 }
 
 function resolveDeps (load, seen) {
@@ -157,7 +157,7 @@ function getOrCreateLoad (url, source) {
 
   const depcache = importMap.depcache[url];
   if (depcache)
-    depcache.forEach(depUrl => getOrCreateLoad(importShim.resolveImport(depUrl, url)));
+    depcache.forEach(depUrl => getOrCreateLoad(importShim.resolveImport(depUrl, url, importMap)));
 
   load.f = (async () => {
     if (!source) {
@@ -184,7 +184,7 @@ function getOrCreateLoad (url, source) {
 
   load.L = load.f.then(async deps => {
     load.d = await Promise.all(deps.map(async depId => {
-      const resolved = importShim.resolveImport(depId, load.r || load.u);
+      const resolved = importShim.resolveImport(depId, load.r || load.u, importMap);
       if (importShim.skip.test(resolved))
         return { b: resolved };
       const depLoad = getOrCreateLoad(resolved);
@@ -216,7 +216,7 @@ async function processScripts () {
   }
 }
 
-function resolve (id, parentUrl) {
+function resolve (id, parentUrl, importMap) {
   return resolveImportMap(importMap, resolveIfNotPlainOrUrl(id, parentUrl) || id, parentUrl) || throwUnresolved(id, parentUrl);
 }
 

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -43,12 +43,12 @@ async function topLevelLoad (url, source) {
 }
 
 async function importShimFn (id, parentUrl) {
-  return topLevelLoad(importShim.resolveImport(id, parentUrl || pageBaseUrl, importMap));
+  return topLevelLoad(importShim.resolve(id, parentUrl || pageBaseUrl, importMap));
 }
 
 async function importMetaResolve (id, parentUrl = this.url) {
   await importMapPromise;
-  return importShim.resolveImport(id, `${parentUrl}`, importMap);
+  return importShim.resolve(id, `${parentUrl}`, importMap);
 }
 
 function resolveDeps (load, seen) {
@@ -157,7 +157,7 @@ function getOrCreateLoad (url, source) {
 
   const depcache = importMap.depcache[url];
   if (depcache)
-    depcache.forEach(depUrl => getOrCreateLoad(importShim.resolveImport(depUrl, url, importMap)));
+    depcache.forEach(depUrl => getOrCreateLoad(importShim.resolve(depUrl, url, importMap)));
 
   load.f = (async () => {
     if (!source) {
@@ -184,7 +184,7 @@ function getOrCreateLoad (url, source) {
 
   load.L = load.f.then(async deps => {
     load.d = await Promise.all(deps.map(async depId => {
-      const resolved = importShim.resolveImport(depId, load.r || load.u, importMap);
+      const resolved = importShim.resolve(depId, load.r || load.u, importMap);
       if (importShim.skip.test(resolved))
         return { b: resolved };
       const depLoad = getOrCreateLoad(resolved);
@@ -229,7 +229,7 @@ const importShimDefaults = {
   fetch: url => fetch(url),
   skip: /^https?:\/\/(cdn\.pika\.dev|dev\.jspm\.io|jspm\.dev)\//,
   load: processScripts,
-  resolveImport: resolve,
+  resolve: resolve,
   resolveImportMap: resolveAndComposeImportMap,
   onerror: () => {}
 }


### PR DESCRIPTION
https://github.com/guybedford/es-module-shims/issues/94

Few things this introduces
 * Enables a global `importShimOptions` object to be defined before importShim is loaded, this allows the consumer to specify overrides before the "firstTopLevelProcess" is called.
 * Exposes `resolve` and `resolveImportMap` functions that can now be overridden via `importShimOptions` or by directly mutating `importShim`
 * Exposes a `defaults` object that overridden functions could leverage to use default behavior
 * Add `importMap` argument to all `importShim.resolve` calls
 * Added a `start` script to run a simple http server to run the `test` HTML files in the default browser
 * Removed unused dependencies