### PR TITLE
feat: force shim paths under ESMS_DEBUG

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -1,5 +1,3 @@
-export const resolvedPromise = Promise.resolve();
-
 export const edge = navigator.userAgent.match(/Edge\/\d\d\.\d+$/);
 
 export let baseUrl;


### PR DESCRIPTION
When running a development build with `ESMS_DEBUG` enabled, it is useful to also force the shim paths. This enables an easy workflow for testing the polyfill performance under this option where it doesn't defer to the native loader but always does the source analysis and blob rewriting.