### PR TITLE
fix: retriggering of readystatechange and DOMContentLoaded events

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -498,11 +498,14 @@ if (document.readyState === 'complete') {
   readyStateCompleteCheck();
 }
 else {
-  document.addEventListener('readystatechange', async () => {
+  function readyListener () {
     processImportMaps();
-    if (document.readyState === 'complete')
+    if (document.readyState === 'complete') {
       readyStateCompleteCheck();
-  });
+      document.removeEventListener('readystatechange', readyListener);
+    }
+  }
+  document.addEventListener('readystatechange', readyListener);
 }
 function readyStateCompleteCheck () {
   if (--readyStateCompleteCnt === 0 && !noLoadEventRetriggers)

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -500,8 +500,8 @@ if (document.readyState === 'complete') {
 else {
   document.addEventListener('readystatechange', async () => {
     processImportMaps();
-    await initPromise;
-    readyStateCompleteCheck();
+    if (document.readyState === 'complete')
+      readyStateCompleteCheck();
   });
 }
 function readyStateCompleteCheck () {
@@ -543,15 +543,15 @@ function processScript (script) {
     return;
   script.ep = true;
   // does this load block readystate complete
-  const blocksReady = script.getAttribute('async') === null && readyStateCompleteCnt > 0;
+  const isBlockingReadyScript = script.getAttribute('async') === null && readyStateCompleteCnt > 0;
   // does this load block DOMContentLoaded
-  const blocksDomContentLoaded = domContentLoadedCnt > 0;
-  if (blocksReady) readyStateCompleteCnt++;
-  if (blocksDomContentLoaded) domContentLoadedCnt++;
-  const loadPromise = topLevelLoad(script.src || pageBaseUrl, getFetchOpts(script), !script.src && script.innerHTML, !shimMode, blocksReady && lastStaticLoadPromise).catch(throwError);
-  if (blocksReady)
+  const isDomContentLoadedScript = domContentLoadedCnt > 0;
+  if (isBlockingReadyScript) readyStateCompleteCnt++;
+  if (isDomContentLoadedScript) domContentLoadedCnt++;
+  const loadPromise = topLevelLoad(script.src || pageBaseUrl, getFetchOpts(script), !script.src && script.innerHTML, !shimMode, isBlockingReadyScript && lastStaticLoadPromise).catch(throwError);
+  if (isBlockingReadyScript)
     lastStaticLoadPromise = loadPromise.then(readyStateCompleteCheck);
-  if (blocksDomContentLoaded)
+  if (isDomContentLoadedScript)
     loadPromise.then(domContentLoadedCheck);
 }
 

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -498,7 +498,8 @@ if (document.readyState === 'complete') {
   readyStateCompleteCheck();
 }
 else {
-  function readyListener () {
+  async function readyListener () {
+    await initPromise;
     processImportMaps();
     if (document.readyState === 'complete') {
       readyStateCompleteCheck();

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -153,6 +153,20 @@ const initPromise = featureDetectionPromise.then(() => {
     }).observe(document, { childList: true, subtree: true });
     processImportMaps();
     processScriptsAndPreloads();
+    if (document.readyState === 'complete') {
+      readyStateCompleteCheck();
+    }
+    else {
+      async function readyListener () {
+        await initPromise;
+        processImportMaps();
+        if (document.readyState === 'complete') {
+          readyStateCompleteCheck();
+          document.removeEventListener('readystatechange', readyListener);
+        }
+      }
+      document.addEventListener('readystatechange', readyListener);
+    }
     return lexer.init;
   }
 });
@@ -494,20 +508,6 @@ document.addEventListener('DOMContentLoaded', async () => {
 });
 
 let readyStateCompleteCnt = 1;
-if (document.readyState === 'complete') {
-  readyStateCompleteCheck();
-}
-else {
-  async function readyListener () {
-    await initPromise;
-    processImportMaps();
-    if (document.readyState === 'complete') {
-      readyStateCompleteCheck();
-      document.removeEventListener('readystatechange', readyListener);
-    }
-  }
-  document.addEventListener('readystatechange', readyListener);
-}
 function readyStateCompleteCheck () {
   if (--readyStateCompleteCnt === 0 && !noLoadEventRetriggers)
     document.dispatchEvent(new Event('readystatechange'));

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -543,16 +543,15 @@ function processScript (script) {
     return;
   script.ep = true;
   // does this load block readystate complete
-  const isReadyScript = readyStateCompleteCnt > 0;
+  const blocksReady = script.getAttribute('async') === null && readyStateCompleteCnt > 0;
   // does this load block DOMContentLoaded
-  const isDomContentLoadedScript = domContentLoadedCnt > 0;
-  if (isReadyScript) readyStateCompleteCnt++;
-  if (isDomContentLoadedScript) domContentLoadedCnt++;
-  const blocks = script.getAttribute('async') === null && isReadyScript;
-  const loadPromise = topLevelLoad(script.src || pageBaseUrl, getFetchOpts(script), !script.src && script.innerHTML, !shimMode, blocks && lastStaticLoadPromise).catch(throwError);
-  if (blocks)
+  const blocksDomContentLoaded = domContentLoadedCnt > 0;
+  if (blocksReady) readyStateCompleteCnt++;
+  if (blocksDomContentLoaded) domContentLoadedCnt++;
+  const loadPromise = topLevelLoad(script.src || pageBaseUrl, getFetchOpts(script), !script.src && script.innerHTML, !shimMode, blocksReady && lastStaticLoadPromise).catch(throwError);
+  if (blocksReady)
     lastStaticLoadPromise = loadPromise.then(readyStateCompleteCheck);
-  if (isDomContentLoadedScript)
+  if (blocksDomContentLoaded)
     loadPromise.then(domContentLoadedCheck);
 }
 

--- a/test/test-preload-case.html
+++ b/test/test-preload-case.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.esm.browser.js">
   <script type="importmap">
     { "imports": { "vue": "https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.esm.browser.js" } }
   </script>
+  <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.esm.browser.js">
   <script type="module" src="/src/es-module-shims.js"></script>
   <script type="module">
     import Vue from 'vue'


### PR DESCRIPTION
This fixes the bug https://github.com/guybedford/es-module-shims/issues/286, where the [retriggering of the readystatechange](https://github.com/guybedford/es-module-shims#no-load-event-retriggers) event would fire too early, instead of waiting on the ES module scripts when these scripts were detected too late in the loading process. 

In addition some further event handling cleanup is included.