### PR TITLE
fix: trailing comment regex from #229

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -269,7 +269,7 @@ function resolveDeps (load, seen) {
   load.S = undefined;
 }
 
-const sourceMapURLRegEx = /\n\/\/# source(Mapping)?URL=([^\n]+)\s*((;|\/\/[^#][^\n]+)\s*)*$/;
+const sourceMapURLRegEx = /\n\/\/# source(Mapping)?URL=([^\n]+)\s*((;|\/\/[^#][^\n]*)\s*)*$/;
 
 const jsContentType = /^(text|application)\/(x-)?javascript(;|$)/;
 const jsonContentType = /^(text|application)\/json(;|$)/;


### PR DESCRIPTION
This fixes the trailing comment regex landed in #229 for Ruby 7 source maps support in Safari, ensuring that comments with only one character are fully supported.