### PR TITLE
fix: csp perf via direct dynamic import

### DIFF
--- a/src/dynamic-import-csp.js
+++ b/src/dynamic-import-csp.js
@@ -3,7 +3,7 @@ import { createBlob, baseUrl, noop } from './common.js';
 
 let err;
 window.addEventListener('error', _err => err = _err);
-export function dynamicImport (url, { errUrl = url } = {}) {
+function dynamicImportScript (url, { errUrl = url } = {}) {
   err = undefined;
   const src = createBlob(`import*as m from'${url}';self._esmsi=m`);
   const s = Object.assign(document.createElement('script'), { type: 'module', src });
@@ -30,4 +30,10 @@ export function dynamicImport (url, { errUrl = url } = {}) {
   return p;
 }
 
-export const supportsDynamicImportCheck = dynamicImport(createBlob('0&&import("")')).catch(noop);
+export let dynamicImport = dynamicImportScript;
+
+export const supportsDynamicImportCheck = dynamicImportScript(createBlob('export default u=>import(u)')).then(_dynamicImport => {
+  if (_dynamicImport)
+    dynamicImport = _dynamicImport.default;
+  return !!_dynamicImport;
+}, noop);

--- a/src/features.js
+++ b/src/features.js
@@ -17,7 +17,7 @@ export const featureDetectionPromise = Promise.resolve(supportsDynamicImportChec
   supportsDynamicImport = true;
 
   return Promise.all([
-    dynamicImport(createBlob('import.meta')).then(() => supportsImportMeta = true, noop).
+    dynamicImport(createBlob('import.meta')).then(() => supportsImportMeta = true, noop),
     cssModulesEnabled && dynamicImport(createBlob('import"data:text/css,{}"assert{type:"css"}')).then(() => supportsCssAssertions = true, noop),
     jsonModulesEnabled && dynamicImport(createBlob('import"data:text/json,{}"assert{type:"json"}')).then(() => supportsJsonAssertions = true, noop),
     new Promise(resolve => {


### PR DESCRIPTION
This fixes up the CSP build performance regressions by ensuring we use a dynamic import from the target module nonce context, instead of always using `<script>` injection. This brings performance roughly in line to the Wasm version.