### PR TITLE
fixup: preserve pool ordering

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -268,7 +268,7 @@ function pushFetchPool () {
 function popFetchPool () {
   c--;
   if (p.length)
-    p.pop()();
+    p.shift()();
 }
 
 async function doFetch (url, fetchOpts) {


### PR DESCRIPTION
This fixes up the fetch pool to preserve original ordering via first in first out instead of first in last out!