### PR TITLE
fix: alternative 227 implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Use Chomp
         run: cargo install chompbuild
       - name: Chomp Test
-      - run: chomp test
+        run: chomp test
         env:
           CI_BROWSER: C:\hostedtoolcache\windows\chromium\${{ matrix.chrome }}\x64\chrome.exe
           CI_BROWSER_FLAGS: 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Chomp
-        uses: guybedford/chomp-action@main
+        uses: guybedford/chomp-action@v1
       - name: Setup Node.js ${{ matrix.node }}
         uses: actions/setup-node@v2
         with:
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Chomp
-        uses: guybedford/chomp-action@main
+        uses: guybedford/chomp-action@v1
       - name: Setup Node.js ${{ matrix.node }}
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,10 @@ jobs:
         uses: browser-actions/setup-firefox@latest
         with:
           firefox-version: ${{ matrix.firefox }}
-      - name: npm install
-        run: npm install
-      - name: npm run build
-        run: npm run build
-      - name: npm run test
-        run: npm run test
+      - name: Use Chomp
+        run: cargo install chompbuild
+      - name: Chomp Test
+        run: chomp test
         env:
           CI_BROWSER: /opt/hostedtoolcache/firefox/${{ matrix.firefox }}/x64/firefox
           CI_BROWSER_FLAGS: -headless
@@ -57,12 +55,10 @@ jobs:
         uses: browser-actions/setup-chrome@latest
         with:
           chrome-version: ${{ matrix.chrome }}
-      - name: npm install
-        run: npm install
-      - name: npm run build
-        run: npm run build
-      - name: npm run test
-        run: npm run test
+      - name: Use Chomp
+        run: cargo install chompbuild
+      - name: Chomp Test
+      - run: chomp test
         env:
           CI_BROWSER: C:\hostedtoolcache\windows\chromium\${{ matrix.chrome }}\x64\chrome.exe
           CI_BROWSER_FLAGS: 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: browser-actions/setup-firefox@latest
         with:
           firefox-version: ${{ matrix.firefox }}
-      - name: Use Chomp
+      - name: Setup Chomp
         uses: guybedford/chomp-action@main
       - name: Chomp Test
         run: chomp test
@@ -55,7 +55,7 @@ jobs:
         uses: browser-actions/setup-chrome@latest
         with:
           chrome-version: ${{ matrix.chrome }}
-      - name: Use Chomp
+      - name: Setup Chomp
         uses: guybedford/chomp-action@main
       - name: Chomp Test
         run: chomp test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           firefox-version: ${{ matrix.firefox }}
       - name: Use Chomp
-        run: cargo install chompbuild
+        uses: guybedford/chomp-action@main
       - name: Chomp Test
         run: chomp test
         env:
@@ -56,7 +56,7 @@ jobs:
         with:
           chrome-version: ${{ matrix.chrome }}
       - name: Use Chomp
-        run: cargo install chompbuild
+        uses: guybedford/chomp-action@main
       - name: Chomp Test
         run: chomp test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     name: Firefox Browser Tests
     steps:
       - uses: actions/checkout@v2
+      - name: Setup Chomp
+        uses: guybedford/chomp-action@main
       - name: Setup Node.js ${{ matrix.node }}
         uses: actions/setup-node@v2
         with:
@@ -27,8 +29,6 @@ jobs:
         uses: browser-actions/setup-firefox@latest
         with:
           firefox-version: ${{ matrix.firefox }}
-      - name: Setup Chomp
-        uses: guybedford/chomp-action@main
       - name: Chomp Test
         run: chomp test
         env:
@@ -47,6 +47,8 @@ jobs:
     name: Chrome Browser Tests
     steps:
       - uses: actions/checkout@v2
+      - name: Setup Chomp
+        uses: guybedford/chomp-action@main
       - name: Setup Node.js ${{ matrix.node }}
         uses: actions/setup-node@v2
         with:
@@ -55,8 +57,6 @@ jobs:
         uses: browser-actions/setup-chrome@latest
         with:
           chrome-version: ${{ matrix.chrome }}
