### PR TITLE
fix: Safari parse errors

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -500,7 +500,8 @@ function processScript (script) {
   if (isDomContentLoadedScript) domContentLoadedCnt++;
   const blocks = script.getAttribute('async') === null && isReadyScript;
   const loadPromise = topLevelLoad(script.src || `${pageBaseUrl}?${id++}`, getFetchOpts(script), !script.src && script.innerHTML, !shimMode, blocks && lastStaticLoadPromise).catch(e => {
-    setTimeout(() => { throw e });
+    // This used to be a setTimeout(() => { throw e }) but this breaks Safari stacks
+    console.error(e);
     onerror(e);
   });
   if (blocks)


### PR DESCRIPTION
When propagating the load error, Safari loses the parse stack information if using `setTimeout(() => { throw e })` to create a window error.

Instead we use `console.error` to display the error message and for error hooking users will need to rely on the `onerror` hook instead.

I have verified that this definitely fixes parse error stacks in Safari.