### PR TITLE
fix: ensure preloads are always deduped

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -411,6 +411,8 @@ function processPreload (link) {
   if (link.ep) // ep marker = processed
     return;
   link.ep = true;
+  if (fetchCache[link.href])
+    return;
   fetchCache[link.href] = doFetch(link.href, getFetchOpts(link));
 }
 


### PR DESCRIPTION
This should resolve https://github.com/guybedford/es-module-shims/issues/163.

I don't have a full replication of the case, so this will need further verification.