### PR TITLE
feat: miscellaneous polishing / perf

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,25 +190,6 @@ is supported in Chromium, provided it is injected before any module loads and th
 
 Both modes in ES Module Shims support dynamic injection using DOM Mutation Observers.
 
-One issue with this Mutation Observer approach is that a dynamic import immediately after the injection may not yet have received the mutation observer update since mutation observers are batched in the browser.
-
-To ensure an import is applied after the import map has been updated, a non-standard custom `onload` event is supported for import maps by ES Module Shims:
-
-```js
-async function injectImportMap (map) {
-  return new Promise(resolve => document.body.appendChild(Object.assign(document.createElement('script'), {
-    type: 'importmap',
-    innerHTML: JSON.stringify(map),
-    onload: resolve
-  })));
-}
-
-await injectImportMap({ imports: { newmap: './module.js' }});
-await importShim('newmap'); // will get the new map attached
-```
-
-This event is fired in both polyfill and shim modes so can be fully relied upon regardless of whether it's just fully delegating to the native loader anyway behind the scenes or not.
-
 While in polyfill mode the same restrictions apply that multiple import maps, import maps with a `src` attribute, and import maps loaded after the first module load are not supported, in shim mode all of these behaviours are fully enabled for `"importmap-shim"`.
 
 ### Dynamic Import

--- a/src/dynamic-import-csp.js
+++ b/src/dynamic-import-csp.js
@@ -25,6 +25,10 @@ export function dynamicImport (specifier) {
         self._esmsi = null;
       }
       else {
+        // If error is undefined, that usually means it was a previously natively loaded module
+        // with a cached error.
+        // TODO: in this case we should do a dynamic import and return the rejection, so long
+        // as we can reliably determine that is the case in all browsers.
         reject(err);
       }
     }
@@ -33,4 +37,4 @@ export function dynamicImport (specifier) {
   return p;
 }
 
-export const supportsDynamicImportCheck = dynamicImport(createBlob('if(0)import("")'));
+export const supportsDynamicImportCheck = dynamicImport(createBlob('()=>import("")'));

--- a/src/dynamic-import-csp.js
+++ b/src/dynamic-import-csp.js
@@ -1,17 +1,10 @@
 import { nonce } from './options.js';
-import { createBlob, baseUrl } from './common.js';
+import { createBlob, baseUrl, noop } from './common.js';
 
