### PR TITLE
Fix immediately added dynamic import maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Just write your HTML modules like you would in the latest Chrome:
 
 and ES Module Shims will make it work in [all browsers with any ES Module Support](#browser-support).
 
+NOTE: `script[type="importmap"]` and `script[type="importmap-shim"]` should be placed before
+any `script[type="module"]` or `script[type="module-shim"]` in the html. 
+
 Note that you will typically see a console error in browsers without import maps support like:
 
 ```

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -64,9 +64,7 @@ async function topLevelLoad (url, source, polyfill) {
 }
 
 async function importShim (id, parentUrl = pageBaseUrl) {
-  // Give dynamically inserted import maps a chance to be processed
-  // if `importShim()` was called synchronously after the insertion.
-  await new Promise(resolve => setTimeout(resolve, 0))
+  await featureDetectionPromise;
   // Make sure all the "in-flight" import maps are loaded and applied.
   await importMapPromise;
   return topLevelLoad(resolve(id, parentUrl).r || throwUnresolved(id, parentUrl));

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -64,6 +64,9 @@ async function topLevelLoad (url, source, polyfill) {
 }
 
 async function importShim (id, parentUrl = pageBaseUrl) {
+  console.log('importShim before await', id)
+  await importMapPromise;
+  console.log('importShim after await', id)
   return topLevelLoad(resolve(id, parentUrl).r || throwUnresolved(id, parentUrl));
 }
 
@@ -291,6 +294,7 @@ new MutationObserver(mutations => {
     if (mutation.type !== 'childList') continue;
     for (const node of mutation.addedNodes) {
       if (node.tagName === 'SCRIPT' && node.type)
+        console.log('MutationObserver', node.innerHTML)
         processScript(node, !firstTopLevelProcess);
     }
   }
@@ -316,11 +320,13 @@ async function processScript (script, dynamic) {
         importMapSrcOrLazy = true;
       hasImportMap = true;
       importMap = resolveAndComposeImportMap(script.src ? await (await fetchHook(script.src)).json() : JSON.parse(script.innerHTML), script.src || pageBaseUrl, importMap);
+      console.log('Processed', script.innerHTML)
     });
   }
 }
 
 function resolve (id, parentUrl) {
+  console.log("resolve", id)
   const urlResolved = resolveIfNotPlainOrUrl(id, parentUrl);
   const resolved = resolveImportMap(importMap, urlResolved || id, parentUrl);
   return { r: resolved, m: urlResolved !== resolved };

--- a/test/dynamic-import-map-shim.html
+++ b/test/dynamic-import-map-shim.html
@@ -1,0 +1,16 @@
+<!doctype html>
+
+<script type="importmap-shim">
+  {
+    "imports": {
+      "react": "https://ga.jspm.io/npm:react@17.0.2/dev.index.js"
+    },
+    "scopes": {
+      "https://ga.jspm.io/": {
+        "object-assign": "https://ga.jspm.io/npm:object-assign@4.1.1/index.js"
+      }
+    }
+  }
+</script>
+<script type="module" src="../src/es-module-shims.js"></script>
+<script src="dynamic-import-map-shim.js" type="module"></script>

--- a/test/dynamic-import-map-shim.js
+++ b/test/dynamic-import-map-shim.js
@@ -1,0 +1,28 @@
+main();
+async function main() {
+    // Append a dynamic import map containing resolution for "react-dom".
+    document.body.appendChild(Object.assign(document.createElement('script'), {
+        type: 'importmap-shim',
+        innerHTML: JSON.stringify({
+            "imports": {
+                "react-dom": "https://ga.jspm.io/npm:react-dom@17.0.2/dev.index.js"
+            },
+            "scopes": {
+                "https://ga.jspm.io/": {
+                    "scheduler": "https://ga.jspm.io/npm:scheduler@0.20.2/dev.index.js",
+                    "scheduler/tracing": "https://ga.jspm.io/npm:scheduler@0.20.2/dev.tracing.js"
+                }
+            }
+        })
+    }));
+
+    const reactStart = performance.now();
+    const [React, ReactDOM] = await Promise.all([
+        importShim('react'),
+        importShim('react-dom'),
+    ]);
+    const reactEnd = performance.now();
+
+    console.log(`React and ReactDOM loaded in ${(reactEnd - reactStart).toFixed(2)}ms`);
+    console.log({ React, ReactDOM });
+}

--- a/test/dynamic-import-map-shim.js
+++ b/test/dynamic-import-map-shim.js
@@ -1,20 +1,16 @@
 main();
 async function main() {
-    // Append a dynamic import map containing resolution for "react-dom".
-    document.body.appendChild(Object.assign(document.createElement('script'), {
-        type: 'importmap-shim',
-        innerHTML: JSON.stringify({
-            "imports": {
-                "react-dom": "https://ga.jspm.io/npm:react-dom@17.0.2/dev.index.js"
-            },
-            "scopes": {
-                "https://ga.jspm.io/": {
-                    "scheduler": "https://ga.jspm.io/npm:scheduler@0.20.2/dev.index.js",
-                    "scheduler/tracing": "https://ga.jspm.io/npm:scheduler@0.20.2/dev.tracing.js"
-                }
+    insertDynamicImportMap({
+        "imports": {
+            "react-dom": "https://ga.jspm.io/npm:react-dom@17.0.2/dev.index.js"
+        },
+        "scopes": {
+            "https://ga.jspm.io/": {
+                "scheduler": "https://ga.jspm.io/npm:scheduler@0.20.2/dev.index.js",
+                "scheduler/tracing": "https://ga.jspm.io/npm:scheduler@0.20.2/dev.tracing.js"
             }
-        })
-    }));
+        }
+    });
 
     const reactStart = performance.now();
     const [React, ReactDOM] = await Promise.all([
@@ -25,4 +21,22 @@ async function main() {
 
     console.log(`React and ReactDOM loaded in ${(reactEnd - reactStart).toFixed(2)}ms`);
     console.log({ React, ReactDOM });
+
+    setTimeout(async () => {
+        insertDynamicImportMap({
+            "imports": {
+                "lodash": "https://ga.jspm.io/npm:lodash-es@4.17.21/lodash.js",
+            }
+        })
+
+        const lodash = await importShim("lodash")
+        console.log({ lodash })
+    }, 1000)
+}
+
+function insertDynamicImportMap(importMap) {
+    document.body.appendChild(Object.assign(document.createElement('script'), {
+        type: 'importmap-shim',
+        innerHTML: JSON.stringify(importMap)
+    }));
 }

--- a/test/server.mjs
+++ b/test/server.mjs
@@ -94,7 +94,7 @@ http.createServer(async function (req, res) {
         mime = mimes[path.extname(filePath)] || 'text/plain';
 
     const headers = filePath.endsWith('content-type-none.json') ?
-        {} : { 'content-type': mime }
+        {} : { 'content-type': mime, 'Cache-Control': 'no-cache' }
 
     res.writeHead(200, headers);
     fileStream.pipe(res);


### PR DESCRIPTION
This draft adds a failing test (`http://localhost:8080/test/dynamic-import-map-shim.html`) for the scenario when an import map is inserted dynamically from JS and `importShim()` that is trying to import a bare module specifier defined in that dynamic import map is called right after the insertion.

In the state after the [first commit](https://github.com/guybedford/es-module-shims/pull/123/commits/6504a33cab7c9e8cd2e153249a4f67ca18dcd867) the code works in Safari and prints the following to the console

![image](https://user-images.githubusercontent.com/1524432/118241014-f186b580-b49b-11eb-9824-01d8c3b465fe.png)

but it fails in Chrome with printing the following:

![image](https://user-images.githubusercontent.com/1524432/118241106-0d8a5700-b49c-11eb-85eb-8a6c665f4223.png)

The second commit fixes it.