### PR TITLE
feat: import hook, meta hook, backwards-compatible sync resolver

### DIFF
--- a/chompfile.toml
+++ b/chompfile.toml
@@ -4,6 +4,9 @@ extensions = ['chomp@0.1:footprint', 'chomp@0.1:npm']
 
 default-task = 'test'
 
+[server]
+port = 8080
+
 [[task]]
 name = 'bench'
 run = 'bash bench/bench.sh'
@@ -30,5 +33,5 @@ dep = 'test:'
 [[task]]
 name = 'test:#'
 serial = true
-deps = ['test/test-#.html', 'npm:install', 'dist/es-module-shims.js', 'dist/es-module-shims.wasm.js']
+deps = ['npm:install', 'dist/es-module-shims.js', 'dist/es-module-shims.wasm.js', 'test/test-#.html']
 run = 'node test/server.mjs test-${{ MATCH }}'

--- a/src/env.js
+++ b/src/env.js
@@ -3,10 +3,15 @@ export const noop = () => {};
 
 const optionsScript = document.querySelector('script[type=esms-options]');
 
-const esmsInitOptions = optionsScript ? JSON.parse(optionsScript.innerHTML) : self.esmsInitOptions ? self.esmsInitOptions : {};
+export const esmsInitOptions = optionsScript ? JSON.parse(optionsScript.innerHTML) : {};
+Object.assign(esmsInitOptions, self.esmsInitOptions || {});
 
 export let shimMode = !!esmsInitOptions.shimMode;
+
+export const importHook = globalHook(shimMode && esmsInitOptions.onimport);
 export const resolveHook = globalHook(shimMode && esmsInitOptions.resolve);
+export let fetchHook = esmsInitOptions.fetch ? globalHook(esmsInitOptions.fetch) : fetch;
+export const metaHook = esmsInitOptions.meta ? globalHook(shimModule && esmsInitOptions.meta) : noop;
 
 export const skip = esmsInitOptions.skip ? new RegExp(esmsInitOptions.skip) : null;
 
@@ -24,8 +29,6 @@ export const onerror = globalHook(esmsInitOptions.onerror || noop);
 export const onpolyfill = esmsInitOptions.onpolyfill ? globalHook(esmsInitOptions.onpolyfill) : () => console.info(`OK: ^ TypeError module failure has been polyfilled`);
 
 export const { revokeBlobURLs, noLoadEventRetriggers, enforceIntegrity } = esmsInitOptions;
