### PR TITLE
Enhanced error-feedback on script-loads

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@rollup/plugin-replace": "^2.4.2",
     "cross-env": "^7.0.3",
-    "es-module-lexer": "^0.9.1",
+    "es-module-lexer": "^0.9.3",
     "esm": "^3.2.25",
     "kleur": "^4.1.4",
     "mocha": "^9.1.1",


### PR DESCRIPTION
I had problems understanding why the library all of the sudden threw 

```shims.js:765 Uncaught SyntaxError: Invalid or unexpected token```

I thought it was because of a syntax-error in the actual library, before i looked into the code and found out that it forwarded an error message from a loaded script. This was very unclear, so therefore i added a warn-log that at least tells you what script the error was from.