### PR TITLE
feat: improve passthrough performance

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -67,11 +67,8 @@ let importMapSrcOrLazy = false;
 let baselinePassthrough;
 let importMapPromise = featureDetectionPromise.then(() => {
   baselinePassthrough = supportsDynamicImport && supportsImportMeta && supportsImportMaps && (!jsonModulesEnabled || supportsJsonAssertions) && (!cssModulesEnabled || supportsCssAssertions) && !importMapSrcOrLazy && !self.ESMS_DEBUG;
-  if (!shimMode) {
-    // final shim mode opt-in
-    if (document.querySelectorAll('script[type="module-shim"],script[type="importmap-shim"]').length)
-      setShimMode();
-  }
+  if (!shimMode && document.querySelectorAll('script[type="module-shim"],script[type="importmap-shim"]').length)
+    setShimMode();
   if (shimMode || !baselinePassthrough) {
     new MutationObserver(mutations => {
       for (const mutation of mutations) {
@@ -148,7 +145,8 @@ function revokeObjectURLs(registryKeys) {
 }
 
 async function importShim (id, parentUrl = pageBaseUrl, _assertion) {
-  processScripts();
+  if (shimMode || !baselinePassthrough)
+    processScripts();
   await importMapPromise;
   return topLevelLoad((await resolve(id, parentUrl)).r || throwUnresolved(id, parentUrl), { credentials: 'same-origin' });
 }

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -444,15 +444,7 @@ function processScript (script) {
     const isDomContentLoadedScript = domContentLoadedCnt > 0;
     if (isReadyScript) readyStateCompleteCnt++;
     if (isDomContentLoadedScript) domContentLoadedCnt++;
-    const loadPromise = topLevelLoad(script.src || `${pageBaseUrl}?${id++}`, getFetchOpts(script), !script.src && script.innerHTML, !shimMode, isReadyScript && lastStaticLoadPromise).then(() => {
-      if (!noLoadEventRetriggers)
-        triggerLoadEvent(script);
-    }).catch(e => {
-      if (!noLoadEventRetriggers)
-        triggerLoadEvent(script);
-      // setTimeout(() => { throw e; });
-      onerror(e);
-    });
+    const loadPromise = topLevelLoad(script.src || `${pageBaseUrl}?${id++}`, getFetchOpts(script), !script.src && script.innerHTML, !shimMode, isReadyScript && lastStaticLoadPromise).catch(onerror);
     if (isReadyScript)
       lastStaticLoadPromise = loadPromise.then(readyStateCompleteCheck);
     if (isDomContentLoadedScript)
@@ -475,10 +467,6 @@ function processScript (script) {
       importMap = resolveAndComposeImportMap(script.src ? await (await fetchHook(script.src)).json() : JSON.parse(script.innerHTML), script.src || pageBaseUrl, importMap);
     });
   }
-}
-
-function triggerLoadEvent (script) {
-  script.dispatchEvent(new Event('load'));
 }
 
 const fetchCache = {};

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -147,6 +147,8 @@ function revokeObjectURLs(registryKeys) {
 }
 
 async function importShim (id, parentUrl = pageBaseUrl, _assertion) {
+  // needed for shim check
+  await initPromise;
   if (shimMode || !baselinePassthrough) {
     processScripts();
     if (acceptingImportMaps)

--- a/test/base-href.js
+++ b/test/base-href.js
@@ -1,5 +1,6 @@
 suite('Base href', () => {
   test(`should should resolve relative to base href`, async () => {
+    window.onerror = () => {};
     const m = await importShim('./base-href-relative.js');
     assert.equal(m.default, 'base href relative');
   });

--- a/test/base-href.js
+++ b/test/base-href.js
@@ -5,6 +5,7 @@ suite('Base href', () => {
   });
 
   test('should resolve import map relative to base href', async () => {
+    window.onerror = () => {};
     const m = await importShim('base-href-bare');
     assert.equal(m.default, 'base href bare');
   });

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -1,30 +1,6 @@
-const nonceScript = document.querySelector('script[nonce]');
-const nonce = nonceScript && nonceScript.getAttribute('nonce');
-
-async function loadModuleScript (src) {
-  window.onerror = () => {};
-  await new Promise(resolve => {
-    let first = true;
-    const s = Object.assign(document.createElement('script'), {
-      type: 'module',
-      src,
-      onerror () {
-        if (first) first = false;
-        else resolve();
-      },
-      onload () {
-        if (first) first = false;
-        else resolve();
-      }
-    });
-    s.setAttribute('nonce', nonce);
-    document.head.appendChild(s);
-  });
-}
-
 suite('Polyfill tests', () => {
   test('should support dynamic import with an import map', async function () {
-    await loadModuleScript('./fixtures/es-modules/importer1.js');
+    await importShim('./fixtures/es-modules/importer1.js');
     assert.equal(window.global1, true);
   });
 
@@ -45,12 +21,12 @@ suite('Polyfill tests', () => {
   });
 
   test('should support css imports', async function () {
-    await loadModuleScript('./fixtures/css-assertion.js');
+    await importShim('./fixtures/css-assertion.js');
     assert.equal(window.cssAssertion, true);
   });
 
   test('URL mappings do not cause double execution', async function () {
-    await loadModuleScript('./fixtures/es-modules/dynamic-parent.js');
+    await importShim('./fixtures/es-modules/dynamic-parent.js');
     if (window.dynamic)
       console.log('POLYFILL');
     if (window.dynamicUrlMap)

--- a/test/shim.js
+++ b/test/shim.js
@@ -112,7 +112,7 @@ suite('Basic loading tests', () => {
       type: 'module-shim',
       src: './fixtures/es-modules/importer1.js'
     }));
-    await new Promise(resolve => setTimeout(resolve, 50));
+    await new Promise(resolve => setTimeout(resolve, 100));
     assert.equal(window.global1, true);
   });
 

--- a/test/shim.js
+++ b/test/shim.js
@@ -108,11 +108,10 @@ suite('Basic loading tests', () => {
   });
 
   test('should support dynamic import with an import map', async function () {
-    await new Promise(resolve => document.head.appendChild(Object.assign(document.createElement('script'), {
+    document.head.appendChild(Object.assign(document.createElement('script'), {
       type: 'module-shim',
-      src: './fixtures/es-modules/importer1.js',
-      onload: resolve
-    })));
+      src: './fixtures/es-modules/importer1.js'
+    }));
     await new Promise(resolve => setTimeout(resolve, 20));
     assert.equal(window.global1, true);
   });

--- a/test/shim.js
+++ b/test/shim.js
@@ -112,7 +112,7 @@ suite('Basic loading tests', () => {
       type: 'module-shim',
       src: './fixtures/es-modules/importer1.js'
     }));
-    await new Promise(resolve => setTimeout(resolve, 20));
+    await new Promise(resolve => setTimeout(resolve, 50));
     assert.equal(window.global1, true);
   });
 


### PR DESCRIPTION
This improves the ES Module Shims passthrough performance by entirely avoiding DOM processing when in polyfill mode and supporting all baseline features.

This includes:
* No preload fetches
* No DOM mutator attachments
* No script processing
* No import map processing