### PR TITLE
update to es-module-lexer@0.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@rollup/plugin-replace": "^2.4.2",
     "cross-env": "^7.0.3",
-    "es-module-lexer": "^0.9.1",
+    "es-module-lexer": "^0.9.3",
     "esm": "^3.2.25",
     "kleur": "^4.1.4",
     "mocha": "^9.1.1",


### PR DESCRIPTION
Updates to the latest version with string specifier support (`import { "key" as name } from 'mod'`).