### PR TITLE
Set default csp policy

### DIFF
--- a/test/test-csp.html
+++ b/test/test-csp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'nonce-asdf' unpkg.com;" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'nonce-asdf' unpkg.com;" />
 <link rel="stylesheet" type="text/css" href="../node_modules/mocha/mocha.css"/>
 <script src="../node_modules/mocha/mocha.js"></script>
 <script src="https://unpkg.com/construct-style-sheets-polyfill@3.0.0/dist/adoptedStyleSheets.js"></script>


### PR DESCRIPTION
Previously there was no default set so
any files could be loaded from anywhere
(except for scripts which were allow-listed).

This changes the csp so that by default
only localhost can be used. This should
detect issues like #290.