### PR TITLE
fix: Polyfill instancing bug

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -133,7 +133,7 @@ async function topLevelLoad (url, fetchOpts, source, nativelyLoaded, lastStaticL
     if (revokeBlobURLs) revokeObjectURLs(Object.keys(seen));
     return module;
   }
-  const module = await dynamicImport((shimMode || load.n) ? load.b : load.u, { errUrl: load.u });
+  const module = await dynamicImport(!shimMode && !load.n && nativelyLoaded ? load.u : load.b, { errUrl: load.u });
   // if the top-level load is a shell, run its update function
   if (load.s)
     (await dynamicImport(load.s)).u$_(module);

--- a/test/fixtures/instance-case-a.js
+++ b/test/fixtures/instance-case-a.js
@@ -1,0 +1,3 @@
+import { common } from "./instance-case-common.js";
+
+window.common_a = common;

--- a/test/fixtures/instance-case-b.js
+++ b/test/fixtures/instance-case-b.js
@@ -1,0 +1,3 @@
+import { common } from "./instance-case-common.js";
+
+window.common_b = common;

--- a/test/fixtures/instance-case-common.js
+++ b/test/fixtures/instance-case-common.js
@@ -1,0 +1,1 @@
+export const common = {};

--- a/test/fixtures/instance-case.js
+++ b/test/fixtures/instance-case.js
@@ -1,0 +1,8 @@
+import 'a';
+
+const bPromise = import('b');
+
+export async function check () {
+  await bPromise;
+  return window.common_a === window.common_b;
+}

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -39,4 +39,10 @@ suite('Polyfill tests', () => {
   test('import maps passthrough polyfill mode', async function () {
     await importShim('test');
   });
+
+  test('Shared instances', async function () {
+    const { check } = await importShim('./fixtures/instance-case.js');
+    const result = await check();
+    assert.equal(result, true);
+  });
 });

--- a/test/test-csp.html
+++ b/test/test-csp.html
@@ -10,7 +10,9 @@
     "test/": "/test/fixtures/",
     "global1": "/test/fixtures/es-modules/global1.js",
     "/test/fixtures/es-modules/dynamic.js": "/test/fixtures/es-modules/dynamic-url-map.js",
-    "data": "data:text/javascript,"
+    "data": "data:text/javascript,",
+    "a": "/test/fixtures/instance-case-a.js",
+    "b": "/test/fixtures/instance-case-b.js"
   }
 }
 </script>

--- a/test/test-polyfill-wasm.html
+++ b/test/test-polyfill-wasm.html
@@ -8,7 +8,9 @@
     "test": "/test/fixtures/es-modules/es6-file.js",
     "test/": "/test/fixtures/",
     "global1": "/test/fixtures/es-modules/global1.js",
-    "/test/fixtures/es-modules/dynamic.js": "/test/fixtures/es-modules/dynamic-url-map.js"
+    "/test/fixtures/es-modules/dynamic.js": "/test/fixtures/es-modules/dynamic-url-map.js",
+    "a": "/test/fixtures/instance-case-a.js",
+    "b": "/test/fixtures/instance-case-b.js"
   }
 }
 </script>

--- a/test/test-polyfill.html
+++ b/test/test-polyfill.html
@@ -8,7 +8,9 @@
     "test": "/test/fixtures/es-modules/es6-file.js",
     "test/": "/test/fixtures/",
     "global1": "/test/fixtures/es-modules/global1.js",
-    "/test/fixtures/es-modules/dynamic.js": "/test/fixtures/es-modules/dynamic-url-map.js"
+    "/test/fixtures/es-modules/dynamic.js": "/test/fixtures/es-modules/dynamic-url-map.js",
+    "a": "/test/fixtures/instance-case-a.js",
+    "b": "/test/fixtures/instance-case-b.js"
   }
 }
 </script>


### PR DESCRIPTION
Resolves https://github.com/guybedford/es-module-shims/issues/219.

This was a result of the performance enhancement in https://github.com/guybedford/es-module-shims/pull/208 which stopped doing fine-grained polyfilling on a per-module basis, and instead duplicates module loads between pure native and pure polyfill modes.

The logic wasn't quite right on one of the codepaths, which has been updated based on the new principle that a top-level `<script type="module">` tag will be assigned to **either** the native loader or the polyfill loader (and the polyfill loader will always apply when the native loader fails). This does still mean that native modules that succeed in polyfill mode will not share dependency instances with polyfilled modules, and this remains an instancing footgun, but at least it is one we can reason about.