### PR TITLE
fix: #255 importShim getting parentUrl

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -168,7 +168,12 @@ function revokeObjectURLs(registryKeys) {
   }
 }
 
-async function importShim (id, parentUrl = pageBaseUrl, _assertion) {
+async function importShim (id, ...args) {
+  // parentUrl if present will be the last argument
+  let parentUrl = args[args.length - 1];
+  if (typeof parentUrl !== 'string') {
+    parentUrl = pageBaseUrl;
+  }
   // needed for shim check
   await initPromise;
   if (acceptingImportMaps || shimMode || !baselinePassthrough) {
@@ -259,7 +264,7 @@ function resolveDeps (load, seen) {
       }
       // dynamic import
       else {
-        resolvedSource += `${source.slice(lastIndex, dynamicImportIndex + 6)}Shim(${source.slice(start, end)}, ${urlJsString(load.r)}${source.slice(end, statementEnd)}`;
+        resolvedSource += `${source.slice(lastIndex, dynamicImportIndex + 6)}Shim(${source.slice(start, statementEnd)}, ${load.r && urlJsString(load.r)}`;
         lastIndex = statementEnd;
       }
     }


### PR DESCRIPTION
This tries to fix https://github.com/guybedford/es-module-shims/issues/255

1. Update `resolveDeps` so that dynamic imports will be converted the form `importShim(id[, assertion][, parentUrl])`

2. Update `importShim` to expect `parentUrl` if present will be the last argument