### PR TITLE
feat: load event refiring and careful static ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,27 @@ import 'shared';
 </script>
 ```
 
+#### No Ready State Change
+
+Because of the extra processing done by ES Module Shims it is possible for module scripts to execute after the DOM ready event, which can cause missed attachment of `document.addEventListener('readystatechange')` when not also checking `document.readyState` statically.
+
+In order to ensure libraries that rely on this event still behave correctly, ES Module Shims will double trigger the ready state change event when
+there are script executions that would normally have executed before the document ready state transition to completion.
+
+The event is carefully only triggered when there definitely were modules that would have missed it but there is still the risk that this can result in double attachments for some rare examples mixing modules and scripts where the scripts might get two events firing.
+
+In such a case, this double readystatechange event firing can be disabled with the `noReadyStateChange` option:
+
+```js
+<script>
+  window.esmsInitOptions = {
+    // do not re-trigger the onreadystatechange DOM event
+    noReadyStateChange: true
+  }
+</script>
+<script async src="es-module-shims.js"></script>
+```
+
 #### Skip Processing
 
 When loading modules that you know will only use baseline modules features, it is possible to set a rule to explicitly

--- a/README.md
+++ b/README.md
@@ -377,22 +377,22 @@ import 'shared';
 </script>
 ```
 
-#### No Ready State Change
+#### No Load Event Retriggers
 
-Because of the extra processing done by ES Module Shims it is possible for module scripts to execute after the DOM ready event, which can cause missed attachment of `document.addEventListener('readystatechange')` when not also checking `document.readyState` statically.
+Because of the extra processing done by ES Module Shims it is possible for static module scripts to execute after the `DOMContentLoaded` or `readystatechange` events they expect, which can cause missed attachment.
 
-In order to ensure libraries that rely on this event still behave correctly, ES Module Shims will double trigger the ready state change event when
+In order to ensure libraries that rely on these event still behave correctly, ES Module Shims will double trigger these events when
 there are script executions that would normally have executed before the document ready state transition to completion.
 
-The event is carefully only triggered when there definitely were modules that would have missed it but there is still the risk that this can result in double attachments for some rare examples mixing modules and scripts where the scripts might get two events firing.
+These events are carefully only triggered when there definitely were modules that would have missed attachment but there is still the risk that this can result in double attachments when mixing modules and scripts where the scripts might get two events firing.
 
