### PR TITLE
fix: supported nested dynamic import structure replacements

### DIFF
--- a/test/fixtures/test-nested-dynamic.js
+++ b/test/fixtures/test-nested-dynamic.js
@@ -1,0 +1,1 @@
+export default import(`data:text/javascript,export default "${import.meta.url}"`);

--- a/test/fixtures/test-rel-dynamic.js
+++ b/test/fixtures/test-rel-dynamic.js
@@ -1,0 +1,1 @@
+export default import('./test-dep.js');

--- a/test/shim.js
+++ b/test/shim.js
@@ -116,6 +116,16 @@ suite('Basic loading tests', () => {
     await p;
   });
 
+  test('should support relative dynamic import', async function () {
+    const result = await (await importShim('./fixtures/test-rel-dynamic.js')).default;
+    assert.equal(result.hello, 'world');
+  });
+
+  test('should support nested import.meta.url in dynamic import', async function () {
+    const result = await (await importShim('./fixtures/test-nested-dynamic.js')).default;
+    assert.ok(result.default.endsWith('test-nested-dynamic.js'));
+  });
+
   test('Should import a module via a full url, with scheme', async function () {
     const url = window.location.href.replace('/test-shim.html', '/fixtures/es-modules/no-imports.js');
     assert.equal(url.slice(0, 4), 'http');
@@ -126,7 +136,7 @@ suite('Basic loading tests', () => {
 
   test('Should import a module via a full url, without scheme', async function () {
     const url = window.location.href.split('#')[0].split('?')[0]
-      .replace('/test-shim.html', '/fixtures/es-modules/no-imports.js')
+      .replace('/test-shim.html', '/fixtures/es-modules/no-imports.js') 
       .replace(/^http(s)?:/, '');
     assert.equal(url.slice(0, 2), '//');
     var m = await importShim(url);


### PR DESCRIPTION
Resolves https://github.com/guybedford/es-module-shims/issues/275 in supporting nested dynamic import structures, like `impor(new URL('./x', import.meta.url))` or even things like `import('./feature-' + (await import('feature')).name)`.