### PR TITLE
Allow overriding a dynamic import map mapping to the same resolution

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -128,7 +128,7 @@ export function resolveUrl (relUrl, parentUrl) {
 function resolveAndComposePackages (packages, outPackages, baseUrl, parentMap) {
   for (let p in packages) {
     const resolvedLhs = resolveIfNotPlainOrUrl(p, baseUrl) || p;
-    if (outPackages[resolvedLhs]) {
+    if (outPackages[resolvedLhs] && (outPackages[resolvedLhs] !== packages[resolvedLhs])) {
       throw Error(`Rejected map override "${resolvedLhs}" from ${outPackages[resolvedLhs]} to ${packages[resolvedLhs]}.`);
     }
     let target = packages[p];

--- a/test/shim.js
+++ b/test/shim.js
@@ -386,6 +386,24 @@ suite('Errors', function () {
     assert(error.message === 'Rejected map override "global1" from http://localhost:8080/test/fixtures/es-modules/global1.js to data:text/javascript,throw new Error(\'Shim should not allow dynamic import map to override existing entries\');.');
   })
 
+  test('Dynamic import map shim with override to the same mapping is allowed', async function () {
+    const expectingNoError = new Promise((resolve, reject) => {
+      window.addEventListener('error', (event) => reject(event.error))
+      // waiting for 1 sec should be enough to make sure the error didn't happen.
+      setTimeout(resolve, 1000)
+    })
+
+    const removeImportMap = insertDynamicImportMap({
+      "imports": {
+        "global1": "http://localhost:8080/test/fixtures/es-modules/global1.js"
+      }
+    });
+
+    await expectingNoError;
+
+    removeImportMap();
+  })
+
   function insertDynamicImportMap(importMap) {
     const script = Object.assign(document.createElement('script'), {
       type: 'importmap-shim',


### PR DESCRIPTION
I'm running into this because I'm overriding the old "dynamic" import map when user installs a new package with a new import map that contains old mappings as well as the new one.

I could do more processing on my side to avoid old mappings in the new import map but I think a more DX friendly solution would be to not complain in situations where the mapping hasn't really changed.