### PR TITLE
fix: fixup dynamic import polyfill recursion

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -31,6 +31,7 @@ catch (e) {
         `import*as m from'${blobUrl}';self._esmsi=m;`
       );
       const s = document.createElement('script');
+      s.setAttribute('noshim', '');
       s.type = 'module';
       s.src = topLevelBlobUrl;
       document.head.appendChild(s);

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -238,8 +238,8 @@ function resolveDeps (load, seen) {
 }
 
 const jsContentType = /^(text|application)\/(x-)?javascript(;|$)/;
-const jsonContentType = /^application\/json(;|$)/;
-const cssContentType = /^text\/css(;|$)/;
+const jsonContentType = /^(text|application)\/json(;|$)/;
+const cssContentType = /^(text|application)\/css(;|$)/;
 const wasmContentType = /^application\/wasm(;|$)/;
 
 const cssUrlRegEx = /url\(\s*(?:(["'])((?:\\.|[^\n\\"'])+)\1|((?:\\.|[^\s,"'()\\])+))\s*\)/g;


### PR DESCRIPTION
This resolves https://github.com/guybedford/es-module-shims/issues/169 where the polyfill of dynamic import would then try to polyfill its own injections resulting in an infinite loop crashing the browser.