### PR TITLE
feat: asm.js csp build for performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@rollup/plugin-replace": "^2.4.2",
     "cross-env": "^7.0.3",
-    "es-module-lexer": "^0.8.0",
+    "es-module-lexer": "^0.9.0",
     "esm": "^3.2.25",
     "kleur": "^4.1.4",
     "mocha": "^9.1.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,7 +25,7 @@ function config (isWasm) {
             {
                 resolveId (id) {
                     if (!isWasm && id === '../node_modules/es-module-lexer/dist/lexer.js')
-                        return path.resolve('node_modules/es-module-lexer/lexer.js');
+                        return path.resolve('node_modules/es-module-lexer/dist/lexer.asm.js');
                     if (!isWasm && id === './dynamic-import.js')
                         return path.resolve('src/dynamic-import-csp.js');
                 }

--- a/src/dynamic-import-csp.js
+++ b/src/dynamic-import-csp.js
@@ -1,7 +1,10 @@
 import { nonce } from './options.js';
 import { createBlob, baseUrl, noop } from './common.js';
 
+let err;
+window.addEventListener('error', _err => err = _err);
 export function dynamicImport (url, { errUrl = url } = {}) {
+  err = undefined;
   const src = createBlob(`import*as m from'${url}';self._esmsi=m`);
   const s = Object.assign(document.createElement('script'), { type: 'module', src });
   s.setAttribute('nonce', nonce);
@@ -18,7 +21,8 @@ export function dynamicImport (url, { errUrl = url } = {}) {
         self._esmsi = undefined;
       }
       else {
-        reject(new Error(`Error loading or executing the graph of ${errUrl} (check the console for ${src}).`));
+        reject(err.error || new Error(`Error loading or executing the graph of ${errUrl} (check the console for ${src}).`));
+        err = undefined;
       }
     }
   });

--- a/src/dynamic-import.js
+++ b/src/dynamic-import.js
@@ -10,7 +10,10 @@ try {
 catch (e) {}
 
 if (!supportsDynamicImportCheck) {
+  let err;
+  window.addEventListener('error', _err => err = _err);
   dynamicImport = (url, { errUrl = url }) => {
+    err = undefined;
     const src = createBlob(`import*as m from'${url}';self._esmsi=m;`);
     const s = Object.assign(document.createElement('script'), { type: 'module', src });
     s.setAttribute('noshim', '');
@@ -23,7 +26,8 @@ if (!supportsDynamicImportCheck) {
           self._esmsi = null;
         }
         else {
-          reject(new Error(`Error loading or executing the graph of ${errUrl} (check the console for ${src}).`));
+          reject(err.error || new Error(`Error loading or executing the graph of ${errUrl} (check the console for ${src}).`));
+          err = undefined;
         }
       });
     });


### PR DESCRIPTION
This significantly improves the performance of the CSP build by using asm.js instead of plain JS for the execution from the latest es-module-lexer release.