### PR TITLE
Fix typo and move comment about source map compatibility above the line it documents

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -277,7 +277,8 @@ function resolveDeps (load, seen) {
   load.S = undefined;
 }
 
-// ; and // trailer support added for Ruby 7 source maps compatibility
+// ; and // trailer support added for Ruby on Rails 7 source maps compatibility
+// https://github.com/guybedford/es-module-shims/issues/228
 const sourceMapURLRegEx = /\n\/\/# source(Mapping)?URL=([^\n]+)\s*((;|\/\/[^#][^\n]*)\s*)*$/;
 
 const jsContentType = /^(text|application)\/(x-)?javascript(;|$)/;

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -268,7 +268,6 @@ function resolveDeps (load, seen) {
     resolvedSource += source.slice(lastIndex);
   }
 
-  // ; and // trailer support added for Ruby 7 source maps compatibility
   let hasSourceURL = false;
   resolvedSource = resolvedSource.replace(sourceMapURLRegEx, (match, isMapping, url) => (hasSourceURL = !isMapping, match.replace(url, () => new URL(url, load.r))));
   if (!hasSourceURL)
@@ -278,6 +277,7 @@ function resolveDeps (load, seen) {
   load.S = undefined;
 }
 
+// ; and // trailer support added for Ruby 7 source maps compatibility
 const sourceMapURLRegEx = /\n\/\/# source(Mapping)?URL=([^\n]+)\s*((;|\/\/[^#][^\n]*)\s*)*$/;
 
 const jsContentType = /^(text|application)\/(x-)?javascript(;|$)/;


### PR DESCRIPTION
This is a minor follow-up to 76b18ba75273b2bd1330a9b418b100e686d06707 from https://github.com/guybedford/es-module-shims/pull/229 - that refactoring ended up separating the comment from the RegExp it was annotating. I've brought them back together and also fixed a typo: "Ruby 7" was used instead of "Ruby on Rails 7" (the former doesn't exist: [Ruby is currently on version 3](https://www.ruby-lang.org/en/downloads/releases/)). I also extended the comment with a link to the associated issue (https://github.com/guybedford/es-module-shims/issues/228) since I thought it could be helpful for anyone looking for additional context, but let me know if you don't want that.