-In such a case, this double readystatechange event firing can be disabled with the `noReadyStateChange` option:
+In such a case, this double event firing can be disabled with the `noLoadEventRetriggers` option:
 
 ```js
 <script>
   window.esmsInitOptions = {
-    // do not re-trigger the onreadystatechange DOM event
-    noReadyStateChange: true
+    // do not re-trigger the onreadystatechange and DOMContentLoaded DOM events
+    noLoadEventRetriggers: true
   }
 </script>
 <script async src="es-module-shims.js"></script>

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -39,7 +39,7 @@ let importMapPromise = resolvedPromise;
 
 let waitingForImportMapsInterval;
 let firstTopLevelProcess = true;
-async function topLevelLoad (url, fetchOpts, source, nativelyLoaded) {
+async function topLevelLoad (url, fetchOpts, source, nativelyLoaded, lastStaticLoadPromise) {
   // no need to even fetch if we have feature support
   await featureDetectionPromise;
   if (waitingForImportMapsInterval > 0) {
@@ -53,7 +53,7 @@ async function topLevelLoad (url, fetchOpts, source, nativelyLoaded) {
   await importMapPromise;
   // early analysis opt-out
   if (nativelyLoaded && supportsDynamicImport && supportsImportMeta && supportsImportMaps && supportsJsonAssertions && supportsCssAssertions && !importMapSrcOrLazy) {
-    // dont reexec inline for polyfills -> just return null
+    // dont reexec inline for polyfills -> just return null (since no module id for executed inline module scripts)
     return source && nativelyLoaded ? null : dynamicImport(source ? createBlob(source) : url);
   }
   await init;
@@ -62,17 +62,24 @@ async function topLevelLoad (url, fetchOpts, source, nativelyLoaded) {
   await loadAll(load, seen);
   lastLoad = undefined;
   resolveDeps(load, seen);
+  await lastStaticLoadPromise;
   if (source && !shimMode && !load.n) {
+    if (lastStaticLoadPromise)
+      didExecForReadyPromise = true;
     const module = dynamicImport(createBlob(source));
     if (shouldRevokeBlobURLs) revokeObjectURLs(Object.keys(seen));
     return module;
   }
   const module = await dynamicImport(load.b);
+  if (lastStaticLoadPromise && (!nativelyLoaded || load.b !== load.u))
+    didExecForReadyPromise = true;
   // if the top-level load is a shell, run its update function
   if (load.s) {
     (await dynamicImport(load.s)).u$_(module);
   }
   if (shouldRevokeBlobURLs) revokeObjectURLs(Object.keys(seen));
+  // when tla is supported, this should return the tla promise as an actual handle
+  // so readystate can still correspond to the sync subgraph exec completions
   return module;
 }
 
@@ -122,6 +129,7 @@ const fetchHook = esmsInitOptions.fetch || ((url, opts) => fetch(url, opts));
 const skip = esmsInitOptions.skip || /^https?:\/\/(cdn\.skypack\.dev|jspm\.dev)\//;
 const onerror = esmsInitOptions.onerror || ((e) => { throw e; });
 const shouldRevokeBlobURLs = esmsInitOptions.revokeBlobURLs;
+const noReadyStateChange = esmsInitOptions.noReadyStateChange;
 
 function urlJsString (url) {
   return `'${url.replace(/'/g, "\\'")}'`;
@@ -318,7 +326,7 @@ function getOrCreateLoad (url, fetchOpts, source) {
   return load;
 }
 
