### PR TITLE
doc: correct minor syntax error in CSS/JSON modules usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If using CSS modules or JSON modules, since these features are relatively new, t
 
 ```html
 <script>
-window.esmsInitOptions = { enable: ['css-modules', 'json-modules'] }
+window.esmsInitOptions = { polyfillEnable: ['css-modules', 'json-modules'] }
 </script>
 ```
 


### PR DESCRIPTION
I discovered a small typo while following the instructions for configuring JSON module support (the error message correctly indicated which property was expected)