### PR TITLE
Add the exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.12.8",
   "description": "Shims for the latest ES module features",
   "main": "dist/es-module-shims.js",
+  "exports": "./dist/es-module-shims.js",
   "scripts": {
     "build": "rollup -c",
     "footprint": "npm run build && cat dist/es-module-shims.min.js | gzip -9f | wc -c",


### PR DESCRIPTION
This adds an `"exports"` field to the package.json referencing the "main". This ensures the package is fully encapsulated.