### PR TITLE
fix: bug where non-existing dynamic import would fail polyfill execution

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -433,8 +433,10 @@ function getOrCreateLoad (url, fetchOpts, parent, source) {
   load.L = load.f.then(async () => {
     let childFetchOpts = fetchOpts;
     load.d = (await Promise.all(load.a[0].map(async ({ n, d }) => {
-      if (d >= 0 && !supportsDynamicImport || d === 2 && !supportsImportMeta)
+      if (d >= 0 && !supportsDynamicImport || d === 2 && !supportsImportMeta) {
         load.n = true;
+        return;
+      }
       if (!n) return;
       const { r, b } = await resolve(n, load.r || load.u);
       if (b && (!supportsImportMaps || importMapSrcOrLazy))

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -433,11 +433,9 @@ function getOrCreateLoad (url, fetchOpts, parent, source) {
   load.L = load.f.then(async () => {
     let childFetchOpts = fetchOpts;
     load.d = (await Promise.all(load.a[0].map(async ({ n, d }) => {
-      if (d >= 0 && !supportsDynamicImport || d === 2 && !supportsImportMeta) {
+      if (d >= 0 && !supportsDynamicImport || d === 2 && !supportsImportMeta)
         load.n = true;
-        return;
-      }
-      if (!n) return;
+      if (d !== -1 || !n) return;
       const { r, b } = await resolve(n, load.r || load.u);
       if (b && (!supportsImportMaps || importMapSrcOrLazy))
         load.n = true;

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -439,7 +439,6 @@ function getOrCreateLoad (url, fetchOpts, parent, source) {
       const { r, b } = await resolve(n, load.r || load.u);
       if (b && (!supportsImportMaps || importMapSrcOrLazy))
         load.n = true;
-      if (d !== -1) return;
       if (skip && skip.test(r)) return { b: r };
       if (childFetchOpts.integrity)
         childFetchOpts = Object.assign({}, childFetchOpts, { integrity: undefined });


### PR DESCRIPTION
Resolves https://github.com/guybedford/es-module-shims/issues/280 where:

```js
var fs;
if (isNode) {
  fs = await import("fs");
} else {
  fs = ... browser implementation ...
}
```

would fail when `fs` cannot resolve.