### PR TITLE
fix: Firefox error stacks

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -1,4 +1,6 @@
-export const edge = navigator.userAgent.match(/Edge\/\d\d\.\d+$/);
+const uaMatch = navigator.userAgent.match(/(Edge|Safari)\/\d+\.\d+/);
+export const edge = uaMatch && uaMatch[1] === 'Edge';
+export const safari = uaMatch && uaMatch[1] === 'Safari';
 
 export let baseUrl;
 

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -4,6 +4,7 @@ import {
   resolveAndComposeImportMap,
   resolveUrl,
   edge,
+  safari,
   resolveImportMap,
   resolveIfNotPlainOrUrl,
   isURL,
@@ -500,8 +501,12 @@ function processScript (script) {
   if (isDomContentLoadedScript) domContentLoadedCnt++;
   const blocks = script.getAttribute('async') === null && isReadyScript;
   const loadPromise = topLevelLoad(script.src || `${pageBaseUrl}?${id++}`, getFetchOpts(script), !script.src && script.innerHTML, !shimMode, blocks && lastStaticLoadPromise).catch(e => {
-    // This used to be a setTimeout(() => { throw e }) but this breaks Safari stacks
-    console.error(e);
+    // Safari only gives error via console.error
+    if (safari)
+      console.error(e);
+    // Firefox only gives error stack via setTimeout
+    else
+      setTimeout(() => { throw e});
     onerror(e);
   });
   if (blocks)


### PR DESCRIPTION
The fix in https://github.com/guybedford/es-module-shims/pull/238 ensuring proper parse errors for Safari caused Firefox stacks to break.

This branches using UA detection to achieve the best reporting per platform.