### PR TITLE
enforceIntegrity option, modulepreload-shim support

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,18 @@ Adding the `"noshim"` attribute to the script tag will also ensure that ES Modul
 
 Provide a `esmsInitOptions` on the global scope before `es-module-shims` is loaded to configure various aspects of the module loading process:
 
+* [shimMode](#shim-mode-option)
+* [polyfillEnable](#polyfill-enable-option)
+* [enforceIntegrity](#enforce-integrity)
+* [nonce](#nonce)
+* [noLoadEventRetriggers](#no-load-event-retriggers)
+* [skip](#skip-processing)
+* [onerror](#error-hook)
+* [onpolyfill](#polyfill-hook)
+* [resolve](#resolve-hook)
+* [fetch](#fetch-hook)
+* [revokeBlobURLs](#revoke-blob-urls)
+
 ```html
 <script>
 window.esmsInitOptions = {
@@ -419,6 +431,7 @@ window.esmsInitOptions = {
   resolve: (id, parentUrl, resolve) => resolve(id, parentUrl), // default is spec resolution
   fetch: (url, options) => fetch(url, options), // default is native
   revokeBlobURLs: true, // default false
+  enforceIntegrity: true, // default true
 }
 </script>
 <script async src="es-module-shims.js"></script>
@@ -472,6 +485,26 @@ Currently this option supports just `"css-modules"` and `"json-modules"`.
 }
 </script>
 ```
+
+### Enforce Integrity
+
+When enabled, `enforceIntegrity` will ensure that all modules loaded through ES Module Shims must have integrity defined either on a `<link rel="modulepreload" integrity="...">` or on
+a `<link rel="modulepreload-shim" integrity="...">` preload tag in shim mode. Modules without integrity will throw at fetch time.
+
+For example in the following, only the listed `app.js` and `dep.js` modules will be able to execute with the provided integrity:
+
+```html
+<script type="esms-options">{ "enforceIntegrity": true }</script>
+<link rel="modulepreload-shim" href="/app.js" integrity="sha384-..." />\
+<link rel="modulepreload-shim" href="/dep.js" integrity="sha384-..." />
+<script type="module-shim">
+  import '/app.js';
+</script>
+```
+
+Strong execution guarantees are only possible in shim mode since in polyfill mode it is not possible to stop the native loader from executing code without an integrity.
+
+Future versions of this option may provide support for origin-specific allow lists.
 
 ### Nonce
 

--- a/src/common.js
+++ b/src/common.js
@@ -127,17 +127,17 @@ function resolveAndComposePackages (packages, outPackages, baseUrl, parentMap) {
   for (let p in packages) {
     const resolvedLhs = resolveIfNotPlainOrUrl(p, baseUrl) || p;
     if (outPackages[resolvedLhs]) {
-      throw new Error(`Dynamic import map rejected: Overrides entry "${resolvedLhs}" from ${outPackages[resolvedLhs]} to ${packages[resolvedLhs]}.`);
+      throw Error(`Rejected map override "${resolvedLhs}" from ${outPackages[resolvedLhs]} to ${packages[resolvedLhs]}.`);
     }
     let target = packages[p];
-    if (typeof target !== 'string') 
+    if (typeof target !== 'string')
       continue;
     const mapped = resolveImportMap(parentMap, resolveIfNotPlainOrUrl(target, baseUrl) || target, baseUrl);
     if (mapped) {
       outPackages[resolvedLhs] = mapped;
       continue;
     }
-    targetWarning(p, packages[p], 'bare specifier did not resolve');
+    console.warn(`Mapping "${p}" -> "${packages[p]}" does not resolve`);
   }
 }
 
@@ -172,15 +172,8 @@ function applyPackages (id, packages) {
   if (pkgName) {
     const pkg = packages[pkgName];
     if (pkg === null) return;
-    if (id.length > pkgName.length && pkg[pkg.length - 1] !== '/')
-      targetWarning(pkgName, pkg, "should have a trailing '/'");
-    else
-      return pkg + id.slice(pkgName.length);
+    return pkg + id.slice(pkgName.length);
   }
-}
-
-function targetWarning (match, target, msg) {
-  console.warn("Package target " + msg + ", resolving target '" + target + "' for " + match);
 }
 
 export function resolveImportMap (importMap, resolvedOrPlain, parentUrl) {

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -71,7 +71,7 @@ let baselinePassthrough;
 const initPromise = featureDetectionPromise.then(() => {
   // shim mode is determined on initialization, no late shim mode
   if (!shimMode) {
-    if (document.querySelectorAll('script[type=module-shim],script[type=importmap-shim],link[rel=modulepreload]').length) {
+    if (document.querySelectorAll('script[type=module-shim],script[type=importmap-shim],link[rel=modulepreload-shim]').length) {
       setShimMode();
     }
     else {

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -82,7 +82,7 @@ const initPromise = featureDetectionPromise.then(() => {
             seenScript = true;
         }
         else if (script.type === 'importmap') {
-          importmapSrcOrLazy = true;
+          importMapSrcOrLazy = true;
           break;
         }
       }

--- a/src/options.js
+++ b/src/options.js
@@ -20,7 +20,7 @@ if (!nonce) {
 export const onerror = globalHook(esmsInitOptions.onerror || noop);
 export const onpolyfill = globalHook(esmsInitOptions.onpolyfill || noop);
 
-export const { revokeBlobURLs, noLoadEventRetriggers } = esmsInitOptions;
+export const { revokeBlobURLs, noLoadEventRetriggers, enforceIntegrity } = esmsInitOptions;
 
 export const fetchHook = esmsInitOptions.fetch ? globalHook(esmsInitOptions.fetch) : fetch;
 

--- a/test/shim.js
+++ b/test/shim.js
@@ -383,7 +383,7 @@ suite('Errors', function () {
 
     removeImportMap();
 
-    assert(error.message === 'Dynamic import map rejected: Overrides entry "global1" from http://localhost:8080/test/fixtures/es-modules/global1.js to data:text/javascript,throw new Error(\'Shim should not allow dynamic import map to override existing entries\');.');
+    assert(error.message === 'Rejected map override "global1" from http://localhost:8080/test/fixtures/es-modules/global1.js to data:text/javascript,throw new Error(\'Shim should not allow dynamic import map to override existing entries\');.');
   })
 
   function insertDynamicImportMap(importMap) {


### PR DESCRIPTION
This PR adds a new `enforceIntegrity` option, which when set to true will throw if module loads are attempted without integrity being set.

In addition this PR switches shim mode to using `modulepreload-shim` instead of `modulepreload` since when using shim mode in this way it would be desirable not to prime the main module cache for unnecessary performance. This PR also makes `modulepreload-shim` the only supported preload form in shim mode, although since this only affects preloading it is still a backwards compatible change.

In shim mode `enforceIntegrity` is then sufficient to provide strong execution integrity guarantees.

Some refactoring to reduce the footprint is also included in this PR.