### PR TITLE
Fix supportsImportMaps feature detection on null origins

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -62,7 +62,7 @@ export const featureDetectionPromise = Promise.all([
     };
     const iframe = document.createElement('iframe');
     iframe.style.display = 'none';
-    iframe.src = createBlob(`<script type=importmap>{"imports":{"x":"data:text/javascript,"}}<${''}/script><script>import('x').then(()=>1,()=>0).then(v=>parent._$s(v))<${''}/script>`, 'text/html');
+    iframe.srcdoc = `<script type=importmap>{"imports":{"x":"data:text/javascript,"}}<${''}/script><script>import('x').then(()=>1,()=>0).then(v=>parent._$s(v))<${''}/script>`, 'text/html';
     document.body.appendChild(iframe);
   })
 ]);


### PR DESCRIPTION
Fixes https://github.com/guybedford/es-module-shims/issues/127.

In Safari (and Chrome\*), import maps feature detection via a `blob:` iframe fails on null origins (such as `file:`, but I guess it might also fail e.g. in sandboxed iframes) — `parent._$s(v)` fails with a CORS error.

_\* This of course is not really a problem in Chrome, since they support import maps natively anyway. Interestingly enough, it doesn't fail in Firefox, so it looks like Firefox has more lax null origin restrictions?_

This PR proposes to use [`srcdoc`](https://caniuse.com/?search=srcdoc) instead of `src="blob:...` for the iframe, which seems to work.