### PR TITLE
feat: reword polyfill message to remove uncaught term

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -18,7 +18,7 @@ if (!nonce) {
 }
 
 export const onerror = globalHook(esmsInitOptions.onerror || noop);
-export const onpolyfill = esmsInitOptions.onpolyfill ? globalHook(esmsInitOptions.onpolyfill) : () => console.info(`OK: "Uncaught TypeError" module failure has been polyfilled`);
+export const onpolyfill = esmsInitOptions.onpolyfill ? globalHook(esmsInitOptions.onpolyfill) : () => console.info(`OK: ^ TypeError module failure has been polyfilled`);
 
 export const { revokeBlobURLs, noLoadEventRetriggers, enforceIntegrity } = esmsInitOptions;
 


### PR DESCRIPTION
Instead of showing:

```
OK: "Uncaught TypeError" module failure has been polyfilled
```

This updates the polyfill message to:

```
OK: ^ TypeError module failure has been polyfilled
```

This is because Safari doesn't show the term "Uncaught" which might be confusing.