-      - name: Setup Chomp
-        uses: guybedford/chomp-action@main
       - name: Chomp Test
         run: chomp test
         env:

--- a/chompfile.toml
+++ b/chompfile.toml
@@ -1,6 +1,6 @@
 version = 0.1
 
-extensions = ['chomp@0.1:footprint']
+extensions = ['chomp@0.1:footprint', 'chomp@0.1:npm']
 
 default-task = 'test'
 
@@ -15,7 +15,7 @@ run = 'rm -rf bench/results'
 [[task]]
 name = 'build'
 targets = ['dist/es-module-shims.js', 'dist/es-module-shims.wasm.js']
-dep = 'src/*.js'
+deps = ['src/*.js', 'npm:install']
 run = 'rollup -c'
 
 [[task]]
@@ -25,10 +25,6 @@ template = 'footprint'
 
 [[task]]
 name = 'test'
-deps = [':test:']
-
-[[task]]
-name = 'test:#'
 serial = true
-dep = 'test/test-#.html'
+deps = ['test/test-#.html', 'npm:install', 'dist/es-module-shims.js', 'dist/es-module-shims.wasm.js']
 run = 'node test/server.mjs test-${{ MATCH }}'

--- a/chompfile.toml
+++ b/chompfile.toml
@@ -1,0 +1,34 @@
+version = 0.1
+
+extensions = ['chomp@0.1:footprint']
+
+default-task = 'test'
+
+[[task]]
+name = 'bench'
+run = 'bash bench/bench.sh'
+
+[[task]]
+name = 'bench:clear'
+run = 'rm -rf bench/results'
+
+[[task]]
+name = 'build'
+targets = ['dist/es-module-shims.js', 'dist/es-module-shims.wasm.js']
+dep = 'src/*.js'
+run = 'rollup -c'
+
+[[task]]
+name = 'footprint'
+deps = ['dist/es-module-shims.js', 'dist/es-module-shims.wasm.js']
+template = 'footprint'
+
+[[task]]
+name = 'test'
+deps = [':test:']
+
+[[task]]
+name = 'test:#'
+serial = true
+dep = 'test/test-#.html'
+run = 'node test/server.mjs test-${{ MATCH }}'

--- a/package.json
+++ b/package.json
@@ -7,25 +7,6 @@
     ".": "./dist/es-module-shims.js",
     "./wasm": "./dist/es-module-shims.wasm.js"
   },
