### PR TITLE
fix: ensure global script errors reach console

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -400,11 +400,11 @@ function processScript (script, dynamic) {
       script.dispatchEvent(new Event('load'));
     }).catch(e => {
       script.dispatchEvent(new Event('load'));
-      // note onerror can throw itself
+      setTimeout(() => { throw e; });
       onerror(e);
     });
     if (isReadyScript)
-      lastStaticLoadPromise = loadPromise.then(staticLoadCheck, staticLoadCheck);
+      lastStaticLoadPromise = loadPromise.then(staticLoadCheck);
   }
   else if (type === 'importmap') {
     // we dont currently support multiple, external or dynamic imports maps in polyfill mode to match native


### PR DESCRIPTION
Fixes https://github.com/guybedford/es-module-shims/issues/181.

With the new error handling changes global errors were propagating to `onerror` and the script load event but not to the console unhandled rejection.

Improved on 0.12 and made this an uncaught error instead of an unhandled promise rejection as well to more closely match normal script errors.