### PR TITLE
fix: optional catch binding for chrome 64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+ES Module Shims 1.4.2 (2022/01/24)
+* Fix: optional catch binding in `isUrl` function
+
 ES Module Shims 1.4.1 (2021/12/15)
 * Fix: Firefox parse error stacks (https://github.com/guybedford/es-module-shims/pull/239)
 

--- a/src/common.js
+++ b/src/common.js
@@ -26,7 +26,7 @@ export function isURL (url) {
     new URL(url);
     return true;
   }
-  catch {
+  catch(_) {
     return false;
   }
 }


### PR DESCRIPTION
Chrome 64 doesn't handle the absent catch binding, since it's such a minimal code change I was hoping to fix it in the source. Happy to hear your thoughts 🙂 