### PR TITLE
Fixed dynamic retrieval of nonce attribute 

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -14,7 +14,7 @@ export let nonce = esmsInitOptions.nonce;
 if (!nonce) {
   const nonceElement = document.querySelector('script[nonce]');
   if (nonceElement)
-    nonce = nonceElement.nonce;
+    nonce = nonceElement.nonce || nonceElement.getAttribute('nonce');
 }
 
 export const onerror = globalHook(esmsInitOptions.onerror || noop);

--- a/src/options.js
+++ b/src/options.js
@@ -14,7 +14,7 @@ export let nonce = esmsInitOptions.nonce;
 if (!nonce) {
   const nonceElement = document.querySelector('script[nonce]');
   if (nonceElement)
-    nonce = nonceElement.getAttribute('nonce');
+    nonce = nonceElement.nonce;
 }
 
 export const onerror = globalHook(esmsInitOptions.onerror || noop);


### PR DESCRIPTION
I got this error:
<img width="1262" alt="Screenshot 2021-11-16 at 11 22 24" src="https://user-images.githubusercontent.com/48158184/141967709-56564b42-1d27-4697-b905-65d7d57dd4ff.png">

Which was thrown here:
<img width="883" alt="Screenshot 2021-11-16 at 11 23 52" src="https://user-images.githubusercontent.com/48158184/141967917-337f37f4-f83a-43f7-8681-71936316aa66.png">

So i tried to check how the nonce value was retrieved:
https://github.com/guybedford/es-module-shims/blob/b99eddfe33445cff16896f4353d66e3c7a001a0f/src/options.js#L17

Which violates the rules for accessing nonce: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce#accessing_nonces_and_nonce_hiding

Changing the line from 
```ts
nonce = nonceElement.getAttribute('nonce');
```
to
```ts
nonce = nonceElement.nonce
```

seems to fix the issue.