### PR TITLE
fix: fetchHook test and name bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ window.esmsInitOptions = {
   onerror: (e) => { /*...*/ }, // default noop
   onpolyfill: () => {},
   resolve: (id, parentUrl, resolve) => resolve(id, parentUrl), // default is spec resolution
-  fetch: (url) => fetch(url), // default is native
+  fetch: (url, options) => fetch(url, options), // default is native
   revokeBlobURLs: true, // default false
 }
 </script>
@@ -546,15 +546,15 @@ For example:
 <script>
   window.esmsInitOptions = {
     shimMode: true,
-    fetch: async function (url) {
-      const response = await fetch(url);
+    fetch: async function (url, options) {
+      const response = await fetch(url, options);
       if (response.url.endsWith('.ts')) {
         const source = await response.body();
         const transformed = tsCompile(source);
         return new Response(new Blob([transformed], { type: 'application/javascript' }));
       }
       return response;
-    } // defaults to `(url => fetch(url))`
+    } // defaults to `((url, options) => fetch(url, options))`
   }
 </script>
 <script async src="es-module-shims.js"></script>

--- a/src/options.js
+++ b/src/options.js
@@ -22,7 +22,7 @@ export const onpolyfill = globalHook(esmsInitOptions.onpolyfill || noop);
 
 export const { revokeBlobURLs, noLoadEventRetriggers } = esmsInitOptions;
 
-export const fetchHook = esmsInitOptions.fetchHook ? globalHook(esmsInitOptions.fetchHook) : fetch;
+export const fetchHook = esmsInitOptions.fetch ? globalHook(esmsInitOptions.fetch) : fetch;
 
 function globalHook (name) {
   return typeof name === 'string' ? self[name] : name;

--- a/test/fixtures/json-or-js.js
+++ b/test/fixtures/json-or-js.js
@@ -1,1 +1,0 @@
-export { default } from './json.json';

--- a/test/fixtures/template.jsx
+++ b/test/fixtures/template.jsx
@@ -1,0 +1,1 @@
+Totally JSX

--- a/test/fixtures/transform.js
+++ b/test/fixtures/transform.js
@@ -1,0 +1,1 @@
+export { default } from './template.jsx';

--- a/test/fixtures/transformed.js
+++ b/test/fixtures/transformed.js
@@ -1,0 +1,1 @@
+export { transformed } from './file.jsx';

--- a/test/shim.js
+++ b/test/shim.js
@@ -391,35 +391,30 @@ suite('Source maps', () => {
 suite('Fetch hook', () => {
   test('Should hook fetch', async function () {
     const baseFetchHook = window.fetchHook;
-    window.fetchHook = async (url) => {
+    window.fetchHook = async (url, options) => {
+      if (!url.endsWith('.jsx'))
+        return fetch(url, options);
       const response = await fetch(url);
-      if (!response.ok)
-        throw new Error(`${response.status} ${response.statusText} ${response.url}`);
-      const contentType = response.headers.get('content-type');
-      if (!/^application\/json($|;)/.test(contentType))
-        return response;
       const reader = response.body.getReader();
       return new Response(new ReadableStream({
-        async start (controller) {
+        async start (resStream) {
           let done, value;
-          controller.enqueue(new Uint8Array([...'export default '].map(c => c.charCodeAt(0))));
-          while (({ done, value } = await reader.read()) && !done) {
-            controller.enqueue(value);
-          }
-          controller.close();
+          resStream.enqueue(new TextEncoder().encode('export default `'));
+          while (({ done, value } = await reader.read()) && !done)
+            resStream.enqueue(value);
+          resStream.enqueue(new TextEncoder().encode('`'));
+          resStream.close();
         }
       }), {
         status: 200,
-        headers: {
-          "Content-Type": "application/javascript"
-        }
+        headers: { 'Content-Type': 'application/javascript' }
       });
     };
 
-    var m = await importShim('./fixtures/json-or-js.js');
+    var m = await importShim('./fixtures/transform.js')
     window.fetchHook = baseFetchHook;
     assert(m.default);
-    assert.equal(m.default.json, 'module');
+    assert.equal(m.default, 'Totally JSX\n');
   });
 });
 


### PR DESCRIPTION
The fetch hook mistakenly got renamed to `fetchHook` due to actual JSON support stopping the fetch hook test from applying.

This fixes up the fetch hook test, reverts the naming, and updates the docs.