### PR TITLE
fix: improve browser compatibility

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -66,8 +66,8 @@ export const featureDetectionPromise = Promise.all([
     };
     const iframe = document.createElement('iframe');
     iframe.style.display = 'none';
-    iframe.srcdoc = `<script type=importmap>{"imports":{"x":"data:text/javascript,"}}<${''}/script><script>import('x').then(()=>1,()=>0).then(v=>parent._$s(v))<${''}/script>`, 'text/html';
     document.body.appendChild(iframe);
+    iframe.contentWindow.document.write(`<script type=importmap>{"imports":{"x":"data:text/javascript,"}}<${''}/script><script>import('x').then(()=>1,()=>0).then(v=>parent._$s(v))<${''}/script>`);
   })
 ]);
 


### PR DESCRIPTION
some browser such as Weixin built-in browser don't support setting srcdoc property of iframe element.
so es-module-shims doesn't work well in this browser because the `featureDetectionPromise` never be resolved.
and there are many user of the Weixin Official Accounts which use this browser.
and i think document.write has better compatibility.