### PR TITLE
fix: importShim must still follow import maps even for passthrough

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -149,10 +149,17 @@ function revokeObjectURLs(registryKeys) {
 async function importShim (id, parentUrl = pageBaseUrl, _assertion) {
   // needed for shim check
   await initPromise;
-  if (shimMode || !baselinePassthrough) {
+  if (acceptingImportMaps || shimMode || !baselinePassthrough) {
     processScripts();
-    if (acceptingImportMaps)
+    if (acceptingImportMaps) {
+      if (!shimMode) {
+        acceptingImportMaps = false;
+      }
+      else {
+        nativeAcceptingImportMaps = false;
+      }
       await importMapPromise;
+    }
   }
   return topLevelLoad((await resolve(id, parentUrl)).r || throwUnresolved(id, parentUrl), { credentials: 'same-origin' });
 }

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -35,4 +35,8 @@ suite('Polyfill tests', () => {
     assert.equal(window.dynamic || window.dynamicUrlMap, true);
     assert.equal(Boolean(window.dynamic && window.dynamicUrlMap), false);
   });
+
+  test('import maps passthrough polyfill mode', async function () {
+    await importShim('test');
+  });
 });


### PR DESCRIPTION
This fixes a bug in the native passthrough improvements implemented in https://github.com/guybedford/es-module-shims/pull/194.

When using `importShim()` directly, the only way to construct a contextual dynamic import (even just at the top level) is to fully reconstruct the resolver, thus we still need full knowledge of the import maps on the page.