### PR TITLE
Hot reloading support via import.meta.hot

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,7 +638,13 @@ In polyfill mode, all modules will be initialized twice when hot reloading to re
 
 The `hotReloadInterval` option can also be configured which is the interval at which hot reload events are batched together as a single reload operation, with the default of `100`.
 
-When enabled, [native passthrough](#native-passthrough) will be automatically disabled, and all modules will be provided with the `import.meta.hot` API fully supporting [Vite's `import.meta.hot`](https://vite.dev/guide/api-hmr), except for the event handlers.
+When enabled, [native passthrough](#native-passthrough) will be automatically disabled, and all modules will be provided with the `import.meta.hot` API fully supporting [Vite's `import.meta.hot`](https://vite.dev/guide/api-hmr), supporting the following methods except for the event handlers:
+
+* `hot.accept(cb)`: Accept a hot update.
+* `hot.accept(dep, cb)`: Accept a hot update of a dependency specifier string.
+* `hot.accept(deps, cb)`: Accept a hot update of a list of dependency specifier strings.
+* `hot.dispose(cb)`: Provide a dispose function for when this module is expected to be accepted by others.
+* 
 
 To trigger a hot reload, call the `importShim.hotReload(url)` API with the URL of the module that has changed. All of CSS, JSON, Wasm and TypeScript imports are supported in hot reloading.
 

--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ The `hotReloadInterval` option can also be configured which is the interval at w
 
 When enabled, [native passthrough](#native-passthrough) will be automatically disabled, and all modules will be provided with the `import.meta.hot` API fully supporting [Vite's `import.meta.hot`](https://vite.dev/guide/api-hmr), except for the event handlers.
 
-To trigger a hot reload, call the `importShim.hotReload(url)` API with the URL of the module that has changed. All of CSS, JSON and TypeScript imports are supported in hot reloading. Wasm hot reloading support is still a work in progress.
+To trigger a hot reload, call the `importShim.hotReload(url)` API with the URL of the module that has changed. All of CSS, JSON, Wasm and TypeScript imports are supported in hot reloading.
 
 This hot reload API can then be attached to a Web Socket, Server Side Events emitter or any other event source to provide a native hot reloading development environment.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The following modules features are polyfilled:
 * [Wasm modules](#wasm-modules) with support for Source Phase Imports, when enabled.
 * [Import defer](#import-defer) via syntax stripping to allow usage in modern browsers with a polyfill fallback, when enabled.
 * [TypeScript](#typescript-type-stripping) type stripping.
-* [Hot Reloading](#hot-reloading) with a Vite-style `import.meta.host` API.
+* [Hot Reloading](#hot-reloading) with a Vite-style `import.meta.hot` API.
 
 When running in shim mode, module rewriting is applied for all users and custom [resolve](#resolve-hook) and [fetch](#fetch-hook) hooks can be implemented allowing for custom resolution and streaming in-browser transform workflows.
 
@@ -634,11 +634,13 @@ test.html
 <script type="module" src="/app.js"></script>
 ```
 
+In polyfill mode, all modules will be initialized twice when hot reloading to reinitiate with `import.meta.hot`. To avoid this, shim mode is recommended for hot reloading workflows whenever possible.
+
 The `hotReloadInterval` option can also be configured which is the interval at which hot reload events are batched together as a single reload operation, with the default of `100`.
 
-When enabled, [native passthrough](#native-passthrough) will be automatically disabled, and all modules will be provided with the `import.meta.hot` API.
+When enabled, [native passthrough](#native-passthrough) will be automatically disabled, and all modules will be provided with the `import.meta.hot` API fully supporting [Vite's `import.meta.hot`](https://vite.dev/guide/api-hmr), except for the event handlers.
 
-To trigger a hot reload, call the `importShim.hotReload(url)` API with the URL of the module that has changed. All of CSS, JSON, Wasm and TypeScript imports loaded through the module system are supported in this API.
+To trigger a hot reload, call the `importShim.hotReload(url)` API with the URL of the module that has changed. All of CSS, JSON and TypeScript imports are supported in hot reloading. Wasm hot reloading support is still a work in progress.
 
 This hot reload API can then be attached to a Web Socket, Server Side Events emitter or any other event source to provide a native hot reloading development environment.
 

--- a/src/env.js
+++ b/src/env.js
@@ -1,4 +1,4 @@
-import { hotImportHook, hotResolveHook, hotMetaHook } from './hot-reload.js';
+import { initHotReload } from './hot-reload.js';
 
 if (self.importShim) {
   if (self.ESMS_DEBUG)
@@ -50,6 +50,9 @@ if (esmsInitOptions.resolve) resolveHook = globalHook(esmsInitOptions.resolve);
 if (esmsInitOptions.fetch) fetchHook = globalHook(esmsInitOptions.fetch);
 if (esmsInitOptions.meta) metaHook = globalHook(esmsInitOptions.meta);
 if (esmsInitOptions.tsTransform) tsTransform = globalHook(esmsInitOptions.tsTransform);
+
+if (hotReload)
+  [importHook, resolveHook, metaHook] = initHotReload();
 
 export const mapOverrides = esmsInitOptions.mapOverrides;
 

--- a/src/env.js
+++ b/src/env.js
@@ -19,22 +19,24 @@ Object.assign(esmsInitOptions, self.esmsInitOptions || {});
 
 // shim mode is determined on initialization, no late shim mode
 export const shimMode =
-  hasDocument ?
-    esmsInitOptions.shimMode ||
-    document.querySelectorAll('script[type=module-shim],script[type=importmap-shim],link[rel=modulepreload-shim]')
-      .length > 0
-  : true;
-
-export const importHook = globalHook(shimMode && esmsInitOptions.onimport);
-export const resolveHook = globalHook(shimMode && esmsInitOptions.resolve);
-export let fetchHook = esmsInitOptions.fetch ? globalHook(esmsInitOptions.fetch) : fetch;
-export const metaHook = esmsInitOptions.meta ? globalHook(shimMode && esmsInitOptions.meta) : noop;
-export const tsTransform =
-  esmsInitOptions.tsTransform ||
+  esmsInitOptions.shimMode ||
   (hasDocument &&
-    document.currentScript &&
-    document.currentScript.src.replace(self.ESMS_DEBUG ? /\.debug\.js$/ : /\.js$/, '-typescript.js')) ||
-  './es-module-shims-typescript.js';
+    document.querySelectorAll('script[type=module-shim],script[type=importmap-shim],link[rel=modulepreload-shim]')
+      .length > 0);
+
+export let importHook,
+  resolveHook,
+  fetchHook = fetch,
+  metaHook = noop,
+  tsTransform =
+    (hasDocument && document.currentScript && document.currentScript.src.replace(/(\.\w+)?\.js$/, '-typescript.js')) ||
+    './es-module-shims-typescript.js';
+
+if (esmsInitOptions.onimport) importHook = globalHook(esmsInitOptions.onimport);
+if (esmsInitOptions.resolve) resolveHook = globalHook(esmsInitOptions.resolve);
+if (esmsInitOptions.fetch) fetchHook = globalHook(esmsInitOptions.fetch);
+if (esmsInitOptions.meta) metaHook = globalHook(esmsInitOptions.meta);
+if (esmsInitOptions.tsTransform) tsTransform = globalHook(esmsInitOptions.tsTransform);
 
 export const mapOverrides = esmsInitOptions.mapOverrides;
 
@@ -46,7 +48,14 @@ if (!nonce && hasDocument) {
 
 export const onerror = globalHook(esmsInitOptions.onerror || noop);
 
-export const { revokeBlobURLs, noLoadEventRetriggers, enforceIntegrity } = esmsInitOptions;
+export const {
+  revokeBlobURLs,
+  noLoadEventRetriggers,
+  enforceIntegrity,
+  nativePassthrough,
+  hotReload,
+  hotReloadInterval
+} = esmsInitOptions;
 
 function globalHook(name) {
   return typeof name === 'string' ? self[name] : name;

--- a/src/env.js
+++ b/src/env.js
@@ -1,3 +1,5 @@
+import { hotImportHook, hotResolveHook, hotMetaHook } from './hot-reload.js';
+
 if (self.importShim) {
   if (self.ESMS_DEBUG)
     console.info(
@@ -32,6 +34,17 @@ export let importHook,
     (hasDocument && document.currentScript && document.currentScript.src.replace(/(\.\w+)?\.js$/, '-typescript.js')) ||
     './es-module-shims-typescript.js';
 
+export const {
+  revokeBlobURLs,
+  noLoadEventRetriggers,
+  enforceIntegrity,
+  nativePassthrough,
+  hotReload,
+  hotReloadInterval = 100
+} = esmsInitOptions;
+
+const globalHook = name => (typeof name === 'string' ? self[name] : name);
+
 if (esmsInitOptions.onimport) importHook = globalHook(esmsInitOptions.onimport);
 if (esmsInitOptions.resolve) resolveHook = globalHook(esmsInitOptions.resolve);
 if (esmsInitOptions.fetch) fetchHook = globalHook(esmsInitOptions.fetch);
@@ -47,19 +60,6 @@ if (!nonce && hasDocument) {
 }
 
 export const onerror = globalHook(esmsInitOptions.onerror || noop);
-
-export const {
-  revokeBlobURLs,
-  noLoadEventRetriggers,
-  enforceIntegrity,
-  nativePassthrough,
-  hotReload,
-  hotReloadInterval
-} = esmsInitOptions;
-
-function globalHook(name) {
-  return typeof name === 'string' ? self[name] : name;
-}
 
 const enable = Array.isArray(esmsInitOptions.polyfillEnable) ? esmsInitOptions.polyfillEnable : [];
 const enableAll = esmsInitOptions.polyfillEnable === 'all' || enable.includes('all');
@@ -103,6 +103,4 @@ export const throwError = err => {
   (self.reportError || dispatchError)(err), void onerror(err);
 };
 
-export function fromParent(parent) {
-  return parent ? ` imported from ${parent}` : '';
-}
+export const fromParent = parent => (parent ? ` imported from ${parent}` : '');

--- a/src/env.js
+++ b/src/env.js
@@ -38,9 +38,9 @@ export const {
   revokeBlobURLs,
   noLoadEventRetriggers,
   enforceIntegrity,
-  nativePassthrough,
   hotReload,
-  hotReloadInterval = 100
+  hotReloadInterval = 100,
+  nativePassthrough = !hotReload
 } = esmsInitOptions;
 
 const globalHook = name => (typeof name === 'string' ? self[name] : name);
@@ -51,8 +51,7 @@ if (esmsInitOptions.fetch) fetchHook = globalHook(esmsInitOptions.fetch);
 if (esmsInitOptions.meta) metaHook = globalHook(esmsInitOptions.meta);
 if (esmsInitOptions.tsTransform) tsTransform = globalHook(esmsInitOptions.tsTransform);
 
-if (hotReload)
-  [importHook, resolveHook, metaHook] = initHotReload();
+if (hotReload) [importHook, resolveHook, metaHook] = initHotReload();
 
 export const mapOverrides = esmsInitOptions.mapOverrides;
 

--- a/src/hot-reload.js
+++ b/src/hot-reload.js
@@ -1,0 +1,4 @@
+import { hotReload, hotReloadInterval } from './env.js';
+
+if (hotReload) {
+}

--- a/src/hot-reload.js
+++ b/src/hot-reload.js
@@ -1,4 +1,154 @@
 import { hotReload, hotReloadInterval } from './env.js';
 
-if (hotReload) {
+let defaultResolve, getHotData, stripVersion, toVersioned, Hot;
+export const hotResolveHook = (id, parent, _defaultResolve) => {
+  if (!defaultResolve) defaultResolve = _defaultResolve;
+  const originalParent = stripVersion(parent);
+  const url = stripVersion(defaultResolve(id, originalParent));
+  const parents = getHotData(url).p;
+  if (!parents.includes(originalParent)) parents.push(originalParent);
+  return toVersioned(url);
+};
+export const hotImportHook = url => {
+  getHotData(url).e = true;
+};
+export const hotMetaHook = (metaObj, url) => {
+  metaObj.hot = new Hot(url);
+};
+
+if (false) {
+  Hot = class Hot {
+    constructor(url) {
+      this.data = getHotData((this.url = stripVersion(url))).d;
+    }
+    accept(deps, cb) {
+      if (typeof deps === 'function') {
+        cb = deps;
+        deps = null;
+      }
+      const hotData = getHotData(this.url);
+      (hotData.a = hotData.a || []).push([
+        typeof deps === 'string' ? defaultResolve(deps, this.url)
+        : deps ? deps.map(d => defaultResolve(d, this.url))
+        : null,
+        cb
+      ]);
+    }
+    dispose(cb) {
+      getHotData(this.url).u = cb;
+    }
+    decline() {
+      getHotData(this.url).r = true;
+    }
+    invalidate() {
+      invalidate(this.url);
+      queueInvalidationInterval();
+    }
+  };
+
+  const versionedRegEx = /\?v=\d+$/;
+  const stripVersion = url => {
+    const versionMatch = url.match(versionedRegEx);
+    if (!versionMatch) return url;
+    return url.slice(0, -versionMatch[0].length);
+  };
+
+  const versionedRegEx = /\?v=\d+$/;
+  stripVersion = url => {
+    const versionMatch = url.match(versionedRegEx);
+    if (!versionMatch) return url;
+    return url.slice(0, -versionMatch[0].length);
+  };
+
+  toVersioned = url => {
+    const { v } = getHotData(url);
+    return url + (v ? '?v=' + v : '');
+  };
+
+  let hotRegistry = {};
+  let curInvalidationRoots = new Set();
+  let curInvalidationInterval;
+
+  getHotData = url =>
+    hotRegistry[url] ||
+    (hotRegistry[url] = {
+      // version
+      v: 0,
+      // refresh (decline)
+      r: false,
+      // accept list ([deps, cb] pairs)
+      a: null,
+      // unload callback
+      u: null,
+      // entry point
+      e: false,
+      // hot data
+      d: {},
+      // parents
+      p: []
+    });
+
+  const invalidate = (url, fromUrl, seen = []) => {
+    if (!seen.includes(url)) {
+      seen.push(url);
+      const hotData = hotRegistry[url];
+      if (hotData) {
+        if (hotData.r) {
+          location.href = location.href;
+        } else {
+          if (
+            hotData.a &&
+            hotData.a.some(([d]) => d && (typeof d === 'string' ? d === fromUrl : d.includes(fromUrl)))
+          ) {
+            curInvalidationRoots.add(fromUrl);
+          } else {
+            if (hotData.u) hotData.u(hotData.d);
+            if (hotData.e || hotData.a) curInvalidationRoots.add(url);
+            hotData.v++;
+            if (!hotData.a) {
+              for (const parent of hotData.p) invalidate(parent, url, seen);
+            }
+          }
+        }
+      }
+    }
+  };
+
+  const queueInvalidationInterval = () => {
+    curInvalidationInterval = setTimeout(() => {
+      const earlyRoots = new Set();
+      for (const root of curInvalidationRoots) {
+        const promise = importShim(toVersioned(root));
+        const { a, p } = hotRegistry[root];
+        promise.then(m => {
+          if (a) a.every(([d, c]) => d === null && !earlyRoots.has(c) && c(m));
+          for (const parent of p) {
+            const hotData = hotRegistry[parent];
+            if (hotData && hotData.a)
+              hotData.a.every(
+                async ([d, c]) =>
+                  d &&
+                  !earlyRoots.has(c) &&
+                  (typeof d === 'string' ?
+                    d === root && c(m)
+                  : c(await Promise.all(d.map(d => (earlyRoots.push(c), importShim(toVersioned(d)))))))
+              );
+          }
+        });
+      }
+      curInvalidationRoots = new Set();
+    }, hotReloadInterval);
+  };
+
+  const baseURI = document.baseURI;
+  const websocket = new WebSocket(`ws://${esmsInitOptions.hotHost || new URL(baseURI).host}/watch`);
+  websocket.onmessage = evt => {
+    const { data } = evt;
+    if (data === 'Connected') {
+      console.info('Hot Reload ' + data);
+    } else {
+      invalidate(new URL(data, baseURI).href);
+      queueInvalidationInterval();
+    }
+  };
 }

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -2,17 +2,16 @@ import { mapOverrides, shimMode } from './env.js';
 
 const backslashRegEx = /\\/g;
 
-export function asURL(url) {
+export const asURL = url => {
   try {
     if (url.indexOf(':') !== -1) return new URL(url).href;
   } catch (_) {}
-}
+};
 
-export function resolveUrl(relUrl, parentUrl) {
-  return resolveIfNotPlainOrUrl(relUrl, parentUrl) || asURL(relUrl) || resolveIfNotPlainOrUrl('./' + relUrl, parentUrl);
-}
+export const resolveUrl = (relUrl, parentUrl) =>
+  resolveIfNotPlainOrUrl(relUrl, parentUrl) || asURL(relUrl) || resolveIfNotPlainOrUrl('./' + relUrl, parentUrl);
 
-export function resolveIfNotPlainOrUrl(relUrl, parentUrl) {
+export const resolveIfNotPlainOrUrl = (relUrl, parentUrl) => {
   const hIdx = parentUrl.indexOf('#'),
     qIdx = parentUrl.indexOf('?');
   if (hIdx + qIdx > -2)
@@ -100,9 +99,9 @@ export function resolveIfNotPlainOrUrl(relUrl, parentUrl) {
     if (segmentIndex !== -1) output.push(segmented.slice(segmentIndex));
     return parentUrl.slice(0, parentUrl.length - pathname.length) + output.join('');
   }
-}
+};
 
-export function resolveAndComposeImportMap(json, baseUrl, parentMap) {
+export const resolveAndComposeImportMap = (json, baseUrl, parentMap) => {
   const outMap = {
     imports: Object.assign({}, parentMap.imports),
     scopes: Object.assign({}, parentMap.scopes),
@@ -125,27 +124,27 @@ export function resolveAndComposeImportMap(json, baseUrl, parentMap) {
   if (json.integrity) resolveAndComposeIntegrity(json.integrity, outMap.integrity, baseUrl);
 
   return outMap;
-}
+};
 
-function getMatch(path, matchObj) {
+const getMatch = (path, matchObj) => {
   if (matchObj[path]) return path;
   let sepIndex = path.length;
   do {
     const segment = path.slice(0, sepIndex + 1);
     if (segment in matchObj) return segment;
   } while ((sepIndex = path.lastIndexOf('/', sepIndex - 1)) !== -1);
-}
+};
 
-function applyPackages(id, packages) {
+const applyPackages = (id, packages) => {
   const pkgName = getMatch(id, packages);
   if (pkgName) {
     const pkg = packages[pkgName];
     if (pkg === null) return;
     return pkg + id.slice(pkgName.length);
   }
-}
+};
 
-export function resolveImportMap(importMap, resolvedOrPlain, parentUrl) {
+export const resolveImportMap = (importMap, resolvedOrPlain, parentUrl) => {
   let scopeUrl = parentUrl && getMatch(parentUrl, importMap.scopes);
   while (scopeUrl) {
     const packageResolution = applyPackages(resolvedOrPlain, importMap.scopes[scopeUrl]);
@@ -153,9 +152,9 @@ export function resolveImportMap(importMap, resolvedOrPlain, parentUrl) {
     scopeUrl = getMatch(scopeUrl.slice(0, scopeUrl.lastIndexOf('/')), importMap.scopes);
   }
   return applyPackages(resolvedOrPlain, importMap.imports) || (resolvedOrPlain.indexOf(':') !== -1 && resolvedOrPlain);
-}
+};
 
-function resolveAndComposePackages(packages, outPackages, baseUrl, parentMap) {
+const resolveAndComposePackages = (packages, outPackages, baseUrl, parentMap) => {
   for (let p in packages) {
     const resolvedLhs = resolveIfNotPlainOrUrl(p, baseUrl) || p;
     if (
@@ -177,9 +176,9 @@ function resolveAndComposePackages(packages, outPackages, baseUrl, parentMap) {
     }
     console.warn(`es-module-shims: Mapping "${p}" -> "${packages[p]}" does not resolve`);
   }
-}
+};
 
-function resolveAndComposeIntegrity(integrity, outIntegrity, baseUrl) {
+const resolveAndComposeIntegrity = (integrity, outIntegrity, baseUrl) => {
   for (let p in integrity) {
     const resolvedLhs = resolveIfNotPlainOrUrl(p, baseUrl) || p;
     if (
@@ -193,4 +192,4 @@ function resolveAndComposeIntegrity(integrity, outIntegrity, baseUrl) {
     }
     outIntegrity[resolvedLhs] = integrity[p];
   }
-}
+};

--- a/test/fixtures/hotreload-accept-dep.js
+++ b/test/fixtures/hotreload-accept-dep.js
@@ -1,0 +1,12 @@
+import * as d from './hotreload.js';
+
+window.depUpdated = false;
+window.hotReloadAcceptDepCnt = window.hotReloadAcceptDepCnt || 0;
+window.hotReloadAcceptDepCnt++;
+
+if (import.meta.hot) {
+  import.meta.hot.accept('./hotreload.js', () => {
+    console.log("ACCEPT DEP");
+    window.depUpdated = true;
+  });
+}

--- a/test/fixtures/hotreload-parent.js
+++ b/test/fixtures/hotreload-parent.js
@@ -1,0 +1,8 @@
+import { p } from './hotreload.js';
+
+window.hotReloadParentCnt = window.hotReloadParentCnt || 0;
+window.hotReloadParentCnt++;
+
+export function getP () {
+  return p;
+}

--- a/test/fixtures/hotreload.js
+++ b/test/fixtures/hotreload.js
@@ -1,5 +1,5 @@
 import stylesheet from './sheet.css' with { type: 'css' }
-document.adoptedStyleSheets.push(stylesheet);
+document.adoptedStyleSheets = [...document.adoptedStyleSheets, stylesheet];
 
 if (import.meta.hot) {
   import.meta.hot.accept(newMod => {

--- a/test/fixtures/hotreload.js
+++ b/test/fixtures/hotreload.js
@@ -1,0 +1,17 @@
+import stylesheet from './sheet.css' with { type: 'css' }
+document.adoptedStyleSheets.push(stylesheet);
+
+if (import.meta.hot) {
+  import.meta.hot.accept(newMod => {
+    if (window.acceptInvalidate) {
+      import.meta.hot.invalidate();
+      return;
+    }
+    p = newMod.p;
+  });
+  import.meta.hot.dispose(() => {
+    window.disposed = true;
+  });
+}
+
+export var p = 10;

--- a/test/fixtures/json-assertion.js
+++ b/test/fixtures/json-assertion.js
@@ -1,3 +1,3 @@
 import json from './json.json' with { type: 'json' };
 
-export const m = json;
+export { json as m }

--- a/test/fixtures/test.ts
+++ b/test/fixtures/test.ts
@@ -1,3 +1,4 @@
+console.log('hi');
 export type P = number;
 
 export var p: number = 5;

--- a/test/hot.js
+++ b/test/hot.js
@@ -11,7 +11,7 @@ function syntheticResponse (contents, contentType = 'text/javascript') {
   };
 }
 
-const HOT_WAIT = 1000;
+const HOT_WAIT = 2000;
 
 let jsonSource = '{ "json": "module" }';
 let cssSource = 'body { background-color: mistyrose }';

--- a/test/hot.js
+++ b/test/hot.js
@@ -11,6 +11,8 @@ function syntheticResponse (contents, contentType = 'text/javascript') {
   };
 }
 
+const HOT_WAIT = 1000;
+
 let jsonSource = '{ "json": "module" }';
 let cssSource = 'body { background-color: mistyrose }';
 let hotreloadSource = 'export var p = 5';
@@ -34,7 +36,7 @@ suite('Hot reloading tests', () => {
       return fetch(url, opts);
     };
     importShim.hotReload('fixtures/hotreload.js');
-    await new Promise(resolve => setTimeout(resolve, 300));
+    await new Promise(resolve => setTimeout(resolve, HOT_WAIT));
     assert.equal(mod.getP(), 5);
     assert.equal(window.disposed, true);
     assert.equal(window.hotReloadParentCnt, 1);
@@ -49,11 +51,11 @@ suite('Hot reloading tests', () => {
     assert.equal(m.m.json, 'module');
     jsonSource = '{ "json": "hot" }';
     importShim.hotReload('fixtures/json.json');
-    await new Promise(resolve => setTimeout(resolve, 300));
+    await new Promise(resolve => setTimeout(resolve, HOT_WAIT));
     assert.equal(m.m.json, 'hot');
     jsonSource = '{ "json": "hot2" }';
     importShim.hotReload('fixtures/json.json');
-    await new Promise(resolve => setTimeout(resolve, 300));
+    await new Promise(resolve => setTimeout(resolve, HOT_WAIT));
     assert.equal(m.m.json, 'hot2');
   });
 
@@ -61,7 +63,7 @@ suite('Hot reloading tests', () => {
     window.acceptInvalidate = true;
     assert.equal(window.hotReloadParentCnt, 1);
     importShim.hotReload('fixtures/hotreload.js');
-    await new Promise(resolve => setTimeout(resolve, 300));
+    await new Promise(resolve => setTimeout(resolve, HOT_WAIT));
     assert.equal(window.hotReloadParentCnt, 2);
   });
 
@@ -70,7 +72,7 @@ suite('Hot reloading tests', () => {
     assert.equal(window.depUpdated, false);
     assert.equal(window.hotReloadAcceptDepCnt, 1);
     importShim.hotReload('fixtures/hotreload.js');
-    await new Promise(resolve => setTimeout(resolve, 300));
+    await new Promise(resolve => setTimeout(resolve, HOT_WAIT));
     assert.equal(window.depUpdated, true);
     assert.equal(window.hotReloadAcceptDepCnt, 1);
   });

--- a/test/hot.js
+++ b/test/hot.js
@@ -1,0 +1,77 @@
+function syntheticResponse (contents, contentType = 'text/javascript') {
+  return {
+    status: 200,
+    ok () {
+      return true;
+    },
+    headers: new Headers({ 'content-type': contentType }),
+    text () {
+      return contents;
+    }
+  };
+}
+
+let jsonSource = '{ "json": "module" }';
+let cssSource = 'body { background-color: mistyrose }';
+let hotreloadSource = 'export var p = 5';
+
+suite('Hot reloading tests', () => {
+  test('Hot reload', async function () {
+    const mod = await importShim('test/hotreload-parent.js');
+    assert.equal(mod.getP(), 10);
+    assert.equal(window.hotReloadParentCnt, 1);
+    assert.ok(!window.disposed);
+    hotFetch = (url, opts) => {
+      if (url.includes('test/fixtures/hotreload.js')) {
+        return syntheticResponse(hotreloadSource);
+      }
+      if (url.includes('test/fixtures/sheet.css')) {
+        return syntheticResponse(cssSource, 'text/css');
+      }
+      if (url.includes('test/fixtures/json.json')) {
+        return syntheticResponse(jsonSource, 'text/json');
+      }
+      return fetch(url, opts);
+    };
+    importShim.hotReload('fixtures/hotreload.js');
+    await new Promise(resolve => setTimeout(resolve, 300));
+    assert.equal(mod.getP(), 5);
+    assert.equal(window.disposed, true);
+    assert.equal(window.hotReloadParentCnt, 1);
+  });
+
+  test('CSS Hot reload', async function () {
+    importShim.hotReload('fixtures/sheet.css');
+  });
+
+  test('JSON Hot reload', async function () {
+    const m = await importShim('test/json-assertion.js');
+    assert.equal(m.m.json, 'module');
+    jsonSource = '{ "json": "hot" }';
+    importShim.hotReload('fixtures/json.json');
+    await new Promise(resolve => setTimeout(resolve, 300));
+    assert.equal(m.m.json, 'hot');
+    jsonSource = '{ "json": "hot2" }';
+    importShim.hotReload('fixtures/json.json');
+    await new Promise(resolve => setTimeout(resolve, 300));
+    assert.equal(m.m.json, 'hot2');
+  });
+
+  test('Accept invalidate', async function () {
+    window.acceptInvalidate = true;
+    assert.equal(window.hotReloadParentCnt, 1);
+    importShim.hotReload('fixtures/hotreload.js');
+    await new Promise(resolve => setTimeout(resolve, 300));
+    assert.equal(window.hotReloadParentCnt, 2);
+  });
+
+  test('Deps accept', async function () {
+    const m = await importShim('test/hotreload-accept-dep.js');
+    assert.equal(window.depUpdated, false);
+    assert.equal(window.hotReloadAcceptDepCnt, 1);
+    importShim.hotReload('fixtures/hotreload.js');
+    await new Promise(resolve => setTimeout(resolve, 300));
+    assert.equal(window.depUpdated, true);
+    assert.equal(window.hotReloadAcceptDepCnt, 1);
+  });
+});

--- a/test/shim.js
+++ b/test/shim.js
@@ -512,7 +512,7 @@ suite('Fetch hook', () => {
 suite('Resolve hook', () => {
   test('Should hook resolve', async function () {
     const resolveHook = window.resolveHook;
-    window.resolveHook = async (id, parentUrl, defaultResolve) => {
+    window.resolveHook = (id, parentUrl, defaultResolve) => {
       if (id === 'resolveTestModule') {
         return defaultResolve('./fixtures/es-modules/es6.js', parentUrl);
         // OR just resolve by yourself like this:

--- a/test/test-hot.html
+++ b/test/test-hot.html
@@ -1,5 +1,6 @@
 <!doctype html>
 <link rel="stylesheet" type="text/css" href="../node_modules/mocha/mocha.css"/>
+<script src="https://unpkg.com/construct-style-sheets-polyfill@3.0.0/dist/adoptedStyleSheets.js"></script>
 <script src="../node_modules/mocha/mocha.js"></script>
 <script type="importmap">
 {

--- a/test/test-hot.html
+++ b/test/test-hot.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<link rel="stylesheet" type="text/css" href="../node_modules/mocha/mocha.css"/>
+<script src="../node_modules/mocha/mocha.js"></script>
+<script type="importmap">
+{
+  "imports": {
+    "hotdep": "/test/fixtures/once.js",
+    "test/": "/test/fixtures/"
+  }
+}
+</script>
+<script>
+window.hotFetch = fetch;
+window._hotFetch = (url, opts) => {
+  return window.hotFetch(url, opts);
+};
+window.ESMS_DEBUG = true;
+</script>
+<script type="esms-options">{
+  "hotReload": true,
+  "fetch": "_hotFetch"
+}</script>
+<script type="module" noshim src="../src/es-module-shims.js"></script>
+
+<script type="module" noshim>
+  import { runMochaTests } from "./runMochaTests.js";
+  runMochaTests('hot');
+</script>
+
+<div id="mocha"></div>

--- a/test/typescript.js
+++ b/test/typescript.js
@@ -1,5 +1,5 @@
 suite('TypeScript loading tests', () => {
-  const timeoutInitPromise = new Promise(resolve => setTimeout(resolve, 1000));
+  const timeoutInitPromise = new Promise(resolve => setTimeout(resolve, 2000));
   test('Inline lang=ts support', async function () {
     await timeoutInitPromise;
     assert.ok(globalThis.inlineTypescriptNoWork === 1);


### PR DESCRIPTION
This implements the `import.meta.hot` API from Vite (https://vitejs.dev/guide/api-hmr.html).

The hot reloader is implemented as an extension using initialized hooks that executes before es-module-shims.

In addition this PR adds support for `nativePassthrough: false` to disable native passthrough, which is set automatically when enabling hot reloading.