### PR TITLE
Disable skip option defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ window.esmsInitOptions = {
   polyfillEnable: ['css-modules', 'json-modules'], // default empty
   nonce: 'n0nce', // default null
   noLoadEventRetriggers: true, // default false
-  skip: /^https:\/\/cdn\.com/, // defaults to `/^https?:\/\/(cdn\.skypack\.dev|jspm\.dev)\//`
+  skip: /^https:\/\/cdn\.com/, // defaults to null
   onerror: (e) => { /*...*/ }, // default noop
   resolve: (id, parentUrl, resolve) => resolve(id, parentUrl), // default is spec resolution
   fetch: (url) => fetch(url), // default is native
@@ -470,13 +470,11 @@ This can be configured by providing a URL regular expression for the `skip` opti
 ```js
 <script type="esms-options">
 {
-  skip: "/^https:\/\/cdn\.com/" // defaults to `/^https?:\/\/(cdn\.skypack\.dev|jspm\.dev)\//`
+  skip: "/^https?:\/\/(cdn\.skypack\.dev|jspm\.dev)\//`
 }
 </script>
 <script async src="es-module-shims.js"></script>
 ```
-
-By default, this expression supports `jspm.dev`, `dev.jspm.io` and `cdn.pika.dev`.
 
 #### Error hook
 

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -370,7 +370,7 @@ function getOrCreateLoad (url, fetchOpts, source) {
       if (d !== -1) return;
       if (!r)
         throwUnresolved(n, load.r || load.u);
-      if (skip.test(r)) return { b: r };
+      if (skip && skip.test(r)) return { b: r };
       if (childFetchOpts.integrity)
         childFetchOpts = Object.assign({}, childFetchOpts, { integrity: undefined });
       return getOrCreateLoad(r, childFetchOpts).f;

--- a/src/options.js
+++ b/src/options.js
@@ -7,7 +7,7 @@ const esmsInitOptions = optionsScript ? JSON.parse(optionsScript.innerHTML) : se
 export let shimMode = !!esmsInitOptions.shimMode;
 export const resolveHook = shimMode && esmsInitOptions.resolve;
 
-export const skip = esmsInitOptions.skip ? new RegExp(esmsInitOptions.skip) : /^https:\/\/(cdn\.skypack\.dev|jspm\.dev)\//;
+export const skip = esmsInitOptions.skip ? new RegExp(esmsInitOptions.skip) : null;
 
 export let nonce = esmsInitOptions.nonce;
 

--- a/test/fixtures/es-modules/global1.js
+++ b/test/fixtures/es-modules/global1.js
@@ -1,1 +1,1 @@
-window.global1 = true;
+done();

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -1,7 +1,8 @@
 suite('Polyfill tests', () => {
   test('should support dynamic import with an import map', async function () {
+    const p = new Promise(resolve => window.done = resolve);
     await importShim('./fixtures/es-modules/importer1.js');
-    assert.equal(window.global1, true);
+    await p;
   });
 
   test('should support dyanmic import failure', async function () {

--- a/test/shim.js
+++ b/test/shim.js
@@ -112,7 +112,7 @@ suite('Basic loading tests', () => {
       type: 'module-shim',
       src: './fixtures/es-modules/importer1.js'
     }));
-    await new Promise(resolve => setTimeout(resolve, 100));
+    await new Promise(resolve => setTimeout(resolve, 250));
     assert.equal(window.global1, true);
   });
 

--- a/test/shim.js
+++ b/test/shim.js
@@ -108,12 +108,12 @@ suite('Basic loading tests', () => {
   });
 
   test('should support dynamic import with an import map', async function () {
+    const p = new Promise(resolve => window.done = resolve);
     document.head.appendChild(Object.assign(document.createElement('script'), {
       type: 'module-shim',
       src: './fixtures/es-modules/importer1.js'
     }));
-    await new Promise(resolve => setTimeout(resolve, 250));
-    assert.equal(window.global1, true);
+    await p;
   });
 
   test('Should import a module via a full url, with scheme', async function () {


### PR DESCRIPTION
This was still on the old JSPM and Pika CDNs. Removed the default, and just provided an example that covers `cdn.skypack.dev` and `jspm.dev` as illustrative.