-let err;
-self.addEventListener('error', e => err = e.error);
-
-export function dynamicImport (specifier) {
-  const s = Object.assign(document.createElement('script'), {
-    type: 'module',
-    src: createBlob(
-      `import*as m from'${specifier}';self._esmsi=m`
-    ),
-    nonce
-  });
+export function dynamicImport (url, { errUrl = url } = {}) {
+  const src = createBlob(`import*as m from'${url}';self._esmsi=m`);
+  const s = Object.assign(document.createElement('script'), { type: 'module', src });
+  s.setAttribute('nonce', nonce);
   s.setAttribute('noshim', '');
   const p =  new Promise((resolve, reject) => {
     // Safari is unique in supporting module script error events
@@ -22,14 +15,10 @@ export function dynamicImport (specifier) {
       document.head.removeChild(s);
       if (self._esmsi) {
         resolve(self._esmsi, baseUrl);
-        self._esmsi = null;
+        self._esmsi = undefined;
       }
       else {
-        // If error is undefined, that usually means it was a previously natively loaded module
-        // with a cached error.
-        // TODO: in this case we should do a dynamic import and return the rejection, so long
-        // as we can reliably determine that is the case in all browsers.
-        reject(err);
+        reject(new Error(`Error loading or executing the graph of ${errUrl} (check the console for ${src}).`));
       }
     }
   });
@@ -37,4 +26,4 @@ export function dynamicImport (specifier) {
   return p;
 }
 
-export const supportsDynamicImportCheck = dynamicImport(createBlob('()=>import("")'));
+export const supportsDynamicImportCheck = dynamicImport(createBlob('0&&import("")')).catch(noop);

--- a/src/dynamic-import.js
+++ b/src/dynamic-import.js
@@ -10,13 +10,11 @@ try {
 catch (e) {}
 
 if (!supportsDynamicImportCheck) {
-  let err;
-  self.addEventListener('error', e => err = e.error);
-  dynamicImport = specifier => {
+  dynamicImport = (url, { errUrl = url }) => {
     const s = Object.assign(document.createElement('script'), {
       type: 'module',
       src: createBlob(
-        `import*as m from'${specifier}';self._esmsi=m;`
+        `import*as m from'${url}';self._esmsi=m;`
       )
     });
     s.setAttribute('noshim', '');
@@ -29,7 +27,7 @@ if (!supportsDynamicImportCheck) {
           self._esmsi = null;
         }
         else {
-          reject(err);
+          reject(new Error(`Error loading or executing the graph of ${errUrl} (check the console for ${src}).`));
         }
       });
     });

--- a/src/dynamic-import.js
+++ b/src/dynamic-import.js
@@ -11,12 +11,8 @@ catch (e) {}
 
 if (!supportsDynamicImportCheck) {
   dynamicImport = (url, { errUrl = url }) => {
-    const s = Object.assign(document.createElement('script'), {
-      type: 'module',
-      src: createBlob(
-        `import*as m from'${url}';self._esmsi=m;`
-      )
-    });
+    const src = createBlob(`import*as m from'${url}';self._esmsi=m;`);
+    const s = Object.assign(document.createElement('script'), { type: 'module', src });
     s.setAttribute('noshim', '');
     document.head.appendChild(s);
     return new Promise((resolve, reject) => {

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -85,7 +85,7 @@ async function topLevelLoad (url, fetchOpts, source, nativelyLoaded, lastStaticL
     if (nativelyLoaded)
       return null;
     await lastStaticLoadPromise;
-    return dynamicImport(source ? createBlob(source) : url);
+    return dynamicImport(source ? createBlob(source) : url, { errUrl: url || source });
   }
   await lexer.init;
   const load = getOrCreateLoad(url, fetchOpts, source);
@@ -95,11 +95,11 @@ async function topLevelLoad (url, fetchOpts, source, nativelyLoaded, lastStaticL
   resolveDeps(load, seen);
   await lastStaticLoadPromise;
   if (source && !shimMode && !load.n) {
-    const module = await dynamicImport(createBlob(source));
+    const module = await dynamicImport(createBlob(source), { errUrl: source });
     if (revokeBlobURLs) revokeObjectURLs(Object.keys(seen));
     return module;
   }
-  const module = await dynamicImport(load.b);
+  const module = await dynamicImport(load.b, { errUrl: load.u });
   // if the top-level load is a shell, run its update function
   if (load.s)
     (await dynamicImport(load.s)).u$_(module);
@@ -440,7 +440,7 @@ function processScript (script) {
     }).catch(e => {
       if (!noLoadEventRetriggers)
         triggerLoadEvent(script);
-      setTimeout(() => { throw e; });
+      // setTimeout(() => { throw e; });
       onerror(e);
     });
     if (isReadyScript)

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -128,6 +128,7 @@ function revokeObjectURLs(registryKeys) {
 }
 
 async function importShim (id, parentUrl = pageBaseUrl, _assertion) {
+  processScripts();
   await importMapPromise;
   return topLevelLoad((await resolve(id, parentUrl)).r || throwUnresolved(id, parentUrl), { credentials: 'same-origin' });
 }
@@ -446,7 +447,7 @@ function processScript (script) {
     if (isReadyScript)
       lastStaticLoadPromise = loadPromise.then(readyStateCompleteCheck);
     if (isDomContentLoadedScript)
-      lastStaticLoadPromise = loadPromise.then(domContentLoadedCheck);
+      loadPromise.then(domContentLoadedCheck);
   }
   else if (acceptingImportMaps && type === 'importmap') {
     // we dont currently support multiple, external or dynamic imports maps in polyfill mode to match native
@@ -465,7 +466,6 @@ function processScript (script) {
     importMapPromise = importMapPromise.then(async () => {
       importMap = resolveAndComposeImportMap(script.src ? await (await fetchHook(script.src)).json() : JSON.parse(script.innerHTML), script.src || pageBaseUrl, importMap);
     });
-    triggerLoadEvent(script);
   }
 }
 

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -64,28 +64,29 @@ async function loadAll (load, seen) {
 }
 
 let importMap = { imports: {}, scopes: {} };
-let hasImportMap = false;
 let importMapSrcOrLazy = false;
-let importMapPromise = resolvedPromise;
+let importMapPromise = featureDetectionPromise;
 
-let waitingForImportMapsInterval;
-let firstTopLevelProcess = true;
+let acceptingImportMaps = true;
+let nativeAcceptingImportMaps = true;
 async function topLevelLoad (url, fetchOpts, source, nativelyLoaded, lastStaticLoadPromise) {
-  // no need to even fetch if we have feature support
-  await featureDetectionPromise;
-  if (waitingForImportMapsInterval > 0) {
-    clearTimeout(waitingForImportMapsInterval);
-    waitingForImportMapsInterval = 0;
-  }
-  if (firstTopLevelProcess) {
-    firstTopLevelProcess = false;
-    processScripts();
+  if (acceptingImportMaps) {
+    if (!shimMode) {
+      acceptingImportMaps = false;
+      mutationObserver.disconnect();
+    }
+    else {
+      nativeAcceptingImportMaps = false;
+    }
   }
   await importMapPromise;
-  // early analysis opt-out
-  if (nativelyLoaded && supportsDynamicImport && supportsImportMeta && supportsImportMaps && (!jsonModulesEnabled || supportsJsonAssertions) && (!cssModulesEnabled || supportsCssAssertions) && !importMapSrcOrLazy) {
-    // dont reexec inline for polyfills -> just return null (since no module id for executed inline module scripts)
-    return source && nativelyLoaded ? null : dynamicImport(source ? createBlob(source) : url);
+  // early analysis opt-out - no need to even fetch if we have feature support
+  if (!shimMode && supportsDynamicImport && supportsImportMeta && supportsImportMaps && (!jsonModulesEnabled || supportsJsonAssertions) && (!cssModulesEnabled || supportsCssAssertions) && !importMapSrcOrLazy) {
+    // for polyfill case, only dynamic import needs a return value here, and dynamic import will never pass nativelyLoaded
+    if (nativelyLoaded)
+      return null;
+    await lastStaticLoadPromise;
+    return dynamicImport(source ? createBlob(source) : url);
   }
   await lexer.init;
   const load = getOrCreateLoad(url, fetchOpts, source);
@@ -95,21 +96,11 @@ async function topLevelLoad (url, fetchOpts, source, nativelyLoaded, lastStaticL
   resolveDeps(load, seen);
   await lastStaticLoadPromise;
   if (source && !shimMode && !load.n) {
-    if (lastStaticLoadPromise) {
-      didExecForReadyPromise = true;
-      if (domContentLoaded)
-        didExecForDomContentLoaded = true;
-    }
     const module = await dynamicImport(createBlob(source));
     if (revokeBlobURLs) revokeObjectURLs(Object.keys(seen));
     return module;
   }
   const module = await dynamicImport(load.b);
-  if (lastStaticLoadPromise && (!nativelyLoaded || load.b !== load.u)) {
-    didExecForReadyPromise = true;
-    if (domContentLoaded)
-      didExecForDomContentLoaded = true;
-  }
   // if the top-level load is a shell, run its update function
   if (load.s)
     (await dynamicImport(load.s)).u$_(module);
@@ -137,8 +128,6 @@ function revokeObjectURLs(registryKeys) {
 }
 
 async function importShim (id, parentUrl = pageBaseUrl, _assertion) {
-  await featureDetectionPromise;
-  // Make sure all the "in-flight" import maps are loaded and applied.
   await importMapPromise;
   return topLevelLoad((await resolve(id, parentUrl)).r || throwUnresolved(id, parentUrl), { credentials: 'same-origin' });
 }
@@ -372,14 +361,13 @@ function getOrCreateLoad (url, fetchOpts, source) {
   return load;
 }
 
+const scriptQuery = 'script[type="module-shim"],script[type="importmap-shim"],script[type="module"],script[type="importmap"]';
+const preloadQuery = 'link[rel="modulepreload"]';
+
 function processScripts () {
-  if (waitingForImportMapsInterval > 0 && document.readyState !== 'loading') {
-    clearTimeout(waitingForImportMapsInterval);
-    waitingForImportMapsInterval = 0;
-  }
-  for (const link of document.querySelectorAll('link[rel="modulepreload"]'))
+  for (const link of document.querySelectorAll(preloadQuery))
     processPreload(link);
-  const scripts = document.querySelectorAll('script[type="module-shim"],script[type="importmap-shim"],script[type="module"],script[type="importmap"]');
+  const scripts = document.querySelectorAll(scriptQuery);
   // early shim mode opt-in
   if (!shimMode) {
     for (const script of scripts) {
@@ -406,23 +394,27 @@ function getFetchOpts (script) {
   return fetchOpts;
 }
 
-let staticLoadCnt = 0;
-let didExecForReadyPromise = false;
-let didExecForDomContentLoaded = false;
 let lastStaticLoadPromise = Promise.resolve();
-let domContentLoaded = false;
-document.addEventListener('DOMContentLoaded', () => domContentLoaded = true);
-function staticLoadCheck () {
-  staticLoadCnt--;
-  if (staticLoadCnt === 0 && !noLoadEventRetriggers) {
-    if (didExecForDomContentLoaded)
-      document.dispatchEvent(new Event('DOMContentLoaded'));
-    if (didExecForReadyPromise && document.readyState === 'complete')
-      document.dispatchEvent(new Event('readystatechange'));
-  }
+
+let domContentLoadedCnt = 1;
+function domContentLoadedCheck () {
+  if (--domContentLoadedCnt === 0 && !noLoadEventRetriggers)
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+}
+// this should always trigger because we assume es-module-shims is itself a domcontentloaded requirement
+document.addEventListener('DOMContentLoaded', domContentLoadedCheck);
+
+let readyStateCompleteCnt = 1;
+if (document.readyState === 'complete')
+  readyStateCompleteCheck();
+else
+  document.addEventListener('readystatechange', readyStateCompleteCheck);
+function readyStateCompleteCheck () {
+  if (--readyStateCompleteCnt === 0 && !noLoadEventRetriggers)
+    document.dispatchEvent(new Event('readystatechange'));
 }
 
-function processScript (script, dynamic) {
+function processScript (script) {
   if (script.ep) // ep marker = script processed
     return;
   const shim = script.type.endsWith('-shim');
@@ -436,29 +428,49 @@ function processScript (script, dynamic) {
     return;
   script.ep = true;
   if (type === 'module') {
-    const isReadyScript = document.readyState !== 'complete';
-    if (isReadyScript) staticLoadCnt++;
+    // does this load block readystate complete
+    const isReadyScript = readyStateCompleteCnt > 0;
+    // does this load block DOMContentLoaded
+    const isDomContentLoadedScript = domContentLoadedCnt > 0;
+    if (isReadyScript) readyStateCompleteCnt++;
+    if (isDomContentLoadedScript) domContentLoadedCnt++;
     const loadPromise = topLevelLoad(script.src || `${pageBaseUrl}?${id++}`, getFetchOpts(script), !script.src && script.innerHTML, !shimMode, isReadyScript && lastStaticLoadPromise).then(() => {
-      script.dispatchEvent(new Event('load'));
+      if (!noLoadEventRetriggers)
+        triggerLoadEvent(script);
     }).catch(e => {
-      script.dispatchEvent(new Event('load'));
+      if (!noLoadEventRetriggers)
+        triggerLoadEvent(script);
       setTimeout(() => { throw e; });
       onerror(e);
     });
     if (isReadyScript)
-      lastStaticLoadPromise = loadPromise.then(staticLoadCheck);
+      lastStaticLoadPromise = loadPromise.then(readyStateCompleteCheck);
+    if (isDomContentLoadedScript)
+      lastStaticLoadPromise = loadPromise.then(domContentLoadedCheck);
   }
-  else if (type === 'importmap') {
+  else if (acceptingImportMaps && type === 'importmap') {
     // we dont currently support multiple, external or dynamic imports maps in polyfill mode to match native
-    if (!shimMode && (hasImportMap || script.src || dynamic))
-      return;
-    hasImportMap = true;
+    if (script.src || !nativeAcceptingImportMaps) {
+      if (!shimMode)
+        return;
+      importMapSrcOrLazy = true;
+    }
+    if (!shimMode) {
+      acceptingImportMaps = false;
+      mutationObserver.disconnect();
+    }
+    else {
+      nativeAcceptingImportMaps = false;
+    }
     importMapPromise = importMapPromise.then(async () => {
-      if (script.src || dynamic)
-        importMapSrcOrLazy = true;
       importMap = resolveAndComposeImportMap(script.src ? await (await fetchHook(script.src)).json() : JSON.parse(script.innerHTML), script.src || pageBaseUrl, importMap);
     });
+    triggerLoadEvent(script);
   }
+}
+
+function triggerLoadEvent (script) {
+  script.dispatchEvent(new Event('load'));
 }
 
 const fetchCache = {};
@@ -471,12 +483,12 @@ function processPreload (link) {
   fetchCache[link.href] = doFetch(link.href, getFetchOpts(link));
 }
 
-new MutationObserver(mutations => {
+const mutationObserver = new MutationObserver(mutations => {
   for (const mutation of mutations) {
     if (mutation.type !== 'childList') continue;
     for (const node of mutation.addedNodes) {
       if (node.tagName === 'SCRIPT' && node.type)
-        processScript(node, !firstTopLevelProcess);
+        processScript(node);
       else if (node.tagName === 'LINK' && node.rel === 'modulepreload')
         processPreload(node);
     }
@@ -488,4 +500,3 @@ function throwUnresolved (id, parentUrl) {
 }
 
 processScripts();
-waitingForImportMapsInterval = setInterval(processScripts, 20);

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -73,7 +73,6 @@ async function topLevelLoad (url, fetchOpts, source, nativelyLoaded, lastStaticL
   if (acceptingImportMaps) {
     if (!shimMode) {
       acceptingImportMaps = false;
-      mutationObserver.disconnect();
     }
     else {
       nativeAcceptingImportMaps = false;
@@ -458,7 +457,6 @@ function processScript (script) {
     }
     if (!shimMode) {
       acceptingImportMaps = false;
-      mutationObserver.disconnect();
     }
     else {
       nativeAcceptingImportMaps = false;
@@ -483,7 +481,7 @@ function processPreload (link) {
   fetchCache[link.href] = doFetch(link.href, getFetchOpts(link));
 }
 
-const mutationObserver = new MutationObserver(mutations => {
+new MutationObserver(mutations => {
   for (const mutation of mutations) {
     if (mutation.type !== 'childList') continue;
     for (const node of mutation.addedNodes) {

--- a/src/features.js
+++ b/src/features.js
@@ -1,6 +1,6 @@
 import { dynamicImport, supportsDynamicImportCheck } from './dynamic-import.js';
 import { noop, createBlob } from './common.js';
-import { nonce } from './options.js';
+import { nonce, cssModulesEnabled, jsonModulesEnabled } from './options.js';
 
 // support browsers without dynamic import support (eg Firefox 6x)
 export let supportsJsonAssertions = false;
@@ -11,20 +11,27 @@ export let supportsImportMaps = false;
 
 export let supportsDynamicImport = false;
 
-export const featureDetectionPromise = Promise.resolve(supportsDynamicImportCheck).then(ok => !ok ? 0 : (supportsDynamicImport = true, Promise.all([
-  dynamicImport(createBlob('import"data:text/css,{}"assert{type:"css"}'), { errUrl: 'f1' }).then(() => supportsCssAssertions = true, noop),
-  dynamicImport(createBlob('import"data:text/json,{}"assert{type:"json"}'), { errUrl: 'f2', }).then(() => supportsJsonAssertions = true, noop),
-  dynamicImport(createBlob('import.meta'), { errUrl: 'f3' }).then(() => supportsImportMeta = true, noop),
-  new Promise(resolve => {
-    self._$s = v => {
-      document.body.removeChild(iframe);
-      delete self._$s;
-      resolve(v);
-    };
-    const iframe = document.createElement('iframe');
-    iframe.style.display = 'none';
-    document.body.appendChild(iframe);
-    // we use document.write here because eg Weixin built-in browser doesn't support setting srcdoc
-    iframe.contentWindow.document.write(`<script type=importmap nonce="${nonce}">{"imports":{"x":"data:text/javascript,"}}<${''}/script><script nonce="${nonce}">import('x').then(()=>1,()=>0).then(v=>parent._$s(v))<${''}/script>`);
-  }).then(() => supportsImportMaps = true, noop)
-])), noop);
+export const featureDetectionPromise = Promise.resolve(supportsDynamicImportCheck).then(_supportsDynamicImport => {
+  if (!_supportsDynamicImport)
+    return;
+  supportsDynamicImport = true;
+
+  return Promise.all([
+    dynamicImport(createBlob('import.meta')).then(() => supportsImportMeta = true, noop).
+    cssModulesEnabled && dynamicImport(createBlob('import"data:text/css,{}"assert{type:"css"}')).then(() => supportsCssAssertions = true, noop),
+    jsonModulesEnabled && dynamicImport(createBlob('import"data:text/json,{}"assert{type:"json"}')).then(() => supportsJsonAssertions = true, noop),
+    new Promise(resolve => {
+      self._$s = v => {
+        document.body.removeChild(iframe);
+        if (v) supportsImportMaps = true;
+        delete self._$s;
+        resolve();
+      };
+      const iframe = document.createElement('iframe');
+      iframe.style.display = 'none';
+      document.body.appendChild(iframe);
+      // we use document.write here because eg Weixin built-in browser doesn't support setting srcdoc
+      iframe.contentWindow.document.write(`<script type=importmap nonce="${nonce}">{"imports":{"x":"data:text/javascript,"}}<${''}/script><script nonce="${nonce}">import('x').then(()=>1,()=>0).then(v=>parent._$s(v))<${''}/script>`);
+    })
+  ]);
+});

--- a/src/features.js
+++ b/src/features.js
@@ -8,23 +8,23 @@ export let supportsCssAssertions = false;
 
 export let supportsImportMeta = false;
 export let supportsImportMaps = false;
+
 export let supportsDynamicImport = false;
 
-export const featureDetectionPromise = Promise.all([
-  dynamicImport(createBlob('import"data:text/css,{}"assert{type:"css"}')).then(() => supportsCssAssertions = true, noop),
-  dynamicImport(createBlob('import"data:text/json,{}"assert{type:"json"}')).then(() => supportsJsonAssertions = true, noop),
-  dynamicImport(createBlob('import.meta')).then(() => supportsImportMeta = true, noop),
-  Promise.resolve(supportsDynamicImportCheck).then(() => supportsDynamicImport = true, new Promise(resolve => {
+export const featureDetectionPromise = Promise.resolve(supportsDynamicImportCheck).then(ok => !ok ? 0 : (supportsDynamicImport = true, Promise.all([
+  dynamicImport(createBlob('import"data:text/css,{}"assert{type:"css"}'), { errUrl: 'f1' }).then(() => supportsCssAssertions = true, noop),
+  dynamicImport(createBlob('import"data:text/json,{}"assert{type:"json"}'), { errUrl: 'f2', }).then(() => supportsJsonAssertions = true, noop),
+  dynamicImport(createBlob('import.meta'), { errUrl: 'f3' }).then(() => supportsImportMeta = true, noop),
+  new Promise(resolve => {
     self._$s = v => {
       document.body.removeChild(iframe);
-      if (v) supportsImportMaps = true;
       delete self._$s;
-      resolve();
+      resolve(v);
     };
     const iframe = document.createElement('iframe');
     iframe.style.display = 'none';
     document.body.appendChild(iframe);
     // we use document.write here because eg Weixin built-in browser doesn't support setting srcdoc
     iframe.contentWindow.document.write(`<script type=importmap nonce="${nonce}">{"imports":{"x":"data:text/javascript,"}}<${''}/script><script nonce="${nonce}">import('x').then(()=>1,()=>0).then(v=>parent._$s(v))<${''}/script>`);
-  })).catch(noop)
-]);
+  }).then(() => supportsImportMaps = true, noop)
+])), noop);

--- a/src/options.js
+++ b/src/options.js
@@ -14,7 +14,7 @@ export let nonce = esmsInitOptions.nonce;
 if (!nonce) {
   const nonceElement = document.querySelector('script[nonce]');
   if (nonceElement)
-    nonce = nonceElement.nonce;
+    nonce = nonceElement.getAttribute('nonce');
 }
 
 export const {

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -1,9 +1,13 @@
+const nonceScript = document.querySelector('script[nonce]');
+const nonce = nonceScript && nonceScript.nonce;
+
 async function loadModuleScript (src) {
   window.onerror = () => {};
   await new Promise(resolve => {
     let first = true;
     document.head.appendChild(Object.assign(document.createElement('script'), {
       type: 'module',
+      nonce: nonce,
       src,
       onerror () {
         if (first) first = false;
@@ -21,6 +25,22 @@ suite('Polyfill tests', () => {
   test('should support dynamic import with an import map', async function () {
     await loadModuleScript('./fixtures/es-modules/importer1.js');
     assert.equal(window.global1, true);
+  });
+
+  test('should support dyanmic import failure', async function () {
+    try {
+      await import('./fixtures/es-modules/does-not-exist.js');
+    }
+    catch (e) {
+      try {
+        await importShim('./fixtures/es-modules/does-not-exist.js');
+      }
+      catch (e) {
+        return;
+      }
+      throw new Error('Should fail twice');
+    }
+    throw new Error('Should fail');
   });
 
   test('should support css imports', async function () {

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -1,13 +1,12 @@
 const nonceScript = document.querySelector('script[nonce]');
-const nonce = nonceScript && nonceScript.nonce;
+const nonce = nonceScript && nonceScript.getAttribute('nonce');
 
 async function loadModuleScript (src) {
   window.onerror = () => {};
   await new Promise(resolve => {
     let first = true;
-    document.head.appendChild(Object.assign(document.createElement('script'), {
+    const s = Object.assign(document.createElement('script'), {
       type: 'module',
-      nonce: nonce,
       src,
       onerror () {
         if (first) first = false;
@@ -17,7 +16,9 @@ async function loadModuleScript (src) {
         if (first) first = false;
         else resolve();
       }
-    }));
+    });
+    s.setAttribute('nonce', nonce);
+    document.head.appendChild(s);
   });
 }
 

--- a/test/revoke-blob-urls.js
+++ b/test/revoke-blob-urls.js
@@ -3,6 +3,11 @@ test('should revoke blob URLs if `esmsInitOptions.revokeBlobURLs` is set to `tru
 
     const moduleURL = new URL('./fixtures/es-modules/es6-withdep.js', location.href).href;
     const moduleDepURL = new URL('./fixtures/es-modules/es6-dep.js', location.href).href;
+
+    // must be on an old browser to test!
+    if (!window._esmsr[moduleDepURL])
+        return;
+
     const moduleBlobURL = window._esmsr[moduleURL].b;
     const moduleDepBlobURL = window._esmsr[moduleDepURL].b;
     assert(moduleBlobURL.startsWith("blob:http"));

--- a/test/runMochaTests.js
+++ b/test/runMochaTests.js
@@ -17,7 +17,6 @@ export function runMochaTests(suite) {
   importShim('./' + suite + '.js')
   .then(async () => {
     const failures = await new Promise(resolve => mocha.run(resolve));
-    console.log('DOOOOOOO');
     fetch(failures ? '/error?' + failures : '/done');
   }, err => {
     console.error('Unable to import test ' + suite);

--- a/test/shim.js
+++ b/test/shim.js
@@ -301,8 +301,9 @@ suite('Errors', function () {
   });
 
   this.timeout(10000);
-  test('Dynamic import map shim', async () => {
-    insertDynamicImportMap({
+
+  test('Dynamic import map shim', async function () {
+    await insertDynamicImportMap({
         "imports": {
             "react-dom": "https://ga.jspm.io/npm:react-dom@17.0.2/dev.index.js"
         },
@@ -317,27 +318,27 @@ suite('Errors', function () {
         importShim('react'),
         importShim('react-dom'),
     ]);
-
     assert.ok(React);
     assert.ok(ReactDOM);
+  });
 
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    insertDynamicImportMap({
-        "imports": {
-            "lodash": "https://ga.jspm.io/npm:lodash-es@4.17.21/lodash.js",
-        }
+  test('Dynamic import map shim 2', async function () {
+    await insertDynamicImportMap({
+      "imports": {
+          "lodash": "https://ga.jspm.io/npm:lodash-es@4.17.21/lodash.js",
+      }
     });
-
     const lodash = await importShim("lodash");
     assert.ok(lodash);
+  })
 
-    function insertDynamicImportMap(importMap) {
-      document.body.appendChild(Object.assign(document.createElement('script'), {
-          type: 'importmap-shim',
-          innerHTML: JSON.stringify(importMap)
-      }));
-    }
-  });
+  function insertDynamicImportMap(importMap) {
+    return new Promise(resolve => document.body.appendChild(Object.assign(document.createElement('script'), {
+        type: 'importmap-shim',
+        innerHTML: JSON.stringify(importMap),
+        onload: resolve
+    })));
+  }
 });
 
 suite('Source maps', () => {

--- a/test/shim.js
+++ b/test/shim.js
@@ -314,7 +314,6 @@ suite('Errors', function () {
         }
       }
     });
-    console.log('LOADING REACT BARE');
     const [React, ReactDOM] = await Promise.all([
       importShim('react'),
       importShim('react-dom'),

--- a/test/shim.js
+++ b/test/shim.js
@@ -303,27 +303,28 @@ suite('Errors', function () {
   this.timeout(10000);
 
   test('Dynamic import map shim', async function () {
-    await insertDynamicImportMap({
-        "imports": {
-            "react-dom": "https://ga.jspm.io/npm:react-dom@17.0.2/dev.index.js"
-        },
-        "scopes": {
-            "https://ga.jspm.io/": {
-                "scheduler": "https://ga.jspm.io/npm:scheduler@0.20.2/dev.index.js",
-                "scheduler/tracing": "https://ga.jspm.io/npm:scheduler@0.20.2/dev.tracing.js"
-            }
+    insertDynamicImportMap({
+      "imports": {
+        "react-dom": "https://ga.jspm.io/npm:react-dom@17.0.2/dev.index.js"
+      },
+      "scopes": {
+        "https://ga.jspm.io/": {
+          "scheduler": "https://ga.jspm.io/npm:scheduler@0.20.2/dev.index.js",
+          "scheduler/tracing": "https://ga.jspm.io/npm:scheduler@0.20.2/dev.tracing.js"
         }
+      }
     });
+    console.log('LOADING REACT BARE');
     const [React, ReactDOM] = await Promise.all([
-        importShim('react'),
-        importShim('react-dom'),
+      importShim('react'),
+      importShim('react-dom'),
     ]);
     assert.ok(React);
     assert.ok(ReactDOM);
   });
 
   test('Dynamic import map shim 2', async function () {
-    await insertDynamicImportMap({
+    insertDynamicImportMap({
       "imports": {
           "lodash": "https://ga.jspm.io/npm:lodash-es@4.17.21/lodash.js",
       }
@@ -333,11 +334,10 @@ suite('Errors', function () {
   })
 
   function insertDynamicImportMap(importMap) {
-    return new Promise(resolve => document.body.appendChild(Object.assign(document.createElement('script'), {
-        type: 'importmap-shim',
-        innerHTML: JSON.stringify(importMap),
-        onload: resolve
-    })));
+    document.body.appendChild(Object.assign(document.createElement('script'), {
+      type: 'importmap-shim',
+      innerHTML: JSON.stringify(importMap),
+    }));
   }
 });
 

--- a/test/test-csp.html
+++ b/test/test-csp.html
@@ -9,7 +9,8 @@
     "test": "/test/fixtures/es-modules/es6-file.js",
     "test/": "/test/fixtures/",
     "global1": "/test/fixtures/es-modules/global1.js",
-    "/test/fixtures/es-modules/dynamic.js": "/test/fixtures/es-modules/dynamic-url-map.js"
+    "/test/fixtures/es-modules/dynamic.js": "/test/fixtures/es-modules/dynamic-url-map.js",
+    "data": "data:text/javascript,"
   }
 }
 </script>
@@ -24,6 +25,9 @@
 {
   "polyfillEnable": ["json-modules", "css-modules"]
 }
+</script>
+<script nonce="asdf">
+  window.import2 = import('data');
 </script>
 
 <script type="module" src="../dist/es-module-shims.csp.js"></script>

--- a/test/test-csp.html
+++ b/test/test-csp.html
@@ -30,7 +30,7 @@
   window.import2 = import('data');
 </script>
 
-<script type="module" src="../dist/es-module-shims.csp.js"></script>
+<script type="module" src="../dist/es-module-shims.csp.js" nonce="asdf"></script>
 
 <script type="module" noshim nonce="asdf">
   import { runMochaTests } from "./runMochaTests.js";


### PR DESCRIPTION
Most of these are minor perf improvements while simplifying the logic.

Changes include:
* Dynamic import map injections now support an `onload` event
* The "waitingForImportMaps" interval check is now no longer based on a regular timer, which should significantly reduce DOM polling performance issues.
* Dynamic imports always scan for new import maps first to ensure import maps promise attachment.
* Better polyfill mode opt-out for `importShim` / dynamic import. Dynamic import via `importShim` in both polyfill and shim mode now fully uses the native fallback whenever possible instead of still running through the shim functionality.
* DOM load events are now _always_ retriggered, this simplifies the assumption that domready will just call twice. One of the driving reasons for this is that when delegating to the native loader more often, we don't always know if actual execution is happening anymore so it's harder to make the check that these events only retrigger for real execution when most execution is delegated anyway.
* DOMContentLoaded and readystatechange event retriggers now happen independently with independent counters - this matches browser behaviours in that these events have independent lifecycles.
* Nonce attribute handling fixes.
* Error message improvements for opaque CSP errors / dynamic import replacement errors.