### PR TITLE
Use `link[rel=modulepreload]` shim only when necessary

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -13,6 +13,7 @@ export function createBlob (source, type = 'text/javascript') {
 
 export const hasDocument = typeof document !== 'undefined';
 
+export const supportsModulePreload = document.createElement('link').relList.supports('modulepreload');
 // support browsers without dynamic import support (eg Firefox 6x)
 export let supportsDynamicImport = false;
 export let supportsJsonAssertions = false;

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -7,6 +7,7 @@ import {
   resolveIfNotPlainOrUrl,
   resolvedPromise,
   dynamicImport,
+  supportsModulePreload,
   supportsDynamicImport,
   supportsImportMeta,
   supportsImportMaps,
@@ -315,8 +316,10 @@ async function processScripts () {
     clearTimeout(waitingForImportMapsInterval);
     waitingForImportMapsInterval = 0;
   }
-  for (const link of document.querySelectorAll('link[rel="modulepreload"]'))
-    processPreload(link);
+  if (!supportsModulePreload) {
+    for (const link of document.querySelectorAll('link[rel="modulepreload"]'))
+      processPreload(link);
+  }
   for (const script of document.querySelectorAll('script[type="module-shim"],script[type="importmap-shim"],script[type="module"],script[type="importmap"]'))
     await processScript(script);
 }
@@ -327,7 +330,7 @@ new MutationObserver(mutations => {
     for (const node of mutation.addedNodes) {
       if (node.tagName === 'SCRIPT' && node.type)
         processScript(node, !firstTopLevelProcess);
-      else if (node.tagName === 'LINK' && node.rel === 'modulepreload')
+      else if (!supportsModulePreload && node.tagName === 'LINK' && node.rel === 'modulepreload')
         processPreload(node);
     }
   }


### PR DESCRIPTION
Adds feature detection to figure out browser support.