### PR TITLE
Add initial options API

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,26 +163,57 @@ then allowing dynamic injection of `<script type="importmap-shim">` to immediate
 
 This follows the [dynamic import map specification approach outlined in import map extensions](https://github.com/guybedford/import-maps-extensions).
 
-### Skip Processing
+### Init Options
 
 > Stability: Non-spec feature
+
+Provide a `esmsInitOptions` on the global scope before `es-module-shims` is loaded to configure various aspects of the module loading process:
+
+```html
+<script>
+  globalThis.esmsInitOptions = {
+    fetch: (url => fetch(url)),
+    skip: /^https?:\/\/(cdn\.pika\.dev|dev\.jspm\.io|jspm\.dev)\//,
+    onerror: ((e) => { throw e; }),
+  }
+</script>
+<script defer src="es-module-shims.js"></script>
+```
+
+See below for a detailed description of each of these options.
+
+#### Skip Processing
 
 When loading modules that you know will only use baseline modules features, it is possible to set a rule to explicitly
 opt-out modules from rewriting. This improves performance because those modules then do not need to be processed or transformed at all, so that only local application code is handled and not library code.
 
-This can be configured by setting the `skip` URL regular expression on a `esmsInitOptions` global before loading es-module-shims:
+This can be configured by providing a URL regular expression for the `skip` option:
 
 ```js
-globalThis.esmsInitOptions = {
-  skip: /^https:\/\/cdn\.com/
-}
+<script>
+  globalThis.esmsInitOptions = {
+    skip: /^https:\/\/cdn\.com/ // defaults to `/^https?:\/\/(cdn\.pika\.dev|dev\.jspm\.io|jspm\.dev)\//`
+  }
+</script>
+<script defer src="es-module-shims.js"></script>
 ```
 
 By default, this expression supports `jspm.dev`, `dev.jspm.io` and `cdn.pika.dev`.
 
-### Fetch Hook
+#### Error hook
 
-> Stability: Non-spec feature
+You can provide a function to handle errors during the module loading process by providing a `onerror` option:
+
+```js
+<script>
+  globalThis.esmsInitOptions = {
+    onerror: error => console.log(error) // defaults to `((e) => { throw e; })`
+  }
+</script>
+<script defer src="es-module-shims.js"></script>
+```
+
+#### Fetch Hook
 
 This is provided as a convenience feature since the pipeline handles the same data URL rewriting and circular handling of the module graph that applies when trying to implement any module transform system.
 
@@ -191,17 +222,20 @@ The ES Module Shims fetch hook can be used to implement transform plugins.
 For example:
 
 ```js
