### PR TITLE
Use createObjectURL & iframe.src

### DIFF
--- a/src/features.js
+++ b/src/features.js
@@ -30,7 +30,7 @@ export const featureDetectionPromise = Promise.resolve(supportsDynamicImportChec
       const iframe = document.createElement('iframe');
       iframe.style.display = 'none';
       document.head.appendChild(iframe);
-      iframe.src = URL.createObjectURL(new Blob([`<script type=importmap nonce="${nonce}">{"imports":{"x":"data:text/javascript,"}}<${''}/script><script nonce="${nonce}">import('x').then(()=>1,()=>0).then(v=>parent._$s(v))<${''}/script>`], {type : 'text/html'}))
+      iframe.src = createBlob(`<script type=importmap nonce="${nonce}">{"imports":{"x":"data:text/javascript,"}}<${''}/script><script nonce="${nonce}">import('x').then(()=>1,()=>0).then(v=>parent._$s(v))<${''}/script>`, 'text/html')
     })
   ]);
 });

--- a/src/features.js
+++ b/src/features.js
@@ -30,7 +30,7 @@ export const featureDetectionPromise = Promise.resolve(supportsDynamicImportChec
       const iframe = document.createElement('iframe');
       iframe.style.display = 'none';
       document.head.appendChild(iframe);
-      iframe.src = self.createObjectURL(new Blob([`<script type=importmap nonce="${nonce}">{"imports":{"x":"data:text/javascript,"}}<${''}/script><script nonce="${nonce}">import('x').then(()=>1,()=>0).then(v=>parent._$s(v))<${''}/script>`], {type : 'text/html'}))
+      iframe.src = self.URL.createObjectURL(new Blob([`<script type=importmap nonce="${nonce}">{"imports":{"x":"data:text/javascript,"}}<${''}/script><script nonce="${nonce}">import('x').then(()=>1,()=>0).then(v=>parent._$s(v))<${''}/script>`], {type : 'text/html'}))
     })
   ]);
 });

--- a/src/features.js
+++ b/src/features.js
@@ -30,8 +30,7 @@ export const featureDetectionPromise = Promise.resolve(supportsDynamicImportChec
       const iframe = document.createElement('iframe');
       iframe.style.display = 'none';
       document.head.appendChild(iframe);
-      // we use document.write here because eg Weixin built-in browser doesn't support setting srcdoc
-      iframe.contentWindow.document.write(`<script type=importmap nonce="${nonce}">{"imports":{"x":"data:text/javascript,"}}<${''}/script><script nonce="${nonce}">import('x').then(()=>1,()=>0).then(v=>parent._$s(v))<${''}/script>`);
+      iframe.src = self.createObjectURL(new Blob([`<script type=importmap nonce="${nonce}">{"imports":{"x":"data:text/javascript,"}}<${''}/script><script nonce="${nonce}">import('x').then(()=>1,()=>0).then(v=>parent._$s(v))<${''}/script>`], {type : 'text/html'}))
     })
   ]);
 });

--- a/src/features.js
+++ b/src/features.js
@@ -30,7 +30,7 @@ export const featureDetectionPromise = Promise.resolve(supportsDynamicImportChec
       const iframe = document.createElement('iframe');
       iframe.style.display = 'none';
       document.head.appendChild(iframe);
-      iframe.src = self.URL.createObjectURL(new Blob([`<script type=importmap nonce="${nonce}">{"imports":{"x":"data:text/javascript,"}}<${''}/script><script nonce="${nonce}">import('x').then(()=>1,()=>0).then(v=>parent._$s(v))<${''}/script>`], {type : 'text/html'}))
+      iframe.src = URL.createObjectURL(new Blob([`<script type=importmap nonce="${nonce}">{"imports":{"x":"data:text/javascript,"}}<${''}/script><script nonce="${nonce}">import('x').then(()=>1,()=>0).then(v=>parent._$s(v))<${''}/script>`], {type : 'text/html'}))
     })
   ]);
 });


### PR DESCRIPTION
An alternative approach to addressing Weixing Browser compatibility, first attempt here: https://github.com/guybedford/es-module-shims/pull/165

This version uses iframe.src and createObjectURL, which in theory should work anywhere es-module-shims itself does (since it's already used heavily internally), instead of document.write, which results in a lighthouse score hit and scary warning:

![image](https://user-images.githubusercontent.com/6934200/143963255-f8bd83d6-813a-491e-8a34-58e12a380e57.png)

I don't have easy access to Weixing Browser to test this, so we'll probably need to roll a new release and ask for help from @xxgjzftd to try it out.