### PR TITLE
feat: make the CSP asm.js build the main entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,17 +5,18 @@
   "main": "dist/es-module-shims.js",
   "exports": {
     ".": "./dist/es-module-shims.js",
-    "./csp": "./dist/es-module-shims.csp.js"
+    "./wasm": "./dist/es-module-shims.wasm.js"
   },
   "scripts": {
     "build": "rollup -c",
     "footprint": "npm run build && cat dist/es-module-shims.js | brotli | wc -c",
     "footprint:csp": "npm run build && cat dist/es-module-shims.csp.js | brotli | wc -c",
     "prepublishOnly": "npm run build",
-    "test": "npm run test:test-base-href && npm run test:test-csp && npm run test:test-polyfill && npm run test:test-preload-case && npm run test:test-revoke-blob-urls && npm run test:test-shim",
+    "test": "npm run test:test-base-href && npm run test:test-csp && npm run test:test-polyfill && npm run test:test-polyfill-wasm && npm run test:test-preload-case && npm run test:test-revoke-blob-urls && npm run test:test-shim",
     "test:test-base-href": "cross-env TEST_NAME=test-base-href node test/server.mjs",
     "test:test-csp": "cross-env TEST_NAME=test-csp node test/server.mjs",
     "test:test-polyfill": "cross-env TEST_NAME=test-polyfill node test/server.mjs",
+    "test:test-polyfill-wasm": "cross-env TEST_NAME=test-polyfill-wasm node test/server.mjs",
     "test:test-preload-case": "cross-env TEST_NAME=test-preload-case node test/server.mjs",
     "test:test-revoke-blob-urls": "cross-env TEST_NAME=test-revoke-blob-urls node test/server.mjs",
     "test:test-shim": "cross-env TEST_NAME=test-shim node test/server.mjs"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,35 +5,35 @@ import path from 'path';
 const version = JSON.parse(fs.readFileSync('package.json')).version;
 
 export default [
-    config(true),
-    config(false),
-].filter(Boolean);
+  config(true),
+  config(false),
+];
 
 function config (isWasm) {
-    const name = 'es-module-shims'
+  const name = 'es-module-shims'
 
-    return {
-        input: `src/${name}.js`,
-        output: {
-            file: `dist/${name}${isWasm ? '' : '.csp'}.js`,
-            format: 'iife',
-            strict: false,
-            sourcemap: false,
-            banner: `/* ES Module Shims ${isWasm ? '' : 'CSP '}${version} */`
-        },
-        plugins: [
-            {
-                resolveId (id) {
-                    if (!isWasm && id === '../node_modules/es-module-lexer/dist/lexer.js')
-                        return path.resolve('node_modules/es-module-lexer/dist/lexer.asm.js');
-                    if (!isWasm && id === './dynamic-import.js')
-                        return path.resolve('src/dynamic-import-csp.js');
-                }
-            },
-            replace({
-                'self.ESMS_DEBUG': 'false',
-                preventAssignment: true
-            }),
-        ]
-    };
+  return {
+    input: `src/${name}.js`,
+    output: {
+      file: `dist/${name}${isWasm ? '.wasm' : ''}.js`,
+      format: 'iife',
+      strict: false,
+      sourcemap: false,
+      banner: `/* ES Module Shims ${isWasm ? 'Wasm ' : ''}${version} */`
+    },
+    plugins: [
+      {
+        resolveId (id) {
+          if (isWasm && id === '../node_modules/es-module-lexer/dist/lexer.asm.js')
+            return path.resolve('node_modules/es-module-lexer/dist/lexer.js');
+          if (isWasm && id === './dynamic-import-csp.js')
+            return path.resolve('src/dynamic-import.js');
+        }
+      },
+      replace({
+        'self.ESMS_DEBUG': 'false',
+        preventAssignment: true
+      }),
+    ]
+  };
 }

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -20,7 +20,7 @@ import {
   cssModulesEnabled,
   jsonModulesEnabled,
 } from './options.js';
-import { dynamicImport } from './dynamic-import.js';
+import { dynamicImport } from './dynamic-import-csp.js';
 import {
   featureDetectionPromise,
   supportsDynamicImport,
@@ -29,7 +29,7 @@ import {
   supportsCssAssertions,
   supportsJsonAssertions,
 } from './features.js';
-import * as lexer from '../node_modules/es-module-lexer/dist/lexer.js';
+import * as lexer from '../node_modules/es-module-lexer/dist/lexer.asm.js';
 
 async function defaultResolve (id, parentUrl) {
   return resolveImportMap(importMap, resolveIfNotPlainOrUrl(id, parentUrl) || id, parentUrl);

--- a/src/features.js
+++ b/src/features.js
@@ -1,4 +1,4 @@
-import { dynamicImport, supportsDynamicImportCheck } from './dynamic-import.js';
+import { dynamicImport, supportsDynamicImportCheck } from './dynamic-import-csp.js';
 import { noop, createBlob } from './common.js';
 import { nonce, cssModulesEnabled, jsonModulesEnabled } from './options.js';
 

--- a/src/import-map.js
+++ b/src/import-map.js
@@ -1,2 +1,1 @@
 export let importMap = { imports: {}, scopes: {} };
-

--- a/test/test-polyfill-wasm.html
+++ b/test/test-polyfill-wasm.html
@@ -1,38 +1,29 @@
 <!doctype html>
-<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'nonce-asdf' unpkg.com;" />
 <link rel="stylesheet" type="text/css" href="../node_modules/mocha/mocha.css"/>
 <script src="../node_modules/mocha/mocha.js"></script>
 <script src="https://unpkg.com/construct-style-sheets-polyfill@3.0.0/dist/adoptedStyleSheets.js"></script>
-<script type="importmap" nonce="asdf">
+<script type="importmap">
 {
   "imports": {
     "test": "/test/fixtures/es-modules/es6-file.js",
     "test/": "/test/fixtures/",
     "global1": "/test/fixtures/es-modules/global1.js",
-    "/test/fixtures/es-modules/dynamic.js": "/test/fixtures/es-modules/dynamic-url-map.js",
-    "data": "data:text/javascript,"
+    "/test/fixtures/es-modules/dynamic.js": "/test/fixtures/es-modules/dynamic-url-map.js"
   }
 }
 </script>
-<script type="importmap" nonce="asdf">
+<script type="importmap">
 {
   "imports": {
     "global1": "data:text/javascript,throw new Error('Polyfill should not support multiple import maps');"
   }
 }
 </script>
-<script type="esms-options">
-{
-  "polyfillEnable": ["json-modules", "css-modules"]
-}
-</script>
-<script nonce="asdf">
-  window.import2 = import('data');
-</script>
+<script>window.esmsInitOptions = { polyfillEnable: ['json-modules', 'css-modules' ] }</script>
 
-<script type="module" src="../src/es-module-shims.js" nonce="asdf"></script>
+<script type="module" src="../dist/es-module-shims.wasm.js"></script>
 
-<script type="module" noshim nonce="asdf">
+<script type="module" noshim>
   import { runMochaTests } from "./runMochaTests.js";
   runMochaTests('polyfill');
 </script>


### PR DESCRIPTION
It turns out that in Safari, the asm.js build is actually faster than the Wasm build.

So since in Chrome and Firefox the compressed footprints are now equivalent AND the performance is identical, switching to the CSP build by default just makes sense - users shouldn't have to think about this stuff.

The win is then that iPhone / Safari performance then gets a ~25% speed improvement overall!

The Wasm build is still available and tested, but separately under `es-module-shims/dist/es-module-shims.wasm.js`. This will be 0.16 to be released shortly.