### PR TITLE
fix: import.meta polyfill, better feature detection

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -451,7 +451,7 @@ function getOrCreateLoad (url, fetchOpts, parent, source) {
   load.L = load.f.then(async () => {
     let childFetchOpts = fetchOpts;
     load.d = (await Promise.all(load.a[0].map(async ({ n, d }) => {
-      if (d >= 0 && !supportsDynamicImport || d === 2 && !supportsImportMeta)
+      if (d >= 0 && !supportsDynamicImport || d === -2 && !supportsImportMeta)
         load.n = true;
       if (d !== -1 || !n) return;
       const { r, b } = await resolve(n, load.r || load.u);

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -451,7 +451,7 @@ function getOrCreateLoad (url, fetchOpts, parent, source) {
   load.L = load.f.then(async () => {
     let childFetchOpts = fetchOpts;
     load.d = (await Promise.all(load.a[0].map(async ({ n, d }) => {
-      if (d >= 0 && !supportsDynamicImport || d === -2 && !supportsImportMeta)
+      if (d >= 0 && !supportsDynamicImport || d === 2 && !supportsImportMeta)
         load.n = true;
       if (d !== -1 || !n) return;
       const { r, b } = await resolve(n, load.r || load.u);

--- a/src/features.js
+++ b/src/features.js
@@ -10,7 +10,7 @@ export let supportsImportMaps = HTMLScriptElement.supports ? HTMLScriptElement.s
 
 export let supportsDynamicImport = false;
 
-export const featureDetectionPromise = Promise.resolve(supportsDynamicImportCheck).then(_supportsDynamicImport => {
+export const featureDetectionPromise = Promise.resolve(supportsImportMaps || supportsDynamicImportCheck).then(_supportsDynamicImport => {
   if (!_supportsDynamicImport)
     return;
   supportsDynamicImport = true;

--- a/src/features.js
+++ b/src/features.js
@@ -6,7 +6,7 @@ export let supportsJsonAssertions = false;
 export let supportsCssAssertions = false;
 
 export let supportsImportMeta = false;
-export let supportsImportMaps = false;
+export let supportsImportMaps = HTMLScriptElement.supports ? HTMLScriptElement.supports('importmap') : false;
 
 export let supportsDynamicImport = false;
 
@@ -16,10 +16,10 @@ export const featureDetectionPromise = Promise.resolve(supportsDynamicImportChec
   supportsDynamicImport = true;
 
   return Promise.all([
-    dynamicImport(createBlob('import.meta')).then(() => supportsImportMeta = true, noop),
+    supportsImportMaps || dynamicImport(createBlob('import.meta')).then(() => supportsImportMeta = true, noop),
     cssModulesEnabled && dynamicImport(createBlob('import"data:text/css,{}"assert{type:"css"}')).then(() => supportsCssAssertions = true, noop),
     jsonModulesEnabled && dynamicImport(createBlob('import"data:text/json,{}"assert{type:"json"}')).then(() => supportsJsonAssertions = true, noop),
-    HTMLScriptElement.supports ? supportsImportMaps = HTMLScriptElement.supports('importmap') : new Promise(resolve => {
+    supportsImportMaps || new Promise(resolve => {
       self._$s = v => {
         document.head.removeChild(iframe);
         if (v) supportsImportMaps = true;

--- a/src/features.js
+++ b/src/features.js
@@ -5,9 +5,8 @@ import { createBlob, noop, nonce, cssModulesEnabled, jsonModulesEnabled } from '
 export let supportsJsonAssertions = false;
 export let supportsCssAssertions = false;
 
-export let supportsImportMeta = false;
 export let supportsImportMaps = HTMLScriptElement.supports ? HTMLScriptElement.supports('importmap') : false;
-
+export let supportsImportMeta = supportsImportMaps;
 export let supportsDynamicImport = false;
 
 export const featureDetectionPromise = Promise.resolve(supportsImportMaps || supportsDynamicImportCheck).then(_supportsDynamicImport => {

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -21,6 +21,7 @@ suite('Polyfill tests', () => {
     throw new Error('Should fail');
   });
 
+  if (!navigator.userAgent.includes('Firefox/60.0') && !navigator.userAgent.includes('Firefox/67.0'))
   test('should support css imports', async function () {
     await importShim('./fixtures/css-assertion.js');
     assert.equal(window.cssAssertion, true);

--- a/test/test-csp.html
+++ b/test/test-csp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'nonce-asdf' unpkg.com;" />
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'nonce-asdf' unpkg.com;" />
 <link rel="stylesheet" type="text/css" href="../node_modules/mocha/mocha.css"/>
 <script src="../node_modules/mocha/mocha.js"></script>
 <script src="https://unpkg.com/construct-style-sheets-polyfill@3.0.0/dist/adoptedStyleSheets.js"></script>

--- a/test/test-csp.html
+++ b/test/test-csp.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'nonce-asdf' unpkg.com;" />
+<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'nonce-asdf' unpkg.com;" />
 <link rel="stylesheet" type="text/css" href="../node_modules/mocha/mocha.css"/>
 <script src="../node_modules/mocha/mocha.js"></script>
 <script src="https://unpkg.com/construct-style-sheets-polyfill@3.0.0/dist/adoptedStyleSheets.js"></script>


### PR DESCRIPTION
This fixes a typo in the case of a module with only an `import.meta` polyfill.

In addition we automatically treat `import.meta` and dynamic imports as supported if the browser supports import maps, since all browsers that support import maps support import meta (there were two compat cases where dynamic imports were supported before import meta - Opera and Safari). This results in less unnecessary feature detection work.