### PR TITLE
Add nonce to feature detection iframe

### DIFF
--- a/src/features.js
+++ b/src/features.js
@@ -28,6 +28,7 @@ export const featureDetectionPromise = Promise.resolve(supportsDynamicImportChec
       };
       const iframe = document.createElement('iframe');
       iframe.style.display = 'none';
+      iframe.setAttribute('nonce', nonce);
       iframe.srcdoc = `<script type=importmap nonce="${nonce}">{"imports":{"x":"data:text/javascript,"}}<${''}/script><script nonce="${nonce}">import('x').then(()=>1,()=>0).then(v=>parent._$s(v))<${''}/script>`;
       document.head.appendChild(iframe);
     })


### PR DESCRIPTION
es-module-shims creates an iframe to do feature
detection. However, if a site is using CSP then
this iframe is blocked unless the CSP config allows
frame-src to use blobs, which prevents es-module-shims
from running. In chrome that error looks like:

    Refused to frame 'blob:http://localhost:3000/477a88e6-fb4c-48fd-a677-2ba7fb69fc45'
    because it violates the following Content Security Policy directive:
    "default-src 'self' https:". Note that 'frame-src' was not explicitly set,
    so 'default-src' is used as a fallback.

In safari it looks like:

    Refused to load blob:https://cors-test.herokuapp.com/12cecc46-329e-4791-a73b-4824852d1ad1
    because it appears in neither the child-src directive nor the default-src
    directive of the Content Security Policy.

To prevent this, I've updated `feature.js` to set a nonce
value on the iframe, and this fixes the error.