### PR TITLE
fix: polyfill fallback

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -62,7 +62,7 @@ async function topLevelLoad (url, fetchOpts, source, nativelyLoaded) {
   await loadAll(load, seen);
   lastLoad = undefined;
   resolveDeps(load, seen);
-  if (source && !nativelyLoaded && !shimMode && !load.n) {
+  if (source && !shimMode && !load.n) {
     const module = dynamicImport(createBlob(source));
     if (shouldRevokeBlobURLs) revokeObjectURLs(Object.keys(seen));
     return module;

--- a/test/server.mjs
+++ b/test/server.mjs
@@ -116,5 +116,5 @@ if (process.env.CI_BROWSER) {
   spawnPs = spawn(process.env.CI_BROWSER, [...process.env.CI_BROWSER_FLAGS ? process.env.CI_BROWSER_FLAGS.split(' ') : [], `http://localhost:${port}/test/${testName}.html`]);
 }
 else {
-  open(`http://localhost:${port}/test/${testName}.html`);
+  open(`http://localhost:${port}/test/${testName}.html`, { app: { name: 'chrome' } });
 }


### PR DESCRIPTION
Fixes https://github.com/guybedford/es-module-shims/issues/157 ensuring that inline scripts properly opt-out of execution in the fallback case now when they don't hit the global fallback due to the new JSON / CSS module analysis pass.