-
-export const fetchHook = esmsInitOptions.fetch ? globalHook(esmsInitOptions.fetch) : fetch;
 
 function globalHook (name) {
   return typeof name === 'string' ? self[name] : name;
@@ -51,12 +54,6 @@ const eoop = err => setTimeout(() => { throw err });
 
 export const throwError = err => { (window.reportError || window.safari && console.error || eoop)(err), void onerror(err) };
 
-export function isURL (url) {
-  try {
-    new URL(url);
-    return true;
-  }
-  catch (_) {
-    return false;
-  }
+export function fromParent (parent) {
+  return parent ? ` imported from ${parent}` : '';
 }

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -4,6 +4,17 @@ export let importMap = { imports: {}, scopes: {} };
 
 const backslashRegEx = /\\/g;
 
+export function isURL (url) {
+  if (url.indexOf(':') === -1) return false;
+  try {
+    new URL(url);
+    return true;
+  }
+  catch (_) {
+    return false;
+  }
+}
+
 /*
  * Import maps implementation
  *
@@ -12,12 +23,14 @@ const backslashRegEx = /\\/g;
  *
  */
 export function resolveUrl (relUrl, parentUrl) {
-  return resolveIfNotPlainOrUrl(relUrl, parentUrl) || (relUrl.indexOf(':') !== -1 ? relUrl : resolveIfNotPlainOrUrl('./' + relUrl, parentUrl));
+  return resolveIfNotPlainOrUrl(relUrl, parentUrl) || (isURL(relUrl) ? relUrl : resolveIfNotPlainOrUrl('./' + relUrl, parentUrl));
 }
 
 export function resolveIfNotPlainOrUrl (relUrl, parentUrl) {
   // strip off any trailing query params or hashes
-  parentUrl = parentUrl && parentUrl.split('#')[0].split('?')[0];
+  const queryHashIndex = parentUrl.indexOf('?', parentUrl.indexOf('#') === -1 ? parentUrl.indexOf('#') : parentUrl.length);
+  if (queryHashIndex !== -1)
+    parentUrl = parentUrl.slice(0, queryHashIndex);
   if (relUrl.indexOf('\\') !== -1)
     relUrl = relUrl.replace(backslashRegEx, '/');
   // protocol-relative

--- a/test/revoke-blob-urls.js
+++ b/test/revoke-blob-urls.js
@@ -5,11 +5,11 @@ test('should revoke blob URLs if `esmsInitOptions.revokeBlobURLs` is set to `tru
     const moduleDepURL = new URL('./fixtures/es-modules/es6-dep.js', location.href).href;
 
     // must be on an old browser to test!
-    if (!window._esmsr[moduleDepURL])
+    if (!importShim._r[moduleDepURL])
         return;
 
-    const moduleBlobURL = window._esmsr[moduleURL].b;
-    const moduleDepBlobURL = window._esmsr[moduleDepURL].b;
+    const moduleBlobURL = importShim._r[moduleURL].b;
+    const moduleDepBlobURL = importShim._r[moduleDepURL].b;
     assert(moduleBlobURL.startsWith("blob:http"));
     assert(moduleDepBlobURL.startsWith("blob:http"));
 

--- a/test/shim.js
+++ b/test/shim.js
@@ -128,7 +128,6 @@ suite('Basic loading tests', () => {
     const url = window.location.href.split('#')[0].split('?')[0]
       .replace('/test-shim.html', '/fixtures/es-modules/no-imports.js')
       .replace(/^http(s)?:/, '');
-    console.log(url);
     assert.equal(url.slice(0, 2), '//');
     var m = await importShim(url);
     assert(m);

--- a/test/shim.js
+++ b/test/shim.js
@@ -125,9 +125,10 @@ suite('Basic loading tests', () => {
   });
 
   test('Should import a module via a full url, without scheme', async function () {
-    const url = window.location.href
+    const url = window.location.href.split('#')[0].split('?')[0]
       .replace('/test-shim.html', '/fixtures/es-modules/no-imports.js')
       .replace(/^http(s)?:/, '');
+    console.log(url);
     assert.equal(url.slice(0, 2), '//');
     var m = await importShim(url);
     assert(m);
@@ -135,7 +136,7 @@ suite('Basic loading tests', () => {
   });
 
   test("Should import a module via a relative path re-mapped with importmap's scopes", async function () {
-    const url = window.location.href
+    const url = window.location.href.split('#')[0].split('?')[0]
       .replace('/test-shim.html', '/fixtures/es-modules/import-relative-path.js');
     var m = await importShim(url);
     assert(m);
@@ -380,6 +381,7 @@ suite('Errors', function () {
     });
 
     const error = await listeningForError;
+    console.log('got error');
 
     removeImportMap();
 
@@ -418,7 +420,7 @@ suite('Source maps', () => {
   test('should include `//# sourceURL=` directive if one is not present in original module', async () => {
     const moduleURL = new URL("./fixtures/es-modules/without-source-url.js", location.href).href;
     await importShim(moduleURL);
-    const moduleBlobURL = window._esmsr[moduleURL].b
+    const moduleBlobURL = importShim._r[moduleURL].b
     const blobContent = await fetch(moduleBlobURL).then(r => r.text())
     assert(blobContent.includes(`//# sourceURL=${moduleURL}`))
   });
@@ -426,7 +428,7 @@ suite('Source maps', () => {
   test('should replace relative paths in `//# sourceURL=` directive with absolute URL', async () => {
     const moduleURL = new URL('./fixtures/es-modules/with-relative-source-url.js', location.href).href;
     await importShim(moduleURL);
-    const moduleBlobURL = window._esmsr[moduleURL].b;
+    const moduleBlobURL = importShim._r[moduleURL].b;
     const blobContent = await fetch(moduleBlobURL).then(r => r.text());
     const sourceURL = new URL('module.ts', moduleURL).href;
     assert(blobContent.endsWith(`//# sourceURL=${sourceURL}`));
@@ -437,7 +439,7 @@ suite('Source maps', () => {
   test('should replace relative paths in `//# sourceMappingURL=` directive with absolute URL and add `//# sourceURL=`', async () => {
     const moduleURL = new URL('./fixtures/es-modules/with-relative-source-mapping-url.js', location.href).href;
     await importShim(moduleURL);
-    const moduleBlobURL = window._esmsr[moduleURL].b;
+    const moduleBlobURL = importShim._r[moduleURL].b;
     const blobContent = await fetch(moduleBlobURL).then(r => r.text());
     const sourceMappingURL = new URL('./with-relative-source-mapping-url.js.map', moduleURL).href;
     assert(blobContent.endsWith(
@@ -451,7 +453,7 @@ suite('Source maps', () => {
   test('should keep original absolute URL in `//# sourceMappingURL=` directive and add `//# sourceURL=`', async () => {
     const moduleURL = new URL('./fixtures/es-modules/with-absolute-source-mapping-url.js', location.href).href;
     await importShim(moduleURL);
-    const moduleBlobURL = window._esmsr[moduleURL].b;
+    const moduleBlobURL = importShim._r[moduleURL].b;
     const blobContent = await fetch(moduleBlobURL).then(r => r.text());
     assert(blobContent.endsWith(
         `//# sourceMappingURL=https://example.com/module.js.map\n//# sourceURL=${moduleURL}`

--- a/test/test-revoke-blob-urls.html
+++ b/test/test-revoke-blob-urls.html
@@ -13,7 +13,6 @@
     shimMode: true,
     revokeBlobURLs: true
   };
-  window.ESMS_DEBUG = true;
 </script>
 <script type="module" src="../src/es-module-shims.js"></script>
 <script type="module" noshim>


### PR DESCRIPTION
This adds two new hooks to the configuration - an `onimport` hook which is called on each top-level import and that can do any async work, and a `meta(metaObj, url)` hook which allows customizing the import.meta object for all module sources.

This PR also updates `import.meta.resolve` to be synchronous. As an experimental feature this change is considered non-breaking since the status was indicated alongside the feature as experimental from the beginning.

The sync resolver is also made available globally via `importShim.resolve`.

Asynchronous resolve hooks will still be supported, but will then be deprecated in the next major.

This then fully aligns with the HTML sync import.meta.resolve function per https://github.com/whatwg/html/pull/5572.