### PR TITLE
Try fix mocha issues

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -87,7 +87,6 @@ async function topLevelLoad (url, fetchOpts, source, nativelyLoaded, lastStaticL
   if (shouldRevokeBlobURLs) revokeObjectURLs(Object.keys(seen));
   // when tla is supported, this should return the tla promise as an actual handle
   // so readystate can still correspond to the sync subgraph exec completions
-  console.log(url, 'DONE');
   return module;
 }
 

--- a/test/browser-modules.js
+++ b/test/browser-modules.js
@@ -2,12 +2,13 @@ const edge = !!navigator.userAgent.match(/Edge\/\d\d\.\d+$/);
 
 self.baseURL = location.href.substr(0, location.href.lastIndexOf('/') + 1);
 
-beforeEach(() => {
-  // mocha issues
-  window.onerror = () => {};
-});
-
 suite('Basic loading tests', () => {
+
+  beforeEach(() => {
+    // mocha issues
+    window.onerror = () => {};
+  });
+
   test('Static load order and domcontentloaded and ready state', async function () {
     await new Promise(resolve => {
       if (window.domContentLoadedOrder)

--- a/test/browser-modules.js
+++ b/test/browser-modules.js
@@ -2,9 +2,13 @@ const edge = !!navigator.userAgent.match(/Edge\/\d\d\.\d+$/);
 
 self.baseURL = location.href.substr(0, location.href.lastIndexOf('/') + 1);
 
+beforeEach(() => {
+  // mocha issues
+  window.onerror = () => {};
+});
+
 suite('Basic loading tests', () => {
   test('Static load order and domcontentloaded and ready state', async function () {
-    window.onerror = () => {};
     await new Promise(resolve => {
       if (window.domContentLoadedOrder)
         resolve();
@@ -22,7 +26,6 @@ suite('Basic loading tests', () => {
   });
 
   test('Load counter', function () {
-    window.onerror = () => {};
     assert.equal(count, 2);
   });
   test('Should import a module', async function () {

--- a/test/browser-modules.js
+++ b/test/browser-modules.js
@@ -3,13 +3,8 @@ const edge = !!navigator.userAgent.match(/Edge\/\d\d\.\d+$/);
 self.baseURL = location.href.substr(0, location.href.lastIndexOf('/') + 1);
 
 suite('Basic loading tests', () => {
-
-  beforeEach(() => {
-    // mocha issues
-    window.onerror = () => {};
-  });
-
   test('Static load order and domcontentloaded and ready state', async function () {
+    window.onerror = () => {};
     await new Promise(resolve => {
       if (window.domContentLoadedOrder)
         resolve();

--- a/test/runMochaTests.js
+++ b/test/runMochaTests.js
@@ -1,7 +1,7 @@
 export function runMochaTests(suites) {
   mocha.setup({
     ui: 'tdd',
-    // cleanReferencesAfterRun: false
+    cleanReferencesAfterRun: false
   });
   mocha.allowUncaught();
   self.assert = function (val) {

--- a/test/runMochaTests.js
+++ b/test/runMochaTests.js
@@ -1,7 +1,7 @@
 export function runMochaTests(suites) {
   mocha.setup({
     ui: 'tdd',
-    cleanReferencesAfterRun: false
+    // cleanReferencesAfterRun: false
   });
   mocha.allowUncaught();
   self.assert = function (val) {

--- a/test/test.html
+++ b/test/test.html
@@ -75,7 +75,7 @@
 <script type="module" src="../src/es-module-shims.js"></script>
 <script type="module" noshim>
   import { runMochaTests } from "./runMochaTests.js";
-  runMochaTests(['browser-modules', 'fetch-hook', 'resolve-hook'])
+  runMochaTests(['browser-modules', 'fetch-hook', 'resolve-hook']);
 </script>
 
 <div id="mocha"></div>


### PR DESCRIPTION
Attempts to fix flakey mocha tests in Firefox 60.

Mocha is far more trouble than it is worth when we should just be importing tests via dynamic import and failing if they throw. All this work to support a buggy library with unclear conventions and timings just to get nice green ticks is getting ridiculous.