### PR TITLE
Fix dynamic imports in inline scripts

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -184,7 +184,7 @@ function resolveDeps (load, seen) {
       }
       // dynamic import
       else {
-        resolvedSource += `${source.slice(lastIndex, dynamicImportIndex + 6)}Shim(${source.slice(start, end)}, ${urlJsString(load.r)}`;
+        resolvedSource += `${source.slice(lastIndex, dynamicImportIndex + 6)}Shim(${source.slice(start, end)}, ${load.r && urlJsString(load.r)}`;
         lastIndex = end;
       }
     }

--- a/test/browser-modules.js
+++ b/test/browser-modules.js
@@ -74,6 +74,10 @@ suite('Basic loading tests', () => {
     assert.equal(dynamicModule.default, 'bareDynamicImport');
   });
 
+  test('should support dynamic import in an inline script', async function () {
+    assert.equal(window.inlineScriptDynamicImportResult.default, 'bareDynamicImport');
+  });
+
   test('Should import a module via a full url, with scheme', async function () {
     const url = window.location.href.replace('/test.html', '/fixtures/es-modules/no-imports.js');
     assert.equal(url.slice(0, 4), 'http');

--- a/test/test.html
+++ b/test/test.html
@@ -29,6 +29,9 @@
   console.log(test);
 </script>
 <script type="module-shim">
+  window.inlineScriptDynamicImportResult = await import("bare-dynamic-import");
+</script>
+<script type="module-shim">
   syntax-error();
 </script>
 <script>


### PR DESCRIPTION
Attempting to polyfill a dynamic import in an inline script currently fails with `TypeError: url is undefined`.

![image](https://user-images.githubusercontent.com/1155764/120000051-b2478100-bfd2-11eb-8330-e61625a01536.png)

![image](https://user-images.githubusercontent.com/1155764/120000064-b5427180-bfd2-11eb-8a06-e8c146c6815c.png)

`load.r` is only set when the source needs to be fetched, which is not the case for inline scripts.

https://github.com/guybedford/es-module-shims/blob/986733009f4c9374decd4c0348740134ff499157/src/es-module-shims.js#L240-L244

My proposed solution is to rewrite such imports as `importShim("...", undefined)` … which seems to work, as it's gonna default to `pageBaseUrl`.