### PR TITLE
Allow scripts to dynamically be added

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -221,7 +221,7 @@ async function processScripts () {
   }
   for (const script of document.querySelectorAll('script[type="module-shim"],script[type="importmap-shim"]')) {
     if (script.ep) // ep marker = script processed
-      return;
+      continue;
     if (script.type === 'module-shim') {
       await topLevelLoad(script.src || `${pageBaseUrl}?${id++}`, !script.src && script.innerHTML).catch(e => importShim.onerror(e));
     }


### PR DESCRIPTION
### Description

Currently, if any script has been processed previously the `for` loop within `processScripts` function causes the function to return early. 

This is changed to `continue` to allow processing of new `module-shim` and `importmap-shim` scripts when calling `importShim.load()`.

Fixes #103 