### PR TITLE
feat: utilize and polyfill HTMLScriptElement.supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,6 +675,8 @@ window.polyfilling = () => console.log('The polyfill is actively applying');
 
 The default hook will log a message to the console with `console.info` noting that polyfill mode is enabled and that the native error can be ignored.
 
+Overriding this hook with an empty function will disable the default polyfill log output.
+
 In the above, running in latest Chromium browsers, nothing will be logged, while running in an older browser that does not support newer features like import maps the console log will be output.
 
 #### Error hook

--- a/src/env.js
+++ b/src/env.js
@@ -30,8 +30,6 @@ export const onpolyfill = esmsInitOptions.onpolyfill ? globalHook(esmsInitOption
   console.log('%c^^ Module TypeError above is polyfilled and can be ignored ^^', 'font-weight:900;color:#391');
 };
 
-export const supports = HTMLScriptElement.supports || (type => type === 'classic' || type === 'module');
-
 export const { revokeBlobURLs, noLoadEventRetriggers, enforceIntegrity } = esmsInitOptions;
 
 function globalHook (name) {

--- a/src/env.js
+++ b/src/env.js
@@ -30,6 +30,8 @@ export const onpolyfill = esmsInitOptions.onpolyfill ? globalHook(esmsInitOption
   console.log('%c^^ Module TypeError above is polyfilled and can be ignored ^^', 'font-weight:900;color:#391');
 };
 
+export const supports = HTMLScriptElement.supports || (() => type === 'classic' || type === 'module');
+
 export const { revokeBlobURLs, noLoadEventRetriggers, enforceIntegrity } = esmsInitOptions;
 
 function globalHook (name) {

--- a/src/env.js
+++ b/src/env.js
@@ -30,7 +30,7 @@ export const onpolyfill = esmsInitOptions.onpolyfill ? globalHook(esmsInitOption
   console.log('%c^^ Module TypeError above is polyfilled and can be ignored ^^', 'font-weight:900;color:#391');
 };
 
-export const supports = HTMLScriptElement.supports || (() => type === 'classic' || type === 'module');
+export const supports = HTMLScriptElement.supports || (type => type === 'classic' || type === 'module');
 
 export const { revokeBlobURLs, noLoadEventRetriggers, enforceIntegrity } = esmsInitOptions;
 

--- a/src/env.js
+++ b/src/env.js
@@ -26,7 +26,9 @@ if (!nonce) {
 }
 
 export const onerror = globalHook(esmsInitOptions.onerror || noop);
-export const onpolyfill = esmsInitOptions.onpolyfill ? globalHook(esmsInitOptions.onpolyfill) : () => console.log('%c^^ Module TypeError above is polyfilled and can be ignored ^^', 'font-weight:900;color:#391');
+export const onpolyfill = esmsInitOptions.onpolyfill ? globalHook(esmsInitOptions.onpolyfill) : () => {
+  console.log('%c^^ Module TypeError above is polyfilled and can be ignored ^^', 'font-weight:900;color:#391');
+};
 
 export const { revokeBlobURLs, noLoadEventRetriggers, enforceIntegrity } = esmsInitOptions;
 

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -135,6 +135,10 @@ const initPromise = featureDetectionPromise.then(() => {
     }
   }
   baselinePassthrough = esmsInitOptions.polyfillEnable !== true && supportsDynamicImport && supportsImportMeta && supportsImportMaps && (!jsonModulesEnabled || supportsJsonAssertions) && (!cssModulesEnabled || supportsCssAssertions) && !importMapSrcOrLazy && !self.ESMS_DEBUG;
+  if (!supportsImportMaps && typeof HTMLScriptElement === 'function') {
+    const s = HTMLScriptElement.supports || (() => type === 'classic' || type === 'module');
+    HTMLScriptElement.supports = type => s(type) || type === 'importmap';
+  }
   if (shimMode || !baselinePassthrough) {
     new MutationObserver(mutations => {
       for (const mutation of mutations) {

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -24,8 +24,7 @@ import {
   onpolyfill,
   enforceIntegrity,
   fromParent,
-  esmsInitOptions,
-  supports,
+  esmsInitOptions
 } from './env.js';
 import { dynamicImport } from './dynamic-import-csp.js';
 import {

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -136,8 +136,10 @@ const initPromise = featureDetectionPromise.then(() => {
     }
   }
   baselinePassthrough = esmsInitOptions.polyfillEnable !== true && supportsDynamicImport && supportsImportMeta && supportsImportMaps && (!jsonModulesEnabled || supportsJsonAssertions) && (!cssModulesEnabled || supportsCssAssertions) && !importMapSrcOrLazy && !self.ESMS_DEBUG;
-  if (!supportsImportMaps && typeof HTMLScriptElement === 'function')
-    HTMLScriptElement.supports = type => supports(type) || type === 'importmap';
+  if (!supportsImportMaps) {
+    const supports = HTMLScriptElement.supports || (type => type === 'classic' || type === 'module');
+    HTMLScriptElement.supports = type => type === 'importmap' || supports(type);
+  }
   if (shimMode || !baselinePassthrough) {
     new MutationObserver(mutations => {
       for (const mutation of mutations) {

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -135,10 +135,8 @@ const initPromise = featureDetectionPromise.then(() => {
     }
   }
   baselinePassthrough = esmsInitOptions.polyfillEnable !== true && supportsDynamicImport && supportsImportMeta && supportsImportMaps && (!jsonModulesEnabled || supportsJsonAssertions) && (!cssModulesEnabled || supportsCssAssertions) && !importMapSrcOrLazy && !self.ESMS_DEBUG;
-  if (!supportsImportMaps && typeof HTMLScriptElement === 'function') {
-    const s = HTMLScriptElement.supports || (() => type === 'classic' || type === 'module');
-    HTMLScriptElement.supports = type => s(type) || type === 'importmap';
-  }
+  if (!supportsImportMaps && typeof HTMLScriptElement === 'function')
+    HTMLScriptElement.supports = type => supports(type) || type === 'importmap';
   if (shimMode || !baselinePassthrough) {
     new MutationObserver(mutations => {
       for (const mutation of mutations) {

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -25,6 +25,7 @@ import {
   enforceIntegrity,
   fromParent,
   esmsInitOptions,
+  supports,
 } from './env.js';
 import { dynamicImport } from './dynamic-import-csp.js';
 import {

--- a/src/features.js
+++ b/src/features.js
@@ -1,5 +1,5 @@
 import { dynamicImport, supportsDynamicImportCheck } from './dynamic-import-csp.js';
-import { createBlob, noop, nonce, cssModulesEnabled, jsonModulesEnabled, supports } from './env.js';
+import { createBlob, noop, nonce, cssModulesEnabled, jsonModulesEnabled } from './env.js';
 
 // support browsers without dynamic import support (eg Firefox 6x)
 export let supportsJsonAssertions = false;
@@ -19,7 +19,7 @@ export const featureDetectionPromise = Promise.resolve(supportsDynamicImportChec
     dynamicImport(createBlob('import.meta')).then(() => supportsImportMeta = true, noop),
     cssModulesEnabled && dynamicImport(createBlob('import"data:text/css,{}"assert{type:"css"}')).then(() => supportsCssAssertions = true, noop),
     jsonModulesEnabled && dynamicImport(createBlob('import"data:text/json,{}"assert{type:"json"}')).then(() => supportsJsonAssertions = true, noop),
-    supports('importmap') || new Promise(resolve => {
+    HTMLScriptElement.supports ? supportsImportMaps = HTMLScriptElement.supports('importmap') : new Promise(resolve => {
       self._$s = v => {
         document.head.removeChild(iframe);
         if (v) supportsImportMaps = true;

--- a/src/features.js
+++ b/src/features.js
@@ -1,5 +1,5 @@
 import { dynamicImport, supportsDynamicImportCheck } from './dynamic-import-csp.js';
-import { createBlob, noop, nonce, cssModulesEnabled, jsonModulesEnabled } from './env.js';
+import { createBlob, noop, nonce, cssModulesEnabled, jsonModulesEnabled, supports } from './env.js';
 
 // support browsers without dynamic import support (eg Firefox 6x)
 export let supportsJsonAssertions = false;
@@ -19,7 +19,7 @@ export const featureDetectionPromise = Promise.resolve(supportsDynamicImportChec
     dynamicImport(createBlob('import.meta')).then(() => supportsImportMeta = true, noop),
     cssModulesEnabled && dynamicImport(createBlob('import"data:text/css,{}"assert{type:"css"}')).then(() => supportsCssAssertions = true, noop),
     jsonModulesEnabled && dynamicImport(createBlob('import"data:text/json,{}"assert{type:"json"}')).then(() => supportsJsonAssertions = true, noop),
-    new Promise(resolve => {
+    supports('importmap') || new Promise(resolve => {
       self._$s = v => {
         document.head.removeChild(iframe);
         if (v) supportsImportMaps = true;


### PR DESCRIPTION
This updates es-module-shims's import map detection to use the `HTMLScriptElement.supports('importmap')` API if available.

In addition this resolves https://github.com/guybedford/es-module-shims/issues/284, in turn adding support for polyfilling `HTMLScriptElement.supports('importmap')` support if the polyfill kicks in.