### PR TITLE
fix: baseURI for inline scripts

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -21,7 +21,6 @@ export function isURL (url) {
 
 const backslashRegEx = /\\/g;
 export function resolveIfNotPlainOrUrl (relUrl, parentUrl) {
-  console.log(relUrl, parentUrl);
   // strip off any trailing query params or hashes
   parentUrl = parentUrl && parentUrl.split('#')[0].split('?')[0];
   if (relUrl.indexOf('\\') !== -1)
@@ -96,7 +95,6 @@ export function resolveIfNotPlainOrUrl (relUrl, parentUrl) {
     // finish reading out the last segment
     if (segmentIndex !== -1)
       output.push(segmented.slice(segmentIndex));
-    console.log('-> ' + parentUrl.slice(0, parentUrl.length - pathname.length) + output.join(''));
     return parentUrl.slice(0, parentUrl.length - pathname.length) + output.join('');
   }
 }

--- a/src/common.js
+++ b/src/common.js
@@ -21,6 +21,7 @@ export function isURL (url) {
 
 const backslashRegEx = /\\/g;
 export function resolveIfNotPlainOrUrl (relUrl, parentUrl) {
+  console.log(relUrl, parentUrl);
   // strip off any trailing query params or hashes
   parentUrl = parentUrl && parentUrl.split('#')[0].split('?')[0];
   if (relUrl.indexOf('\\') !== -1)
@@ -71,9 +72,9 @@ export function resolveIfNotPlainOrUrl (relUrl, parentUrl) {
         if (segmented[i] === '/') {
           output.push(segmented.slice(segmentIndex, i + 1));
           segmentIndex = -1;
+          continue;
         }
       }
-
       // new segment - check if it is relative
       else if (segmented[i] === '.') {
         // ../ segment
@@ -90,11 +91,12 @@ export function resolveIfNotPlainOrUrl (relUrl, parentUrl) {
       }
       // it is the start of a new segment
       while (segmented[i] === '/') i++;
-      segmentIndex = i;
+      segmentIndex = i; 
     }
     // finish reading out the last segment
     if (segmentIndex !== -1)
       output.push(segmented.slice(segmentIndex));
+    console.log('-> ' + parentUrl.slice(0, parentUrl.length - pathname.length) + output.join(''));
     return parentUrl.slice(0, parentUrl.length - pathname.length) + output.join('');
   }
 }

--- a/src/common.js
+++ b/src/common.js
@@ -1,25 +1,13 @@
-const uaMatch = navigator.userAgent.match(/(Edge|Safari)\/\d+\.\d+/);
-export const edge = uaMatch && uaMatch[1] === 'Edge';
-export const safari = uaMatch && uaMatch[1] === 'Safari';
+export const edge = !!navigator.userAgent.match(/Edge\/\d+\.\d+/);
+export const safari = !!window.safari;
 
-export let baseUrl;
+export const baseUrl = document.baseURI;
 
 export function createBlob (source, type = 'text/javascript') {
   return URL.createObjectURL(new Blob([source], { type }));
 }
 
 export const noop = () => {};
-
-const baseEl = document.querySelector('base[href]');
-if (baseEl)
-  baseUrl = baseEl.href;
-
-if (!baseUrl && typeof location !== 'undefined') {
-  baseUrl = location.href.split('#')[0].split('?')[0];
-  const lastSepIndex = baseUrl.lastIndexOf('/');
-  if (lastSepIndex !== -1)
-    baseUrl = baseUrl.slice(0, lastSepIndex + 1);
-}
 
 export function isURL (url) {
   try {
@@ -92,20 +80,17 @@ export function resolveIfNotPlainOrUrl (relUrl, parentUrl) {
         if (segmented[i + 1] === '.' && (segmented[i + 2] === '/' || i + 2 === segmented.length)) {
           output.pop();
           i += 2;
+          continue;
         }
         // ./ segment
         else if (segmented[i + 1] === '/' || i + 1 === segmented.length) {
           i += 1;
-        }
-        else {
-          // the start of a new segment as below
-          segmentIndex = i;
+          continue;
         }
       }
       // it is the start of a new segment
-      else {
-        segmentIndex = i;
-      }
+      while (segmented[i] === '/') i++;
+      segmentIndex = i;
     }
     // finish reading out the last segment
     if (segmentIndex !== -1)

--- a/src/common.js
+++ b/src/common.js
@@ -71,8 +71,8 @@ export function resolveIfNotPlainOrUrl (relUrl, parentUrl) {
         if (segmented[i] === '/') {
           output.push(segmented.slice(segmentIndex, i + 1));
           segmentIndex = -1;
-          continue;
         }
+        continue;
       }
       // new segment - check if it is relative
       else if (segmented[i] === '.') {

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -128,6 +128,7 @@ async function topLevelLoad (url, fetchOpts, source, nativelyLoaded, lastStaticL
     return dynamicImport(source ? createBlob(source) : url, { errUrl: url || source });
   }
   const load = getOrCreateLoad(url, fetchOpts, source);
+  load.r = pageBaseUrl;
   const seen = {};
   await loadAll(load, seen);
   lastLoad = undefined;
@@ -260,7 +261,7 @@ function resolveDeps (load, seen) {
       }
       // dynamic import
       else {
-        resolvedSource += `${source.slice(lastIndex, dynamicImportIndex + 6)}Shim(${source.slice(start, end)}, ${load.r && urlJsString(load.r)}${source.slice(end, statementEnd)}`;
+        resolvedSource += `${source.slice(lastIndex, dynamicImportIndex + 6)}Shim(${source.slice(start, end)}, ${urlJsString(load.r)}${source.slice(end, statementEnd)}`;
         lastIndex = statementEnd;
       }
     }


### PR DESCRIPTION
This fixes the top-level URL resolution when using `import.meta.resolve` in an inline module script. It also fixes Safari UA detection and double slash (`//`) resolution support.