### PR TITLE
Support JSON Modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         firefox: ['60.0', '84.0', '89.0']
-    name: Browser Tests
+    name: Firefox Browser Tests
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node.js ${{ matrix.node }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        firefox: ['60.0', '84.0', '89.0']
+        firefox: [
+          '60.0', # modules support
+          '67.0', # import(), import.meta
+          '89.0'  # top-level await
+        ]
     name: Firefox Browser Tests
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ _It turns out that we can actually polyfill new modules features on top of these
 This includes support for:
 
 * [Import Maps](https://github.com/wicg/import-maps) support.
-* `import.meta` and `import.meta.url`.
 * Dynamic `import()` shimming when necessary in eg older Firefox versions.
+* `import.meta` and `import.meta.url`.
+* JSON modules with import assertions.
 
 In addition a custom [fetch hook](#fetch-hook) can be implemented allowing for streaming in-browser transform workflows to support custom module types.
 
@@ -93,6 +94,7 @@ Works in all browsers with [baseline ES module support](https://caniuse.com/#fea
 | [import.meta.resolve](#resolve)    | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
 | [Module Workers](#module-workers)  | :heavy_check_mark: ~68+              | :x:<sup>2</sup>                      | :x:<sup>2</sup>                      | :x:<sup>2</sup>                      |
 | [Import Maps](#import-maps)        | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
+| [JSON Modules](#json-modules)      | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
 
 * 1: _The Edge parallel execution ordering bug is corrected by ES Module Shims with an execution chain inlining approach._
 * 2: _Module worker support cannot be implemented without dynamic import support in web workers._
@@ -107,12 +109,15 @@ Works in all browsers with [baseline ES module support](https://caniuse.com/#fea
 | [import.meta.resolve](#resolve)    | :x:                                  | :x:                                  | :x:                                  | :x:                                  |
 | [Module Workers](#module-workers)  | :heavy_check_mark: ~68+              | :x:                                  | :x:                                  | :x:                                  |
 | [Import Maps](#import-maps)        | :heavy_check_mark: 89+               | :x:                                  | :x:                                  | :x:                                  |
+| [JSON Modules](#json-modules)      | :heavy_check_mark: 91+               | :x:                                  | :x:                                  | :x:                                  |
 
 * 1: _Edge executes parallel dependencies in non-deterministic order. ([ChakraCore bug](https://github.com/microsoft/ChakraCore/issues/6261))._
 * ~: _Indicates the exact first version support has not yet been determined (PR's welcome!)._
 * ❕<sup>1</sup>: On module redirects, Safari returns the request URL in `import.meta.url` instead of the response URL as per the spec.
 
 ### Import Maps
+
+> Stability: WhatWG Standard, Single Browser Implementer
 
 Import maps allow for importing "bare specifiers" in JavaScript modules, which prior to import maps throw in all browsers with native modules support.
 
@@ -157,6 +162,24 @@ importShim('/path/to/module.js').then(x => console.log(x));
 > Stability: Stable browser standard
 
 `import.meta.url` provides the full URL of the current module within the context of the module execution.
+
+### JSON Modules
+
+> Stability: WhatWG Standard, Single Browser Implementer
+
+JSON Modules are supported only when using import assertions in Chrome:
+
+```html
+<script type="module">
+import json from 'https://site.com/data.json' assert { type: 'json' };
+</script>
+```
+
+In addition JSON modules need to be served with a valid JSON content type.
+
+ES Module Shims will fully feature detect and shim or polyfill support as necessary for this feature in other browsers.
+
+Checks for assertion failures are not currently included.
 
 ### Resolve
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ importShim('/path/to/module.js').then(x => console.log(x));
 
 > Stability: WhatWG Standard, Single Browser Implementer
 
-JSON Modules are supported only when using import assertions in Chrome:
+JSON Modules are currently supported in Chrome when using them via an import assertion:
 
 ```html
 <script type="module">

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@rollup/plugin-replace": "^2.4.2",
     "cross-env": "^7.0.3",
-    "es-module-lexer": "^0.4.0",
+    "es-module-lexer": "^0.6.0",
     "esm": "^3.2.25",
     "kleur": "^4.1.4",
     "mocha": "^8.4.0",

--- a/src/common.js
+++ b/src/common.js
@@ -15,7 +15,6 @@ export const hasDocument = typeof document !== 'undefined';
 
 // support browsers without dynamic import support (eg Firefox 6x)
 export let supportsDynamicImport = false;
-export let supportsJsonModules = false;
 export let supportsJsonAssertions = false;
 export let dynamicImport;
 try {
@@ -25,7 +24,7 @@ try {
 catch (e) {
   if (hasDocument) {
     let err;
-    window.addEventListener('error', e => err = e.error);
+    self.addEventListener('error', e => err = e.error);
     dynamicImport = blobUrl => {
       const topLevelBlobUrl = createBlob(
         `import*as m from'${blobUrl}';self._esmsi=m;`
@@ -38,8 +37,8 @@ catch (e) {
         s.addEventListener('load', () => {
           document.head.removeChild(s);
           if (self._esmsi) {
-            resolve(window._esmsi, baseUrl);
-            window._esmsi = null;
+            resolve(self._esmsi, baseUrl);
+            self._esmsi = null;
           }
           else {
             reject(err);

--- a/src/common.js
+++ b/src/common.js
@@ -15,6 +15,7 @@ export const hasDocument = typeof document !== 'undefined';
 
 // support browsers without dynamic import support (eg Firefox 6x)
 export let supportsDynamicImport = false;
+export let supportsJsonModules = false;
 export let supportsJsonAssertions = false;
 export let dynamicImport;
 try {

--- a/src/common.js
+++ b/src/common.js
@@ -15,6 +15,7 @@ export const hasDocument = typeof document !== 'undefined';
 
 // support browsers without dynamic import support (eg Firefox 6x)
 export let supportsDynamicImport = false;
+export let supportsJsonAssertions = false;
 export let dynamicImport;
 try {
   dynamicImport = (0, eval)('u=>import(u)');
@@ -52,6 +53,7 @@ export let supportsImportMeta = false;
 export let supportsImportMaps = false;
 
 export const featureDetectionPromise = Promise.all([
+  dynamicImport(createBlob('import"data:text/json,{}"assert{type:"json"}')).then(() => supportsJsonAssertions = true),
   dynamicImport(createBlob('import.meta')).then(() => supportsImportMeta = true),
   supportsDynamicImport && hasDocument && new Promise(resolve => {
     self._$s = v => {

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -11,7 +11,6 @@ import {
   supportsImportMeta,
   supportsImportMaps,
   featureDetectionPromise,
-  supportsJsonAssertions,
   supportsJsonAssertions
 } from './common.js';
 import { init, parse } from '../node_modules/es-module-lexer/dist/lexer.js';

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -10,7 +10,8 @@ import {
   supportsDynamicImport,
   supportsImportMeta,
   supportsImportMaps,
-  featureDetectionPromise
+  featureDetectionPromise,
+  supportsJsonAssertions
 } from './common.js';
 import { init, parse } from '../node_modules/es-module-lexer/dist/lexer.js';
 
@@ -251,16 +252,23 @@ function getOrCreateLoad (url, source) {
         throw new Error(`${res.status} ${res.statusText} ${res.url}`);
       load.r = res.url;
       const contentType = res.headers.get('content-type');
-      if (jsContentType.test(contentType))
+      if (jsContentType.test(contentType)) {
         source = await res.text();
-      else if (jsonContentType.test(contentType))
+      }
+      else if (jsonContentType.test(contentType)) {
+        if (!supportsJsonAssertions)
+          load.n = true;
         source = `export default ${await res.text()}`;
-      else if (cssContentType.test(contentType))
+      }
+      else if (cssContentType.test(contentType)) {
         throw new Error('CSS modules not yet supported');
-      else if (wasmContentType.test(contentType))
+      }
+      else if (wasmContentType.test(contentType)) {
         throw new Error('WASM modules not yet supported');
-      else
+      }
+      else {
         throw new Error(`Unknown Content-Type "${contentType}"`);
+      }
     }
     try {
       load.a = parse(source, load.u);

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -11,6 +11,7 @@ import {
   supportsImportMeta,
   supportsImportMaps,
   featureDetectionPromise,
+  supportsJsonAssertions,
   supportsJsonAssertions
 } from './common.js';
 import { init, parse } from '../node_modules/es-module-lexer/dist/lexer.js';
@@ -252,23 +253,16 @@ function getOrCreateLoad (url, source) {
         throw new Error(`${res.status} ${res.statusText} ${res.url}`);
       load.r = res.url;
       const contentType = res.headers.get('content-type');
-      if (jsContentType.test(contentType)) {
+      if (jsContentType.test(contentType))
         source = await res.text();
-      }
-      else if (jsonContentType.test(contentType)) {
-        if (!supportsJsonAssertions)
-          load.n = true;
+      else if (jsonContentType.test(contentType))
         source = `export default ${await res.text()}`;
-      }
-      else if (cssContentType.test(contentType)) {
+      else if (cssContentType.test(contentType))
         throw new Error('CSS modules not yet supported');
-      }
-      else if (wasmContentType.test(contentType)) {
+      else if (wasmContentType.test(contentType))
         throw new Error('WASM modules not yet supported');
-      }
-      else {
+      else
         throw new Error(`Unknown Content-Type "${contentType}"`);
-      }
     }
     try {
       load.a = parse(source, load.u);
@@ -282,8 +276,10 @@ function getOrCreateLoad (url, source) {
   })();
 
   load.L = load.f.then(async () => {
-    load.d = await Promise.all(load.a[0].map(({ n, d }) => {
-      if (d >= 0 && !supportsDynamicImport || d === 2 && (!supportsImportMeta || source.slice(end, end + 8) === '.resolve'))
+    load.d = await Promise.all(load.a[0].map(({ n, d, a }) => {
+      if (d >= 0 && !supportsDynamicImport ||
+          d === 2 && (!supportsImportMeta || source.slice(end, end + 8) === '.resolve') ||
+          a && !supportsJsonAssertions)
         load.n = true;
       if (!n) return;
       const { r, m } = resolve(n, load.r || load.u);

--- a/test/browser-modules.js
+++ b/test/browser-modules.js
@@ -65,6 +65,11 @@ suite('Basic loading tests', () => {
     assert.equal(m.name, new URL('./fixtures/es-modules/moduleName.js', baseURL).href);
   });
 
+  test('should support import assertions', async function () {
+    var m = await importShim('./fixtures/json-assertion.js');
+    assert.equal(m.m, 'module');
+  });
+
   test('should support dynamic import', async function () {
     var m = await importShim('./fixtures/es-modules/dynamic-import.js');
     var dynamicModule = await m.doImport();

--- a/test/fixtures/json-assertion.js
+++ b/test/fixtures/json-assertion.js
@@ -1,0 +1,3 @@
+import json from './json.json' assert { type: 'json' };
+
+export const m = json.json;


### PR DESCRIPTION
This updates es-module-shims to behave as a full JSON modules polyfill or shim.

When an import assertion is encountered, es-module-shims knows to polyfill and reexecute the graph with rewritten sources excluding the new syntax, using es-module-lexer@0.6.0 import assertions support.

* Updates to es-module-lexer@0.6.0 with import assertion parsing
* Rewrites import assertions into normal imports
* Supports JSON source loading
* JSON module assertions are feature detected on initialization, then marked as requiring polyfilling when encountered.