-async function processScripts () {
+function processScripts () {
   if (waitingForImportMapsInterval > 0 && document.readyState !== 'loading') {
     clearTimeout(waitingForImportMapsInterval);
     waitingForImportMapsInterval = 0;
@@ -326,7 +334,7 @@ async function processScripts () {
   for (const link of document.querySelectorAll('link[rel="modulepreload"]'))
     processPreload(link);
   for (const script of document.querySelectorAll('script[type="module-shim"],script[type="importmap-shim"],script[type="module"],script[type="importmap"]'))
-    await processScript(script);
+    processScript(script);
 }
 
 function getFetchOpts (script) {
@@ -344,12 +352,22 @@ function getFetchOpts (script) {
   return fetchOpts;
 }
 
-async function processScript (script, dynamic) {
+let readyCnt = 0;
+let didExecForReadyPromise = false;
+let lastStaticLoadPromise = Promise.resolve();
+function readyCheck () {
+  readyCnt--;
+  if (readyCnt === 0 && didExecForReadyPromise && !noReadyStateChange && document.readyState === 'complete')
+    document.dispatchEvent(new Event('readystatechange'));
+}
+
+function processScript (script, dynamic) {
   if (script.ep) // ep marker = script processed
     return;
   const shim = script.type.endsWith('-shim');
   if (shim) shimMode = true;
-  const type = shim ? script.type.slice(0, -5) : script.type;
+  const type = shimMode ? script.type.slice(0, -5) : script.type;
+  // dont process module scripts in shim mode or noshim module scripts in polyfill mode
   if (!shim && shimMode || script.getAttribute('noshim') !== null)
     return;
   // empty inline scripts sometimes show before domready
@@ -357,7 +375,14 @@ async function processScript (script, dynamic) {
     return;
   script.ep = true;
   if (type === 'module') {
-    await topLevelLoad(script.src || `${pageBaseUrl}?${id++}`, getFetchOpts(script), !script.src && script.innerHTML, !shim).catch(onerror);
+    const isReadyScript = document.readyState !== 'complete';
+    if (isReadyScript) readyCnt++;
+    const p = topLevelLoad(script.src || `${pageBaseUrl}?${id++}`, getFetchOpts(script), !script.src && script.innerHTML, !shimMode, isReadyScript && lastStaticLoadPromise);
+    p.catch(onerror);
+    if (isReadyScript) {
+      lastStaticLoadPromise = p.catch(readyCheck);
+      p.then(readyCheck);
+    }
   }
   else if (type === 'importmap') {
     importMapPromise = importMapPromise.then(async () => {

--- a/test/browser-modules.js
+++ b/test/browser-modules.js
@@ -3,6 +3,16 @@ const edge = !!navigator.userAgent.match(/Edge\/\d\d\.\d+$/);
 self.baseURL = location.href.substr(0, location.href.lastIndexOf('/') + 1);
 
 suite('Basic loading tests', () => {
+  test('Static load order and ready state', async function () {
+    await new Promise(resolve => {
+      if (window.readyStateOrder)
+        resolve();
+      document.addEventListener('readystatechange', resolve);
+    });
+    assert.ok(window.readyStateOrder);
+    assert.equal(window.readyStateOrder.join(','), '1,2,3,4,5');
+  });
+
   test('Load counter', function () {
     assert.equal(count, 2);
   });

--- a/test/browser-modules.js
+++ b/test/browser-modules.js
@@ -3,7 +3,14 @@ const edge = !!navigator.userAgent.match(/Edge\/\d\d\.\d+$/);
 self.baseURL = location.href.substr(0, location.href.lastIndexOf('/') + 1);
 
 suite('Basic loading tests', () => {
-  test('Static load order and ready state', async function () {
+  test('Static load order and domcontentloaded and ready state', async function () {
+    await new Promise(resolve => {
+      if (window.domContentLoadedOrder)
+        resolve();
+      document.addEventListener('DOMContentLoaded', resolve);
+    });
+    assert.ok(window.domContentLoadedOrder);
+    assert.equal(window.domContentLoadedOrder.join(','), '1,2,3,4,5');
     await new Promise(resolve => {
       if (window.readyStateOrder)
         resolve();

--- a/test/test.html
+++ b/test/test.html
@@ -51,6 +51,9 @@
   document.addEventListener('readystatechange', () => {
     window.readyStateOrder = order;
   });
+  document.addEventListener('DOMContentLoaded', () => {
+    window.domContentLoadedOrder = order;
+  });
 </script>
 <script>
   window.resolveHook = (id, parentUrl, defaultResolve) => defaultResolve(id, parentUrl);

--- a/test/test.html
+++ b/test/test.html
@@ -25,22 +25,32 @@
 }
 </script>
 <script>
+  window.order = [];
   let count = 1
 </script>
 <script type="module">
   count++;
+  order.push(1);
 </script>
-<script type="module">
+<script type="module-shim">
   import test from "test";
-  console.log(test);
+  order.push(2);
 </script>
 <script type="module-shim">
   import("bare-dynamic-import").then(m => {
     window.inlineScriptDynamicImportResult = m;
-  })
+  });
+  order.push(3);
 </script>
 <script type="module-shim">
+  order.push(4);
   syntax-error();
+</script>
+<script type="module-shim">
+  order.push(5);
+  document.addEventListener('readystatechange', () => {
+    window.readyStateOrder = order;
+  });
 </script>
 <script>
   window.resolveHook = (id, parentUrl, defaultResolve) => defaultResolve(id, parentUrl);


### PR DESCRIPTION
This implements re-triggering of the `readystatechange` and `DOMContentLoaded` events given that the polyfill can miss these attachments for userland libraries where changing those libraries to check the static readystate is not an option.

In the process static script ordering semantics are carefully implemented as well to fix ensuring that static module scripts always execute one after another in order while still fetching and processing in parallel.

An opt-out for the behaviour is provided by the init option `noLoadEventRetriggers`, as documented.

Resolves https://github.com/guybedford/es-module-shims/issues/161, https://github.com/guybedford/es-module-shims/issues/99.