### PR TITLE
feat: skip-shim polyfill hints

### DIFF
--- a/test/test-chrome-noshim.html
+++ b/test/test-chrome-noshim.html
@@ -20,6 +20,14 @@ if (window.shared !== 1)
 if (window.polyfill)
   throw new Error('Did not expect polyfill execution');
 
+window.counter = 1;
+</script>
+
+<script type="module" skip-shim="import-maps">
+window.counter += 1;
+if (window.counter !== 2)
+  throw new Error('Expected previous exec');
+
 fetch('/done');
 </script>
 <script type="module" src="/src/es-module-shims.js" async></script>


### PR DESCRIPTION
This implements polyfill hints as outlined in https://github.com/guybedford/es-module-shims/issues/150.

I ended up using the name `skip-shim="import-maps"` on the module script as I think this more closely matches what it actually does in that it ignores all other pollyfill processing of the given script tag when import maps are supported.

For now `import-maps` is the only value, but `css-modules` and `json-modules` will clearly be ones to add and any other new modules features in future are candidates as well.