### PR TITLE
feat: onpolyfill note default

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ window.esmsInitOptions = {
   noLoadEventRetriggers: true, // default false
   skip: /^https:\/\/cdn\.com/, // defaults to null
   onerror: (e) => { /*...*/ }, // default noop
-  onpolyfill: () => {},
+  onpolyfill: () => {}, // default logs to the console
   resolve: (id, parentUrl, resolve) => resolve(id, parentUrl), // default is spec resolution
   fetch: (url, options) => fetch(url, options), // default is native
   revokeBlobURLs: true, // default false
@@ -569,6 +569,8 @@ window.polyfilling = () => console.log('The polyfill is actively applying');
 }
 </script>
 ```
+
+The default hook will log a message to the console with `console.info` noting that polyfill mode is enabled and that the native error can be ignored.
 
 In the above, running in latest Chromium browsers, nothing will be logged, while running in an older browser that does not support newer features
 like import maps the console log will be output.

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -4,7 +4,6 @@ import {
   resolveAndComposeImportMap,
   resolveUrl,
   edge,
-  firefox,
   resolveImportMap,
   resolveIfNotPlainOrUrl,
   isURL,

--- a/src/options.js
+++ b/src/options.js
@@ -18,7 +18,7 @@ if (!nonce) {
 }
 
 export const onerror = globalHook(esmsInitOptions.onerror || noop);
-export const onpolyfill = globalHook(esmsInitOptions.onpolyfill || noop);
+export const onpolyfill = esmsInitOptions.onpolyfill ? globalHook(esmsInitOptions.onpolyfill) : () => console.info(`^ "Uncaught TypeError:" module failure has been polyfilled`);
 
 export const { revokeBlobURLs, noLoadEventRetriggers, enforceIntegrity } = esmsInitOptions;
 

--- a/src/options.js
+++ b/src/options.js
@@ -18,7 +18,7 @@ if (!nonce) {
 }
 
 export const onerror = globalHook(esmsInitOptions.onerror || noop);
-export const onpolyfill = esmsInitOptions.onpolyfill ? globalHook(esmsInitOptions.onpolyfill) : () => console.info(`^ "Uncaught TypeError:" module failure has been polyfilled`);
+export const onpolyfill = esmsInitOptions.onpolyfill ? globalHook(esmsInitOptions.onpolyfill) : () => console.info(`OK: "Uncaught TypeError" module failure has been polyfilled`);
 
 export const { revokeBlobURLs, noLoadEventRetriggers, enforceIntegrity } = esmsInitOptions;
 


### PR DESCRIPTION
This updates the `onpolyfill` hook to apply when first executing polyfilled code instead of just on init, so when there is a real native code path that failed that the polyfill is kicking in to polyfill.

Then, the default hook contains a `console.info` message noting that the native error which will be present can be ignored.

Here's how that looks in Firefox:

![image](https://user-images.githubusercontent.com/598730/146116691-7f4e92d3-3aa8-4275-910e-eb10ce3d4a16.png)

Hopefully this will help avoid any production confusions.