### PR TITLE
feat: add support for dynamic import assertions

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -223,7 +223,7 @@ function resolveDeps (load, seen) {
     // once all deps have loaded we can inline the dependency resolution blobs
     // and define this blob
     let lastIndex = 0, depIndex = 0;
-    for (const { s: start, se: end, d: dynamicImportIndex } of imports) {
+    for (const { s: start, se: end, d: dynamicImportIndex, n: importName } of imports) {
       // dependency source replacements
       if (dynamicImportIndex === -1) {
         const depLoad = load.d[depIndex++];
@@ -260,7 +260,9 @@ function resolveDeps (load, seen) {
       }
       // dynamic import
       else {
-        resolvedSource += `${source.slice(lastIndex, dynamicImportIndex + 6)}Shim(${source.slice(start, end)}, ${load.r && urlJsString(load.r)}`;
+        const assertionStart = start + importName.length + 2;
+        const assertion = source.slice(assertionStart, end);
+        resolvedSource += `${source.slice(lastIndex, dynamicImportIndex + 6)}Shim(${source.slice(start, assertionStart)}, ${load.r && urlJsString(load.r)}${assertion}`;
         lastIndex = end;
       }
     }


### PR DESCRIPTION
For dynamic CSS and JSON import, Chrome requires type assertions, that means it supports (1):

```js
import("foo.json", { assert: { type: "json" } })
```

but not (2):

```js
import("foo.json")
```

SystemJS supports both (it just ignores the assertion part).

Currently `es-module-shims` supports only syntax (2). Syntax (1) will be converted to something like this `importShim("foo.json", { assert: { type: "json" } }, "http://localhost:3000")` which results in an error.

This PR moves the assertion part to be to last argument which will be ignored so that the shims will support both syntaxes.