### PR TITLE
Support processing nested script / link tags in MutationObserver

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -329,6 +329,14 @@ new MutationObserver(mutations => {
         processScript(node, !firstTopLevelProcess);
       else if (node.tagName === 'LINK' && node.rel === 'modulepreload')
         processPreload(node);
+      else if (node.querySelectorAll) {
+        for (const script of node.querySelectorAll('script[type="module-shim"],script[type="importmap-shim"],script[type="module"],script[type="importmap"]')) {
+          processScript(script, !firstTopLevelProcess);
+        }
+        for (const link of node.querySelectorAll('link[rel=modulepreload]')) {
+          processPreload(link);
+        }
+      }
     }
   }
 }).observe(document, { childList: true, subtree: true });


### PR DESCRIPTION
Previously `<script type="module-shim">` tags appended to DOM when replacing the entire `<body>` tag using eg. [Turbolinks](https://github.com/turbolinks/turbolinks) would not be processed.

I have confirmed this patch resolves the issues I had with `es-module-shims` in a local Turbolinks enabled Ruby on Rails application.

I briefly looked at the test folder but failed to figure out how I could add tests for this behaviour. Seems like there are no tests for the MutationObserver currently (no tests failed when I attempted to remove the MutationObserver).

Let me know if there is a strong desire to test this diff. If so I'll need some help to get started.