-globalThis.esmsInitOptions = {
-  fetch: async function (url) {
-    const response = await fetch(url);
-    if (response.url.endsWith('.ts')) {
-      const source = await response.body();
-      const transformed = tsCompile(source);
-      return new Response(new Blob([transformed], { type: 'application/javascript' }));
-    }
-    return response;
+<script>
+  globalThis.esmsInitOptions = {
+    fetch: async function (url) {
+      const response = await fetch(url);
+      if (response.url.endsWith('.ts')) {
+        const source = await response.body();
+        const transformed = tsCompile(source);
+        return new Response(new Blob([transformed], { type: 'application/javascript' }));
+      }
+      return response;
+    } // defaults to `(url => fetch(url))`
   }
-}
+</script>
+<script defer src="es-module-shims.js"></script>
 ```
 
 Because the dependency analysis applies by ES Module Shims takes care of ensuring all dependencies run through the same fetch hook,
@@ -238,7 +272,7 @@ globalThis.esmsInitOptions = {
 }
 ```
 
-#### Plugins
+##### Plugins
 
 Since the Fetch Hook is very new, there are no plugin examples of it yet, but it should be easy to support various workflows
 such as TypeScript and new JS features this way.

--- a/README.md
+++ b/README.md
@@ -170,10 +170,10 @@ This follows the [dynamic import map specification approach outlined in import m
 When loading modules that you know will only use baseline modules features, it is possible to set a rule to explicitly
 opt-out modules from rewriting. This improves performance because those modules then do not need to be processed or transformed at all, so that only local application code is handled and not library code.
 
-This can be configured by setting the `skip` URL regular expression on a `importShimInitialOptions` global before loading es-module-shims:
+This can be configured by setting the `skip` URL regular expression on a `esmsInitOptions` global before loading es-module-shims:
 
 ```js
-self.importShimInitialOptions = {
+self.esmsInitOptions = {
   skip: /^https:\/\/cdn\.com/
 }
 ```
@@ -197,7 +197,7 @@ The ES Module Shims fetch hook can be used to implement transform plugins.
 For example:
 
 ```js
-self.importShimInitialOptions = {
+self.esmsInitOptions = {
   fetch: async function (url) {
     const response = await fetch(url);
     if (response.url.endsWith('.ts')) {
@@ -216,7 +216,7 @@ the above is all that is needed to implement custom plugins.
 Streaming support is also provided, for example here is a hook with streaming support for JSON:
 
 ```js
-self.importShimInitialOptions = {
+self.esmsInitOptions = {
   fetch: async function (url) {
     const response = await fetch(url);
     if (!response.ok)
@@ -244,7 +244,7 @@ self.importShimInitialOptions = {
 }
 ```
 
-For most use cases you'll likely want to supply the fetch hook as part of the `importShimInitialOptions` global before loading es-module-shims to guarantee the hook gets applied before loading the first shimmed module. Though it is still possible to supply a new fetch hook after es-module-shims is loaded, by setting `importShim.fetch` directly.
+For most use cases you'll likely want to supply the fetch hook as part of the `esmsInitOptions` global before loading es-module-shims to guarantee the hook gets applied before loading the first shimmed module. Though it is still possible to supply a new fetch hook after es-module-shims is loaded, by setting `importShim.fetch` directly.
 
 #### Plugins
 

--- a/README.md
+++ b/README.md
@@ -173,15 +173,9 @@ opt-out modules from rewriting. This improves performance because those modules 
 This can be configured by setting the `skip` URL regular expression on a `esmsInitOptions` global before loading es-module-shims:
 
 ```js
-self.esmsInitOptions = {
+globalThis.esmsInitOptions = {
   skip: /^https:\/\/cdn\.com/
 }
-```
-
-Alternatively, to update this option after es-module-shims has been loaded, you can set `importShim.skip` directly:
-
-```js
-importShim.skip = /^https:\/\/cdn\.com/
 ```
 
 By default, this expression supports `jspm.dev`, `dev.jspm.io` and `cdn.pika.dev`.
@@ -197,7 +191,7 @@ The ES Module Shims fetch hook can be used to implement transform plugins.
 For example:
 
 ```js
-self.esmsInitOptions = {
+globalThis.esmsInitOptions = {
   fetch: async function (url) {
     const response = await fetch(url);
     if (response.url.endsWith('.ts')) {
@@ -216,7 +210,7 @@ the above is all that is needed to implement custom plugins.
 Streaming support is also provided, for example here is a hook with streaming support for JSON:
 
 ```js
-self.esmsInitOptions = {
+globalThis.esmsInitOptions = {
   fetch: async function (url) {
     const response = await fetch(url);
     if (!response.ok)
@@ -243,8 +237,6 @@ self.esmsInitOptions = {
   }
 }
 ```
-
-For most use cases you'll likely want to supply the fetch hook as part of the `esmsInitOptions` global before loading es-module-shims to guarantee the hook gets applied before loading the first shimmed module. Though it is still possible to supply a new fetch hook after es-module-shims is loaded, by setting `importShim.fetch` directly.
 
 #### Plugins
 

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -57,12 +57,11 @@ Object.defineProperties(importShim, {
   l: { value: undefined, writable: true },
   e: { value: undefined, writable: true }
 });
-importShim.fetch = url => fetch(url);
-importShim.skip = /^https?:\/\/(cdn\.pika\.dev|dev\.jspm\.io|jspm\.dev)\//;
+const importShimInitialOptions = self.importShimInitialOptions || {};
+importShim.fetch = importShimInitialOptions.fetch || (url => fetch(url));
+importShim.skip = importShimInitialOptions.skip || /^https?:\/\/(cdn\.pika\.dev|dev\.jspm\.io|jspm\.dev)\//;
+importShim.onerror = importShimInitialOptions.onerror || ((e) => { throw e; });
 importShim.load = processScripts;
-importShim.onerror = (e) => {
-  throw e;
-};
 
 let lastLoad;
 function resolveDeps (load, seen) {

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -123,7 +123,7 @@ function resolveDeps (load, seen) {
       // import.meta
       else if (dynamicImportIndex === -2) {
         meta[load.r] = { url: load.r, resolve: importMetaResolve };
-        resolvedSource += source.slice(lastIndex, start) + 'self.esmsState.m[' + JSON.stringify(load.r) + ']';
+        resolvedSource += source.slice(lastIndex, start) + 'self._esmsState.m[' + JSON.stringify(load.r) + ']';
         lastIndex = end;
       }
       // dynamic import

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -62,6 +62,7 @@ Object.defineProperties(esmsState, {
 });
 
 const esmsInitOptions = self.esmsInitOptions || {};
+self.esmsInitOptions = undefined;
 esmsState.fetch = esmsInitOptions.fetch || (url => fetch(url));
 esmsState.skip = esmsInitOptions.skip || /^https?:\/\/(cdn\.pika\.dev|dev\.jspm\.io|jspm\.dev)\//;
 esmsState.onerror = esmsInitOptions.onerror || ((e) => { throw e; });

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -53,7 +53,7 @@ async function importMetaResolve (id, parentUrl = this.url) {
 }
 
 let esmsState = {}
-self.esmsState = esmsState
+self._esmsState = esmsState
 
 Object.defineProperties(esmsState, {
   m: { value: meta },

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -57,10 +57,10 @@ Object.defineProperties(importShim, {
   l: { value: undefined, writable: true },
   e: { value: undefined, writable: true }
 });
-const importShimInitialOptions = self.importShimInitialOptions || {};
-importShim.fetch = importShimInitialOptions.fetch || (url => fetch(url));
-importShim.skip = importShimInitialOptions.skip || /^https?:\/\/(cdn\.pika\.dev|dev\.jspm\.io|jspm\.dev)\//;
-importShim.onerror = importShimInitialOptions.onerror || ((e) => { throw e; });
+const esmsInitOptions = self.esmsInitOptions || {};
+importShim.fetch = esmsInitOptions.fetch || (url => fetch(url));
+importShim.skip = esmsInitOptions.skip || /^https?:\/\/(cdn\.pika\.dev|dev\.jspm\.io|jspm\.dev)\//;
+importShim.onerror = esmsInitOptions.onerror || ((e) => { throw e; });
 importShim.load = processScripts;
 
 let lastLoad;

--- a/test/fetch-hook.js
+++ b/test/fetch-hook.js
@@ -1,30 +1,35 @@
 
 suite('Fetch hook', () => {
-  importShim.fetch = async function (url) {
-    const response = await fetch(url);
-    if (!response.ok)
-      throw new Error(`${response.status} ${response.statusText} ${response.url}`);
-    const contentType = response.headers.get('content-type');
-    if (!/^application\/json($|;)/.test(contentType))
-      return response;
-    const reader = response.body.getReader();
-    return new Response(new ReadableStream({
-      async start (controller) {
-        let done, value;
-        controller.enqueue(new Uint8Array([...'export default '].map(c => c.charCodeAt(0))));
-        while (({ done, value } = await reader.read()) && !done) {
-          controller.enqueue(value);
-        }
-        controller.close();
-      }
-    }), {
-      status: 200,
-      headers: {
-        "Content-Type": "application/javascript"
-      }
-    });
-  }
   test('Should hook fetch', async function () {
+    globalThis.esmsInitOptions = {
+      fetch: async function (url) {
+        const response = await fetch(url);
+        if (!response.ok)
+          throw new Error(`${response.status} ${response.statusText} ${response.url}`);
+        const contentType = response.headers.get('content-type');
+        if (!/^application\/json($|;)/.test(contentType))
+          return response;
+        const reader = response.body.getReader();
+        return new Response(new ReadableStream({
+          async start (controller) {
+            let done, value;
+            controller.enqueue(new Uint8Array([...'export default '].map(c => c.charCodeAt(0))));
+            while (({ done, value } = await reader.read()) && !done) {
+              controller.enqueue(value);
+            }
+            controller.close();
+          }
+        }), {
+          status: 200,
+          headers: {
+            "Content-Type": "application/javascript"
+          }
+        });
+      }
+    };
+
+    await import('../src/es-module-shims.js');
+
     var m = await importShim('./fixtures/json-or-js.js');
     assert(m.default);
     assert.equal(m.default.json, 'module');

--- a/test/initial-options.js
+++ b/test/initial-options.js
@@ -8,8 +8,8 @@ suite('Initial options', () => {
 
     await import('../src/es-module-shims.js');
 
-    assert.equal(self.esmsInitOptions.fetch, self.importShim.fetch);
-    assert.equal(self.esmsInitOptions.skip, self.importShim.skip);
-    assert.equal(self.esmsInitOptions.onerror, self.importShim.onerror);
+    assert.equal(self.esmsInitOptions.fetch, self.esmsState.fetch);
+    assert.equal(self.esmsInitOptions.skip, self.esmsState.skip);
+    assert.equal(self.esmsInitOptions.onerror, self.esmsState.onerror);
   });
 });

--- a/test/initial-options.js
+++ b/test/initial-options.js
@@ -8,8 +8,8 @@ suite('Initial options', () => {
 
     await import('../src/es-module-shims.js');
 
-    assert.equal(self.esmsInitOptions.fetch, self.esmsState.fetch);
-    assert.equal(self.esmsInitOptions.skip, self.esmsState.skip);
-    assert.equal(self.esmsInitOptions.onerror, self.esmsState.onerror);
+    assert.equal(self.esmsInitOptions.fetch, self._esmsState.fetch);
+    assert.equal(self.esmsInitOptions.skip, self._esmsState.skip);
+    assert.equal(self.esmsInitOptions.onerror, self._esmsState.onerror);
   });
 });

--- a/test/initial-options.js
+++ b/test/initial-options.js
@@ -1,6 +1,6 @@
 suite('Initial options', () => {
   test('Should apply initial options', async function () {
-    self.importShimInitialOptions = {
+    self.esmsInitOptions = {
       fetch: (url) => fetch(url),
       skip: /.*/,
       onerror: (error) => console.log(error)
@@ -8,8 +8,8 @@ suite('Initial options', () => {
 
     await import('../src/es-module-shims.js');
 
-    assert.equal(self.importShimInitialOptions.fetch, self.importShim.fetch);
-    assert.equal(self.importShimInitialOptions.skip, self.importShim.skip);
-    assert.equal(self.importShimInitialOptions.onerror, self.importShim.onerror);
+    assert.equal(self.esmsInitOptions.fetch, self.importShim.fetch);
+    assert.equal(self.esmsInitOptions.skip, self.importShim.skip);
+    assert.equal(self.esmsInitOptions.onerror, self.importShim.onerror);
   });
 });

--- a/test/initial-options.js
+++ b/test/initial-options.js
@@ -1,0 +1,15 @@
+suite('Initial options', () => {
+  test('Should apply initial options', async function () {
+    self.importShimInitialOptions = {
+      fetch: (url) => fetch(url),
+      skip: /.*/,
+      onerror: (error) => console.log(error)
+    };
+
+    await import('../src/es-module-shims.js');
+
+    assert.equal(self.importShimInitialOptions.fetch, self.importShim.fetch);
+    assert.equal(self.importShimInitialOptions.skip, self.importShim.skip);
+    assert.equal(self.importShimInitialOptions.onerror, self.importShim.onerror);
+  });
+});

--- a/test/initial-options.js
+++ b/test/initial-options.js
@@ -1,15 +1,17 @@
 suite('Initial options', () => {
   test('Should apply initial options', async function () {
-    self.esmsInitOptions = {
+    const esmsInitOptions = {
       fetch: (url) => fetch(url),
       skip: /.*/,
       onerror: (error) => console.log(error)
     };
 
+    self.esmsInitOptions = esmsInitOptions
+
     await import('../src/es-module-shims.js');
 
-    assert.equal(self.esmsInitOptions.fetch, self._esmsState.fetch);
-    assert.equal(self.esmsInitOptions.skip, self._esmsState.skip);
-    assert.equal(self.esmsInitOptions.onerror, self._esmsState.onerror);
+    assert.equal(esmsInitOptions.fetch, self._esmsState.fetch);
+    assert.equal(esmsInitOptions.skip, self._esmsState.skip);
+    assert.equal(esmsInitOptions.onerror, self._esmsState.onerror);
   });
 });

--- a/test/test-fetch-hook.html
+++ b/test/test-fetch-hook.html
@@ -2,35 +2,16 @@
 <link rel="stylesheet" type="text/css" href="../node_modules/mocha/mocha.css"/>
 <script src="../node_modules/mocha/mocha.js"></script>
 <script type="importmap-shim">
-{
-  "imports": {
-    "test": "/test/fixtures/es-modules/es6-file.js",
-    "test/": "/test/fixtures/",
-    "bare-dynamic-import": "/test/fixtures/es-modules/bare-dynamic-import.js"
-  },
-  "scopes": {
-    "/": {
-      "test-dep": "/test/fixtures/test-dep.js"
-    },
-    "/test/fixtures/es-modules/import-relative-path.js": {
-      "./relative-path": "/test/fixtures/es-modules/es6-dep.js"
+  {
+    "imports": {
+      "test": "/test/fixtures/es-modules/es6-file.js"
     }
   }
-}
 </script>
 <script type="module-shim">
   import test from "test";
   console.log(test);
 </script>
-<script type="module-shim">
-  syntax-error();
-</script>
-<script>
-  globalThis.esmsInitOptions = {
-    onerror: e => window.e = e,
-  };
-</script>
-<script type="module" src="../src/es-module-shims.js"></script>
 <script type="module">
   mocha.setup('tdd');
   mocha.setup({
@@ -53,12 +34,12 @@
     throw new Error(msg);
   };
 
-  const suites = ['browser-modules'];
+  const suites = ['fetch-hook'];
   function runNextSuite () {
     mocha.suite.suites = [];
     const suite = suites.shift();
     if (suite)
-      importShim('./' + suite + '.js')
+      import('./' + suite + '.js')
       .then(function () {
         mocha.run(runNextSuite);
       });

--- a/test/test-initial-options.html
+++ b/test/test-initial-options.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<link rel="stylesheet" type="text/css" href="../node_modules/mocha/mocha.css"/>
+<script src="../node_modules/mocha/mocha.js"></script>
+<script type="importmap-shim">
+  {
+    "imports": {
+      "test": "/test/fixtures/es-modules/es6-file.js",
+    }
+  }
+</script>
+<script type="module-shim">
+  import test from "test";
+  console.log(test);
+</script>
+<script type="module">
+  mocha.setup('tdd');
+  mocha.setup({
+    ignoreLeaks: true
+  });
+  mocha.allowUncaught();
+
+  self.baseURL = location.href.substr(0, location.href.lastIndexOf('/') + 1);
+  self.rootURL = location.href.substr(0, location.href.length - 'test/test.html'.length);
+  self.assert = function (val) {
+    equal(!!val, true);
+  };
+  assert.equal = equal;
+  assert.ok = assert;
+  function equal (a, b) {
+    if (a !== b)
+      throw new Error('Expected "' + a + '" to be "' + b + '"');
+  }
+  self.fail = function (msg) {
+    throw new Error(msg);
+  };
+
+  const suites = ['initial-options'];
+  function runNextSuite () {
+    mocha.suite.suites = [];
+    const suite = suites.shift();
+    if (suite)
+      import('./' + suite + '.js')
+      .then(function () {
+        mocha.run(runNextSuite);
+      });
+  }
+
+  runNextSuite();
+</script>
+
+<div id="mocha"></div>

--- a/test/test-initial-options.html
+++ b/test/test-initial-options.html
@@ -4,7 +4,7 @@
 <script type="importmap-shim">
   {
     "imports": {
-      "test": "/test/fixtures/es-modules/es6-file.js",
+      "test": "/test/fixtures/es-modules/es6-file.js"
     }
   }
 </script>
@@ -12,6 +12,7 @@
   import test from "test";
   console.log(test);
 </script>
+<script type="module-shim" src="/test/fixtures/es-modules/es6.js"></script>
 <script type="module">
   mocha.setup('tdd');
   mocha.setup({


### PR DESCRIPTION
This PR is meant to address the issue brought up in https://github.com/guybedford/es-module-shims/issues/108, whereby the fetch hook doesn't always get applied in time for the first shimmed module load.

We now accept an `importShimInitialOptions` global to apply specific options on initialization instead of the defaults, which can be supplied by the user before es-module-shims is loaded, guaranteeing that they will be applied to the first shimmed module load.

The API `importShimInitialOptions` was inspired by https://github.com/guybedford/es-module-shims/pull/95, but with the `Initial` qualifier added to hopefully avoid misuse since setting it after es-module-shims is loaded doesn't have any effect. The implementation also differs in that it explicitly applies only specific properties from the global object instead of merging onto it, to keep the API surface minimal and remove the possibility of shadowing other properties that the implementation depends on.

I've also added a new test suite for this. Not sure if the implementation is ideal, happy to take suggestions.