### PR TITLE
feat: improve content type failure message

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -334,7 +334,7 @@ async function doFetch (url, fetchOpts, parent) {
     });export default s;`, t: 'css' };
   }
   else
-    throw Error(`Unsupported Content-Type "${contentType}"`);
+    throw Error(`Unsupported Content-Type "${contentType}" loading ${url}${parent ? ` imported by ${parent}` : ''}. Modules can only be loaded when served with a valid MIME type like application/javascript.`);
 }
 
 function getOrCreateLoad (url, fetchOpts, parent, source) {


### PR DESCRIPTION
This improves the `Error: Unsupported Content-Type` error context to include the full URL, parent importer URL along with a message noting how to resolve the issue.