-  "scripts": {
-    "build": "rollup -c",
-    "bench": "bash bench/bench.sh",
-    "bench:clear": "rm -rf bench/results",
-    "footprint": "npm run build ; cat dist/es-module-shims.js | terser -mc | brotli | wc -c",
-    "footprint:wasm": "npm run build ; cat dist/es-module-shims.wasm.js | terser -mc | brotli | wc -c",
-    "prepublishOnly": "npm run build",
-    "test": "npm run test:test-base-href ; npm run test:test-csp ; npm run test:test-dom-order ; npm run test:test-early-module-load ; npm run test:test-polyfill ; npm run test:test-polyfill-wasm ; npm run test:test-preload-case ; npm run test:test-revoke-blob-urls ; npm run test:test-shim ; npm run test:test-shim-map-overrides",
-    "test:test-base-href": "cross-env TEST_NAME=test-base-href node test/server.mjs",
-    "test:test-csp": "cross-env TEST_NAME=test-csp node test/server.mjs",
-    "test:test-dom-order": "cross-env TEST_NAME=test-dom-order node test/server.mjs",
-    "test:test-early-module-load": "cross-env TEST_NAME=test-early-module-load node test/server.mjs",
-    "test:test-polyfill": "cross-env TEST_NAME=test-polyfill node test/server.mjs",
-    "test:test-polyfill-wasm": "cross-env TEST_NAME=test-polyfill-wasm node test/server.mjs",
-    "test:test-preload-case": "cross-env TEST_NAME=test-preload-case node test/server.mjs",
-    "test:test-revoke-blob-urls": "cross-env TEST_NAME=test-revoke-blob-urls node test/server.mjs",
-    "test:test-shim": "cross-env TEST_NAME=test-shim node test/server.mjs",
-    "test:test-shim-map-overrides": "cross-env TEST_NAME=test-shim-map-overrides node test/server.mjs"
-  },
   "types": "index.d.ts",
   "type": "module",
   "files": [
@@ -37,7 +18,6 @@
   "license": "MIT",
   "devDependencies": {
     "@rollup/plugin-replace": "^2.4.2",
-    "cross-env": "^7.0.3",
     "es-module-lexer": "^0.9.3",
     "esm": "^3.2.25",
     "kleur": "^4.1.4",

--- a/src/dynamic-import.js
+++ b/src/dynamic-import.js
@@ -1,4 +1,4 @@
-import { createBlob, baseUrl } from './env.js';
+import { createBlob, baseUrl, nonce } from './env.js';
 
 export let supportsDynamicImportCheck = false;
 
@@ -17,6 +17,7 @@ if (!supportsDynamicImportCheck) {
     const src = createBlob(`import*as m from'${url}';self._esmsi=m;`);
     const s = Object.assign(document.createElement('script'), { type: 'module', src });
     s.setAttribute('noshim', '');
+    s.setAttribute('nonce', nonce);
     document.head.appendChild(s);
     return new Promise((resolve, reject) => {
       s.addEventListener('load', () => {

--- a/src/features.js
+++ b/src/features.js
@@ -31,9 +31,7 @@ export const featureDetectionPromise = Promise.resolve(supportsDynamicImportChec
       document.head.appendChild(iframe);
       const doc = iframe.contentDocument;
       doc.head.appendChild(Object.assign(doc.createElement('script'), { type: 'importmap', innerHTML: '{"imports":{"x":"data:text/javascript,"}}' }));
-      const script = Object.assign(doc.createElement('script'), { innerHTML: 'import("x").then(()=>1,()=>0).then(v=>parent._$s(v))' });
-      script.setAttribute('nonce', nonce);
-      doc.head.appendChild(script);
+      doc.head.appendChild(Object.assign(doc.createElement('script'), { innerHTML: 'import("x").then(()=>1,()=>0).then(v=>parent._$s(v))' }));
     })
   ]);
 });

--- a/src/features.js
+++ b/src/features.js
@@ -28,8 +28,8 @@ export const featureDetectionPromise = Promise.resolve(supportsDynamicImportChec
       };
       const iframe = document.createElement('iframe');
       iframe.style.display = 'none';
-      document.head.appendChild(iframe);
       iframe.srcdoc = `<script type=importmap nonce="${nonce}">{"imports":{"x":"data:text/javascript,"}}<${''}/script><script nonce="${nonce}">import('x').then(()=>1,()=>0).then(v=>parent._$s(v))<${''}/script>`;
+      document.head.appendChild(iframe);
     })
   ]);
 });

--- a/src/features.js
+++ b/src/features.js
@@ -29,11 +29,7 @@ export const featureDetectionPromise = Promise.resolve(supportsDynamicImportChec
       const iframe = document.createElement('iframe');
       iframe.style.display = 'none';
       document.head.appendChild(iframe);
-      const doc = iframe.contentDocument;
-      doc.head.appendChild(Object.assign(doc.createElement('script'), { type: 'importmap', innerHTML: '{"imports":{"x":"data:text/javascript,"}}' }));
-      const script = Object.assign(doc.createElement('script'), { innerHTML: 'import("x").then(()=>1,()=>0).then(v=>parent._$s(v))' });
-      script.setAttribute('nonce', nonce);
-      doc.head.appendChild(script);
+      iframe.srcdoc = `<script type=importmap nonce="${nonce}">{"imports":{"x":"data:text/javascript,"}}<${''}/script><script nonce="${nonce}">import('x').then(()=>1,()=>0).then(v=>parent._$s(v))<${''}/script>`;
     })
   ]);
 });

--- a/src/features.js
+++ b/src/features.js
@@ -1,5 +1,5 @@
 import { dynamicImport, supportsDynamicImportCheck } from './dynamic-import-csp.js';
