### PR TITLE
feat: support css module scripts & import assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,12 @@ Works in all browsers with [baseline ES module support](https://caniuse.com/#fea
 | [modulepreload](#modulepreload)    | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
 | [Import Maps](#import-maps)        | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
 | [JSON Modules](#json-modules)      | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
+| [CSS Modules](#css-modules)        | :heavy_check_mark:<sup>3</sup>       | :heavy_check_mark:<sup>3</sup>       | :heavy_check_mark:<sup>3</sup>       | :heavy_check_mark:<sup>3</sup>       |
 | [import.meta.resolve](#resolve)    | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
 
 * 1: _The Edge parallel execution ordering bug is corrected by ES Module Shims with an execution chain inlining approach._
 * 2: _Module worker support cannot be implemented without dynamic import support in web workers._
+* 3: _CSS module support requires a separate [Constructable Stylesheets polyfill](https://github.com/calebdwilliams/construct-style-sheets#readme)._
 
 #### Current browser compatibility of modules features without ES module shims:
 
@@ -112,6 +114,7 @@ Works in all browsers with [baseline ES module support](https://caniuse.com/#fea
 | [modulepreload](#modulepreload)    | :heavy_check_mark: 66+               | :x:                                  | :x:                                  | :x:                                  |
 | [Import Maps](#import-maps)        | :heavy_check_mark: 89+               | :x:                                  | :x:                                  | :x:                                  |
 | [JSON Modules](#json-modules)      | :heavy_check_mark: 91+               | :x:                                  | :x:                                  | :x:                                  |
+| [CSS Modules](#css-modules)        | :heavy_check_mark: 95+               | :x:                                  | :x:                                  | :x:                                  |
 | [import.meta.resolve](#resolve)    | :x:                                  | :x:                                  | :x:                                  | :x:                                  |
 
 * 1: _Edge executes parallel dependencies in non-deterministic order. ([ChakraCore bug](https://github.com/microsoft/ChakraCore/issues/6261))._
@@ -192,6 +195,32 @@ import json from 'https://site.com/data.json' assert { type: 'json' };
 ```
 
 In addition JSON modules need to be served with a valid JSON content type.
+
+ES Module Shims will fully feature detect and shim or polyfill support as necessary for this feature in other browsers.
+
+Checks for assertion failures are not currently included.
+
+### CSS Modules
+
+> Stability: WhatWG Standard, Single Browser Implementer
+
+CSS Modules are currently supported in Chrome when using them via an import assertion:
+
+```html
+<script type="module">
+import json from 'https://site.com/sheet.css' assert { type: 'css' };
+</script>
+```
+
+To support the polyfill or shim of this feature, the [Constructable Stylesheets polyfill](https://github.com/calebdwilliams/construct-style-sheets#readme) must be separately included in browsers not supporting [Constructable Stylesheets](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/CSSStyleSheet) eg via:
+
+```html
+<script async src="https://unpkg.com/construct-style-sheets-polyfill@3.0.0/dist/adoptedStyleSheets.js"></script>
+```
+
+For more information see the [web.dev article](https://web.dev/css-module-scripts/).
+
+In addition CSS modules need to be served with a valid CSS content type.
 
 ES Module Shims will fully feature detect and shim or polyfill support as necessary for this feature in other browsers.
 

--- a/src/common.js
+++ b/src/common.js
@@ -16,6 +16,7 @@ export const hasDocument = typeof document !== 'undefined';
 // support browsers without dynamic import support (eg Firefox 6x)
 export let supportsDynamicImport = false;
 export let supportsJsonAssertions = false;
+export let supportsCssAssertions = false;
 export let dynamicImport;
 try {
   dynamicImport = (0, eval)('u=>import(u)');
@@ -53,6 +54,7 @@ export let supportsImportMeta = false;
 export let supportsImportMaps = false;
 
 export const featureDetectionPromise = Promise.all([
+  dynamicImport(createBlob('import"data:text/css,{}"assert{type:"css"}')).then(() => supportsCssAssertions = true, () => {}),
   dynamicImport(createBlob('import"data:text/json,{}"assert{type:"json"}')).then(() => supportsJsonAssertions = true, () => {}),
   dynamicImport(createBlob('import.meta')).then(() => supportsImportMeta = true, () => {}),
   supportsDynamicImport && hasDocument && new Promise(resolve => {

--- a/test/browser-modules.js
+++ b/test/browser-modules.js
@@ -70,6 +70,11 @@ suite('Basic loading tests', () => {
     assert.equal(m.m, 'module');
   });
 
+  test('should support css imports', async function () {
+    var m = await importShim('./fixtures/css-assertion.js');
+    assert.equal(m.default.rules[0].selectorText, 'body');
+  });
+
   test('should support dynamic import', async function () {
     var m = await importShim('./fixtures/es-modules/dynamic-import.js');
     var dynamicModule = await m.doImport();

--- a/test/fixtures/css-assertion.js
+++ b/test/fixtures/css-assertion.js
@@ -1,0 +1,3 @@
+import css from './sheet.css' assert { type: 'css' };
+
+export default css;

--- a/test/fixtures/sheet.css
+++ b/test/fixtures/sheet.css
@@ -1,0 +1,3 @@
+body {
+  background-color: papayawhip;
+}

--- a/test/test-chrome-noshim.html
+++ b/test/test-chrome-noshim.html
@@ -1,5 +1,4 @@
 <!doctype html>
-<script>globalThis.esmsInitOptions = { shimMode: false }</script>
 <script type="importmap">
 {
   "imports": {
@@ -8,16 +7,11 @@
   }
 }
 </script>
-<script type="importmap-shim">
-{
-  "imports": {
-    "app": "data:text/javascript,window.polyfill=true"
-  }
-}
-</script>
+<script async src="https://unpkg.com/construct-style-sheets-polyfill@3.0.0/dist/adoptedStyleSheets.js"></script>
 <script type="module">
 import 'app';
 import 'shared';
+import x from '/test/fixtures/css-assertion.js';
 
 if (!window.native)
   throw new Error('Expected native exec');

--- a/test/test-preload-case.html
+++ b/test/test-preload-case.html
@@ -2,10 +2,10 @@
 <html>
 <head>
   <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.esm.browser.js">
-  <script type="module" src="/src/es-module-shims.js"></script>
   <script type="importmap">
     { "imports": { "vue": "https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.esm.browser.js" } }
   </script>
+  <script type="module" src="/src/es-module-shims.js"></script>
   <script type="module">
     import Vue from 'vue'
     new Vue({ el: '#app-4', data: { todos: [ { text: 'Learn JavaScript' }, { text: 'Learn Vue' }, { text: 'Build something awesome' } ] } });

--- a/test/test.html
+++ b/test/test.html
@@ -2,6 +2,7 @@
 <link rel="stylesheet" type="text/css" href="../node_modules/mocha/mocha.css"/>
 <script src="../node_modules/mocha/mocha.js"></script>
 <link rel="modulepreload" integrity="sha256-EwxIX0ecy1M0ZPP9fYvSRqDFxVMbDixhZl7rE+l+mjA=" href="/test/fixtures/es-modules/bare-dynamic-import.js" />
+<script async src="https://unpkg.com/construct-style-sheets-polyfill@3.0.0/dist/adoptedStyleSheets.js"></script>
 <script type="importmap-shim">
 {
   "imports": {


### PR DESCRIPTION
This adds support for polyfilling CSS module scripts, as well as the careful feature detection to only polyfill CSS modules as necessary by including a feature detection and only triggering the polyfill when there is CSS in the specific subgraph (unless in shim mode as per usual operation).

Support is also included for normalizing URLs in the stylesheet to be relative to the loaded stylesheet URL as per the spec.

Import assertions still do not actually perform the assertion in this project for now, although that may change in future.

