### PR TITLE
fix: revert nested mutation observers

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -479,14 +479,6 @@ new MutationObserver(mutations => {
         processScript(node, !firstTopLevelProcess);
       else if (node.tagName === 'LINK' && node.rel === 'modulepreload')
         processPreload(node);
-      else if (node.querySelectorAll) {
-        for (const script of node.querySelectorAll('script[type="module-shim"],script[type="importmap-shim"],script[type="module"],script[type="importmap"]')) {
-          processScript(script, !firstTopLevelProcess);
-        }
-        for (const link of node.querySelectorAll('link[rel=modulepreload]')) {
-          processPreload(link);
-        }
-      }
     }
   }
 }).observe(document, { childList: true, subtree: true });


### PR DESCRIPTION
This reverts https://github.com/guybedford/es-module-shims/pull/144. After investigating turbolinks more thoroughly, it turns out script injections are separately applied to the head in https://github.com/hotwired/turbo/blob/c4891515645880ae1f9b4ee5757a8d730b89ac4e/src/core/drive/page_renderer.ts#L60 and in the body in https://github.com/hotwired/turbo/blob/c4891515645880ae1f9b4ee5757a8d730b89ac4e/src/core/frames/frame_renderer.ts#L48.

This is consistent with the fact that in HTML, setting the `body` `innerHTML` does not cause script execution.

#144 causes a huge amount of performance cost due to querying all mutations so this is a significant performance improvement.