-import { createBlob, noop, nonce, cssModulesEnabled, jsonModulesEnabled } from './env.js';
+import { createBlob, noop, cssModulesEnabled, jsonModulesEnabled } from './env.js';
 
 // support browsers without dynamic import support (eg Firefox 6x)
 export let supportsJsonAssertions = false;

--- a/src/features.js
+++ b/src/features.js
@@ -1,5 +1,5 @@
 import { dynamicImport, supportsDynamicImportCheck } from './dynamic-import-csp.js';
-import { createBlob, noop, cssModulesEnabled, jsonModulesEnabled } from './env.js';
+import { createBlob, noop, nonce, cssModulesEnabled, jsonModulesEnabled } from './env.js';
 
 // support browsers without dynamic import support (eg Firefox 6x)
 export let supportsJsonAssertions = false;

--- a/src/features.js
+++ b/src/features.js
@@ -29,7 +29,11 @@ export const featureDetectionPromise = Promise.resolve(supportsDynamicImportChec
       const iframe = document.createElement('iframe');
       iframe.style.display = 'none';
       document.head.appendChild(iframe);
-      iframe.src = createBlob(`<script type=importmap nonce="${nonce}">{"imports":{"x":"data:text/javascript,"}}<${''}/script><script nonce="${nonce}">import('x').then(()=>1,()=>0).then(v=>parent._$s(v))<${''}/script>`, 'text/html')
+      const doc = iframe.contentDocument;
+      doc.head.appendChild(Object.assign(doc.createElement('script'), { type: 'importmap', innerHTML: '{"imports":{"x":"data:text/javascript,"}}' }));
+      const script = Object.assign(doc.createElement('script'), { innerHTML: 'import("x").then(()=>1,()=>0).then(v=>parent._$s(v))' });
+      script.setAttribute('nonce', nonce);
+      doc.head.appendChild(script);
     })
   ]);
 });

--- a/src/features.js
+++ b/src/features.js
@@ -31,7 +31,9 @@ export const featureDetectionPromise = Promise.resolve(supportsDynamicImportChec
       document.head.appendChild(iframe);
       const doc = iframe.contentDocument;
       doc.head.appendChild(Object.assign(doc.createElement('script'), { type: 'importmap', innerHTML: '{"imports":{"x":"data:text/javascript,"}}' }));
-      doc.head.appendChild(Object.assign(doc.createElement('script'), { innerHTML: 'import("x").then(()=>1,()=>0).then(v=>parent._$s(v))' }));
+      const script = Object.assign(doc.createElement('script'), { innerHTML: 'import("x").then(()=>1,()=>0).then(v=>parent._$s(v))' });
+      script.setAttribute('nonce', nonce);
+      doc.head.appendChild(script);
     })
   ]);
 });

--- a/test/server.mjs
+++ b/test/server.mjs
@@ -29,10 +29,6 @@ let retry = 0;
 if (testName.startsWith('test-chrome') && process.env.CI_BROWSER && !process.env.CI_BROWSER.includes('chrome'))
   process.exit(0);
 
-// Dont run CSP tests on old Firefox
-if (testName.startsWith('test-csp') && process.env.CI_BROWSER && process.env.CI_BROWSER.includes('firefox') && (process.env.CI_BROWSER.includes('60') || process.env.CI_BROWSER.includes('67')))
-  process.exit(0);
-
 let failTimeout, browserTimeout;
 
 function setBrowserTimeout () {

--- a/test/server.mjs
+++ b/test/server.mjs
@@ -21,7 +21,7 @@ const mimes = {
 };
 
 const shouldExit = process.env.WATCH_MODE !== 'true';
-const testName = process.env.TEST_NAME ?? 'test';
+const testName = process.argv[2] ?? 'test';
 
 let retry = 0;
 


### PR DESCRIPTION
This implements an alternative to https://github.com/guybedford/es-module-shims/pull/227 avoiding the navigation event.

// cc @LarsDenBakker 

@lewisl9029 I'm not easily able to test this on Weixin browser, but I assume the approach should work there in it being a `document.write` restriction and not a `contentDocument` restriction.

This PR also includes the build system upgrade to Chomp.