### PR TITLE
feat: support modulepreload polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Preloading of modules can be achieved by including a `<link rel="modulepreload" 
 
 This tag also supports the `"integrity"`, `"crossorigin"` and `"referrerpolicy"` attributes as supported on module scripts.
 
-This tag just iniates a fetch request in the browser and thus works equally as a preload polyfill in both shimmed and unshimmed modes.
+This tag just initiates a fetch request in the browser and thus works equally as a preload polyfill in both shimmed and unshimmed modes, with integrity validation support.
 
 Unlike the browser specification, the modulepreload polyfill does not request dependency modules by default, in order to avoid unnecessary
 code analysis in the polyfill scenarios. **It is recommended to preload deep imports anyway so that this feature shouldn't be necessary.**

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This includes support for:
 * Dynamic `import()` shimming when necessary in eg older Firefox versions.
 * `import.meta` and `import.meta.url`.
 * JSON modules with import assertions.
+* `<link rel="modulepreload">` polyfill in non Chromium browsers for both shimmed and unshimmed preloading scenarios.
 
 In addition a custom [fetch hook](#fetch-hook) can be implemented allowing for streaming in-browser transform workflows to support custom module types.
 
@@ -91,10 +92,13 @@ Works in all browsers with [baseline ES module support](https://caniuse.com/#fea
 | Executes Modules in Correct Order  | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:<sup>1</sup>       |
 | [Dynamic Import](#dynamic-import)  | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
 | [import.meta.url](#importmetaurl)  | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
-| [import.meta.resolve](#resolve)    | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
-| [Module Workers](#module-workers)  | :heavy_check_mark: ~68+              | :x:<sup>2</sup>                      | :x:<sup>2</sup>                      | :x:<sup>2</sup>                      |
+| [Module Workers](#module-workers)  | :heavy_check_mark: ~68+              | :x:<sup>2</sup>                      |
+:x:<sup>2</sup>                      | :x:<sup>2</sup>                      |
+| [modulepreload](#modulepreload)    | :heavy_check_mark:                   | :heavy_check_mark:                   |
+:heavy_check_mark:                   | :heavy_check_mark:                   |
 | [Import Maps](#import-maps)        | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
 | [JSON Modules](#json-modules)      | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
+| [import.meta.resolve](#resolve)    | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
 
 * 1: _The Edge parallel execution ordering bug is corrected by ES Module Shims with an execution chain inlining approach._
 * 2: _Module worker support cannot be implemented without dynamic import support in web workers._
@@ -106,10 +110,11 @@ Works in all browsers with [baseline ES module support](https://caniuse.com/#fea
 | Executes Modules in Correct Order  | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :x:<sup>1</sup>                      |
 | [Dynamic Import](#dynamic-import)  | :heavy_check_mark: 63+               | :heavy_check_mark: 67+               | :heavy_check_mark: 11.1+             | :x:                                  |
 | [import.meta.url](#importmetaurl)  | :heavy_check_mark: ~76+              | :heavy_check_mark: ~67+              | :heavy_check_mark: ~12+ ❕<sup>1</sup>| :x:                                  |
-| [import.meta.resolve](#resolve)    | :x:                                  | :x:                                  | :x:                                  | :x:                                  |
 | [Module Workers](#module-workers)  | :heavy_check_mark: ~68+              | :x:                                  | :x:                                  | :x:                                  |
+| [modulepreload](#modulepreload)    | :heavy_check_mark: 66+               | :x:                                  | :x:                                  | :x:                                  |
 | [Import Maps](#import-maps)        | :heavy_check_mark: 89+               | :x:                                  | :x:                                  | :x:                                  |
 | [JSON Modules](#json-modules)      | :heavy_check_mark: 91+               | :x:                                  | :x:                                  | :x:                                  |
+| [import.meta.resolve](#resolve)    | :x:                                  | :x:                                  | :x:                                  | :x:                                  |
 
 * 1: _Edge executes parallel dependencies in non-deterministic order. ([ChakraCore bug](https://github.com/microsoft/ChakraCore/issues/6261))._
 * ~: _Indicates the exact first version support has not yet been determined (PR's welcome!)._
@@ -162,6 +167,19 @@ importShim('/path/to/module.js').then(x => console.log(x));
 > Stability: Stable browser standard
 
 `import.meta.url` provides the full URL of the current module within the context of the module execution.
+
+### modulepreload
+
+> Stability: WhatWG Standard, Single Browser Implementer
+
+Preloading of modules can be achieved by including a `<link rel="modulepreload" href="/module.js" />` tag in the HTML or injecting it dynamically.
+
+This tag also supports the `"integrity"`, `"crossorigin"` and `"referrerpolicy"` attributes as supported on module scripts.
+
+This tag just iniates a fetch request in the browser and thus works equally as a preload polyfill in both shimmed and unshimmed modes.
+
+Unlike the browser specification, the modulepreload polyfill does not request dependency modules by default, in order to avoid unnecessary
+code analysis in the polyfill scenarios. **It is recommended to preload deep imports anyway so that this feature shouldn't be necessary.**
 
 ### JSON Modules
 

--- a/test/test.html
+++ b/test/test.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <link rel="stylesheet" type="text/css" href="../node_modules/mocha/mocha.css"/>
 <script src="../node_modules/mocha/mocha.js"></script>
+<link rel="modulepreload" integrity="sha256-EwxIX0ecy1M0ZPP9fYvSRqDFxVMbDixhZl7rE+l+mjA=" href="/test/fixtures/es-modules/bare-dynamic-import.js" />
 <script type="importmap-shim">
 {
   "imports": {


### PR DESCRIPTION
This adds comprehensive support for polyfilling `<link rel="modulepreload" />`. In addition this PR fixes up the fetch options handling to provide support for exact `crossorigin`, `referrerpolicy` and `integrity` attributes on both module scripts and preload tags.

This enables:
* Preloading `modulepreload` for shimmed and non-shimmed modes in non Chromium browsers
* Integrity for all modules via `modulepreload` shimmed and unshimmed, polyfilled and unpolyfilled in all browsers.