### PR TITLE
Enable es-module-shims usage in web workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,10 +292,21 @@ While in polyfill mode the same restrictions apply that multiple import maps, im
 To make it easy to keep track of import map state, es-module-shims provides a `importShim.getImportMap` utility function, available only in shim mode.
 
 ```js
-const importMap = importShim.getImportMap()
+const importMap = importShim.getImportMap();
 
 // importMap will be an object in the same shape as the json in a importmap script
 ```
+
+#### Setting current import map state
+To make it easy to set the import map state, es-module-shims provides a `importShim.setImportMap` utility function, available only in shim mode.
+
+```js
+// importMap will be an object in the same shape as the json in a importmap script
+const importMap = { imports: {/*...*/}, scopes: {/*...*/} };
+
+importShim.setImportMap(importMap);
+```
+
 
 ### Dynamic Import
 
@@ -435,16 +446,21 @@ An example of ES Module Shims usage in web workers is provided below:
  */
 function getWorkerScriptURL(aURL) {
   // baseURL, esModuleShimsURL are considered to be known in advance
-  // esModuleShimsURL - must point to the non-CSP build of ES Module Shims, namely the `es-module-shim.wasm.js` output: es-module-shims/dist/es-module-shims.wasm.js
+  // esModuleShimsURL - must point to the non-CSP build of ES Module Shims, 
+  // namely the `es-module-shim.wasm.js` output: es-module-shims/dist/es-module-shims.wasm.js
 
   return URL.createObjectURL(new Blob(
-    [`importScripts('${new URL(esModuleShimsURL, baseURL).href}');importShim.setImportMap(${JSON.stringify(importShim.getImportMap())});importShim('${new URL(aURL, baseURL).href}').catch(e=>setTimeout(()=>{throw e}))`],
+    [
+      `importScripts('${new URL(esModuleShimsURL, baseURL).href}');
+      importShim.setImportMap(${JSON.stringify(importShim.getImportMap())});
+      importShim('${new URL(aURL, baseURL).href}').catch(e => setTimeout(() => { throw e; }))`
+    ],
     { type: 'application/javascript' }))
 }
 
 const worker = new Worker(getWorkerScriptURL('myEsModule.js'));
 ```
-> For now, in web workers must be used the non-CSP build of ES Module Shims, namely the `es-module-shim.wasm.js` output.
+> For now, in web workers must be used the non-CSP build of ES Module Shims, namely the `es-module-shim.wasm.js` output: es-module-shims/dist/es-module-shims.wasm.js.
 
 ## Init Options
 

--- a/README.md
+++ b/README.md
@@ -298,13 +298,13 @@ const importMap = importShim.getImportMap();
 ```
 
 #### Setting current import map state
-To make it easy to set the import map state, es-module-shims provides a `importShim.extendImportMap` utility function, available only in shim mode.
+To make it easy to set the import map state, es-module-shims provides a `importShim.addImportMap` utility function, available only in shim mode.
 
 ```js
 // importMap will be an object in the same shape as the json in a importmap script
 const importMap = { imports: {/*...*/}, scopes: {/*...*/} };
 
-importShim.extendImportMap(importMap);
+importShim.addImportMap(importMap);
 ```
 
 
@@ -452,7 +452,7 @@ function getWorkerScriptURL(aURL) {
   return URL.createObjectURL(new Blob(
     [
       `importScripts('${new URL(esModuleShimsURL, baseURL).href}');
-      importShim.setImportMap(${JSON.stringify(importShim.getImportMap())});
+      importShim.addImportMap(${JSON.stringify(importShim.getImportMap())});
       importShim('${new URL(aURL, baseURL).href}').catch(e => setTimeout(() => { throw e; }))`
     ],
     { type: 'application/javascript' }))

--- a/README.md
+++ b/README.md
@@ -423,6 +423,29 @@ var resolvedUrl = import.meta.resolve('dep', 'https://site.com/another/scope');
 
 Node.js also implements a similar API, although it's in the process of shifting to a synchronous resolver.
 
+### Module Workers
+ES Module Shims can be used in module workers in browsers that provide dynamic import in worker environments, which at the moment are Chrome(80+), Edge(80+), Safari(15+).
+
+An example of ES Module Shims usage in web workers is provided below:
+```js
+/**
+ * 
+ * @param {string} aURL a string representing the URL of the module script the worker will execute.
+ * @returns {string} The string representing the URL of the script the worker will execute.
+ */
+function getWorkerScriptURL(aURL) {
+  // baseURL, esModuleShimsURL are considered to be known in advance
+  // esModuleShimsURL - must point to the non-CSP build of ES Module Shims, namely the `es-module-shim.wasm.js` output: es-module-shims/dist/es-module-shims.wasm.js
+
+  return URL.createObjectURL(new Blob(
+    [`importScripts('${new URL(esModuleShimsURL, baseURL).href}');importShim.setImportMap(${JSON.stringify(importShim.getImportMap())});importShim('${new URL(aURL, baseURL).href}').catch(e=>setTimeout(()=>{throw e}))`],
+    { type: 'application/javascript' }))
+}
+
+const worker = new Worker(getWorkerScriptURL('myEsModule.js'));
+```
+> For now, in web workers must be used the non-CSP build of ES Module Shims, namely the `es-module-shim.wasm.js` output.
+
 ## Init Options
 
 Provide a `esmsInitOptions` on the global scope before `es-module-shims` is loaded to configure various aspects of the module loading process:

--- a/README.md
+++ b/README.md
@@ -298,13 +298,13 @@ const importMap = importShim.getImportMap();
 ```
 
 #### Setting current import map state
-To make it easy to set the import map state, es-module-shims provides a `importShim.setImportMap` utility function, available only in shim mode.
+To make it easy to set the import map state, es-module-shims provides a `importShim.extendImportMap` utility function, available only in shim mode.
 
 ```js
 // importMap will be an object in the same shape as the json in a importmap script
 const importMap = { imports: {/*...*/}, scopes: {/*...*/} };
 
-importShim.setImportMap(importMap);
+importShim.extendImportMap(importMap);
 ```
 
 

--- a/src/dynamic-import.js
+++ b/src/dynamic-import.js
@@ -1,4 +1,4 @@
-import { createBlob, baseUrl, nonce } from './env.js';
+import { createBlob, baseUrl, nonce, hasDocument } from './env.js';
 
 export let supportsDynamicImportCheck = false;
 
@@ -9,7 +9,7 @@ try {
 }
 catch (e) {}
 
-if (!supportsDynamicImportCheck) {
+if (hasDocument && !supportsDynamicImportCheck) {
   let err;
   window.addEventListener('error', _err => err = _err);
   dynamicImport = (url, { errUrl = url }) => {

--- a/src/env.js
+++ b/src/env.js
@@ -48,23 +48,11 @@ export function setShimMode () {
 
 export const edge = !navigator.userAgentData && !!navigator.userAgent.match(/Edge\/\d+\.\d+/);
 
-function getBaseURL() {
-  let baseUrl;
-
-  if (hasDocument) {
-    baseUrl = document.baseURI;
-  }
-
-  if (!baseUrl && typeof location !== 'undefined') {
-    baseUrl = location.href.split('#')[0].split('?')[0];
-    const lastSepIndex = baseUrl.lastIndexOf('/');
-    if (lastSepIndex !== -1)
-      baseUrl = baseUrl.slice(0, lastSepIndex + 1);
-  }
-
-  return baseUrl;
-}
-export const baseUrl = getBaseURL();
+export const baseUrl = hasDocument
+  ? document.baseURI
+  : `${location.protocol}//${location.host}${location.pathname.includes('/') 
+    ? location.pathname.slice(0, location.pathname.lastIndexOf('/') + 1) 
+    : location.pathname}`;
 
 export function createBlob (source, type = 'text/javascript') {
   return URL.createObjectURL(new Blob([source], { type }));

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -100,7 +100,7 @@ function metaResolve (id, parentUrl = this.url) {
 
 importShim.resolve = resolveSync;
 importShim.getImportMap = () => JSON.parse(JSON.stringify(importMap));
-importShim.extendImportMap = importMapIn => {
+importShim.addImportMap = importMapIn => {
   if (!shimMode) throw new Error('Unsupported in polyfill mode.');
   importMap = resolveAndComposeImportMap(importMapIn, pageBaseUrl, importMap);
 }

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -100,9 +100,9 @@ function metaResolve (id, parentUrl = this.url) {
 
 importShim.resolve = resolveSync;
 importShim.getImportMap = () => JSON.parse(JSON.stringify(importMap));
-importShim.setImportMap = importMapIn => {
+importShim.extendImportMap = importMapIn => {
   if (!shimMode) throw new Error('Unsupported in polyfill mode.');
-  importMap = JSON.parse(JSON.stringify(importMapIn));
+  importMap = resolveAndComposeImportMap(importMapIn, pageBaseUrl, importMap);
 }
 
 const registry = importShim._r = {};

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -68,7 +68,9 @@ async function importShim (id, ...args) {
   await initPromise;
   if (importHook) await importHook(id, typeof args[1] !== 'string' ? args[1] : {}, parentUrl);
   if (acceptingImportMaps || shimMode || !baselinePassthrough) {
-    processImportMaps();
+    if (hasDocument)
+      processImportMaps();
+
     if (!shimMode)
       acceptingImportMaps = false;
   }
@@ -471,8 +473,6 @@ function getOrCreateLoad (url, fetchOpts, parent, source) {
 }
 
 function processScriptsAndPreloads () {
-  if (!hasDocument) return;
-
   for (const script of document.querySelectorAll(shimMode ? 'script[type=module-shim]' : 'script[type=module]'))
     processScript(script);
   for (const link of document.querySelectorAll(shimMode ? 'link[rel=modulepreload-shim]' : 'link[rel=modulepreload]'))
@@ -480,8 +480,6 @@ function processScriptsAndPreloads () {
 }
 
 function processImportMaps () {
-  if (!hasDocument) return;
-
   for (const script of document.querySelectorAll(shimMode ? 'script[type="importmap-shim"]' : 'script[type="importmap"]'))
     processImportMap(script);
 }
@@ -509,7 +507,7 @@ function domContentLoadedCheck () {
     document.dispatchEvent(new Event('DOMContentLoaded'));
 }
 // this should always trigger because we assume es-module-shims is itself a domcontentloaded requirement
-if(hasDocument) {
+if (hasDocument) {
   document.addEventListener('DOMContentLoaded', async () => {
     await initPromise;
     domContentLoadedCheck();

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -24,7 +24,8 @@ import {
   onpolyfill,
   enforceIntegrity,
   fromParent,
-  esmsInitOptions
+  esmsInitOptions,
+  hasDocument
 } from './env.js';
 import { dynamicImport } from './dynamic-import-csp.js';
 import {
@@ -97,6 +98,7 @@ function metaResolve (id, parentUrl = this.url) {
 
 importShim.resolve = resolveSync;
 importShim.getImportMap = () => JSON.parse(JSON.stringify(importMap));
+importShim.setImportMap = (importMapIn) => Object.assign(importMap, JSON.parse(JSON.stringify(importMapIn)));
 
 const registry = importShim._r = {};
 
@@ -135,41 +137,42 @@ const initPromise = featureDetectionPromise.then(() => {
     }
   }
   baselinePassthrough = esmsInitOptions.polyfillEnable !== true && supportsDynamicImport && supportsImportMeta && supportsImportMaps && (!jsonModulesEnabled || supportsJsonAssertions) && (!cssModulesEnabled || supportsCssAssertions) && !importMapSrcOrLazy && !self.ESMS_DEBUG;
-  if (!supportsImportMaps) {
+  if (hasDocument && !supportsImportMaps) {
     const supports = HTMLScriptElement.supports || (type => type === 'classic' || type === 'module');
     HTMLScriptElement.supports = type => type === 'importmap' || supports(type);
   }
   if (shimMode || !baselinePassthrough) {
-    new MutationObserver(mutations => {
-      for (const mutation of mutations) {
-        if (mutation.type !== 'childList') continue;
-        for (const node of mutation.addedNodes) {
-          if (node.tagName === 'SCRIPT') {
-            if (node.type === (shimMode ? 'module-shim' : 'module'))
-              processScript(node);
-            if (node.type === (shimMode ? 'importmap-shim' : 'importmap'))
-              processImportMap(node);
+    if (hasDocument) {
+      new MutationObserver(mutations => {
+        for (const mutation of mutations) {
+          if (mutation.type !== 'childList') continue;
+          for (const node of mutation.addedNodes) {
+            if (node.tagName === 'SCRIPT') {
+              if (node.type === (shimMode ? 'module-shim' : 'module'))
+                processScript(node);
+              if (node.type === (shimMode ? 'importmap-shim' : 'importmap'))
+                processImportMap(node);
+            } else if (node.tagName === 'LINK' && node.rel === (shimMode ? 'modulepreload-shim' : 'modulepreload'))
+              processPreload(node);
           }
-          else if (node.tagName === 'LINK' && node.rel === (shimMode ? 'modulepreload-shim' : 'modulepreload'))
-            processPreload(node);
         }
-      }
-    }).observe(document, { childList: true, subtree: true });
-    processImportMaps();
-    processScriptsAndPreloads();
-    if (document.readyState === 'complete') {
-      readyStateCompleteCheck();
-    }
-    else {
-      async function readyListener () {
-        await initPromise;
-        processImportMaps();
-        if (document.readyState === 'complete') {
-          readyStateCompleteCheck();
-          document.removeEventListener('readystatechange', readyListener);
+      }).observe(document, {childList: true, subtree: true});
+      processImportMaps();
+      processScriptsAndPreloads();
+      if (document.readyState === 'complete') {
+        readyStateCompleteCheck();
+      } else {
+        async function readyListener() {
+          await initPromise;
+          processImportMaps();
+          if (document.readyState === 'complete') {
+            readyStateCompleteCheck();
+            document.removeEventListener('readystatechange', readyListener);
+          }
         }
+
+        document.addEventListener('readystatechange', readyListener);
       }
-      document.addEventListener('readystatechange', readyListener);
     }
     return lexer.init;
   }
@@ -252,7 +255,7 @@ function resolveDeps (load, seen) {
   const source = load.S;
 
   // edge doesnt execute sibling in order, so we fix this up by ensuring all previous executions are explicit dependencies
-  let resolvedSource = edge && lastLoad ? `import '${lastLoad}';` : '';  
+  let resolvedSource = edge && lastLoad ? `import '${lastLoad}';` : '';
 
   if (!imports.length) {
     resolvedSource += source;
@@ -293,7 +296,7 @@ function resolveDeps (load, seen) {
         resolvedSource += `/*${source.slice(start - 1, statementEnd)}*/${urlJsString(blobUrl)}`;
 
         // circular shell execution
-        if (!cycleShell && depLoad.s) {          
+        if (!cycleShell && depLoad.s) {
           resolvedSource += `;import*as m$_${depIndex} from'${depLoad.b}';import{u$_ as u$_${depIndex}}from'${depLoad.s}';u$_${depIndex}(m$_${depIndex})`;
           depLoad.s = undefined;
         }
@@ -380,8 +383,8 @@ async function fetchModule (url, fetchOpts, parent) {
     return { r: res.url, s: `export default ${await res.text()}`, t: 'json' };
   else if (cssContentType.test(contentType)) {
     return { r: res.url, s: `var s=new CSSStyleSheet();s.replaceSync(${
-      JSON.stringify((await res.text()).replace(cssUrlRegEx, (_match, quotes = '', relUrl1, relUrl2) => `url(${quotes}${resolveUrl(relUrl1 || relUrl2, url)}${quotes})`))
-    });export default s;`, t: 'css' };
+        JSON.stringify((await res.text()).replace(cssUrlRegEx, (_match, quotes = '', relUrl1, relUrl2) => `url(${quotes}${resolveUrl(relUrl1 || relUrl2, url)}${quotes})`))
+      });export default s;`, t: 'css' };
   }
   else
     throw Error(`Unsupported Content-Type "${contentType}" loading ${url}${fromParent(parent)}. Modules must be served with a valid MIME type like application/javascript.`);
@@ -468,6 +471,8 @@ function getOrCreateLoad (url, fetchOpts, parent, source) {
 }
 
 function processScriptsAndPreloads () {
+  if (!hasDocument) return;
+
   for (const script of document.querySelectorAll(shimMode ? 'script[type=module-shim]' : 'script[type=module]'))
     processScript(script);
   for (const link of document.querySelectorAll(shimMode ? 'link[rel=modulepreload-shim]' : 'link[rel=modulepreload]'))
@@ -475,6 +480,8 @@ function processScriptsAndPreloads () {
 }
 
 function processImportMaps () {
+  if (!hasDocument) return;
+
   for (const script of document.querySelectorAll(shimMode ? 'script[type="importmap-shim"]' : 'script[type="importmap"]'))
     processImportMap(script);
 }
@@ -502,14 +509,16 @@ function domContentLoadedCheck () {
     document.dispatchEvent(new Event('DOMContentLoaded'));
 }
 // this should always trigger because we assume es-module-shims is itself a domcontentloaded requirement
-document.addEventListener('DOMContentLoaded', async () => {
-  await initPromise;
-  domContentLoadedCheck();
-  if (shimMode || !baselinePassthrough) {
-    processImportMaps();
-    processScriptsAndPreloads();
-  }
-});
+if(hasDocument) {
+  document.addEventListener('DOMContentLoaded', async () => {
+    await initPromise;
+    domContentLoadedCheck();
+    if (shimMode || !baselinePassthrough) {
+      processImportMaps();
+      processScriptsAndPreloads();
+    }
+  });
+}
 
 let readyStateCompleteCnt = 1;
 function readyStateCompleteCheck () {


### PR DESCRIPTION
The purpose of this commit is to enable the usage of `es-module-shims` in module web workers, which at the moment are supported in Chrome based browsers and Safari > 15. As you know, in Firefox the support is still missing.

However, web workers cannot access objects like `document` or `window`. Therefore, I had to do the following changes in `es-modules-shims` code:

- add some simple pieces of code that check whether `document/window` exists before doing something with the `document/window` object; it's not elegant, but these checks are necessary;
- add a function that computes the `baseUrl`. In fact, this function was already defined in `es-module-shims` version `0.4.7`.
- I also added a new function `setImportMap` which can be used to set the import map from outside (obviously). This function is useful when you start a web worker which uses `es-module-shims`.

It’s important to mention that in web workers, I use the `es-module-shims.wasm.js` output. Why? Because of the `dynamicImportScript` function; I’m not sure if there is a solution for the CSP version in web workers.
Also, I want to emphasize that I didn't add new tests because no new functionality was added. The existing tests cover the changes from this pull request. The usage of `es-module-shims` in web worker is a decision that belongs to the client code.

Below, I attach a piece of code that starts a web worker which uses `es-module-shims`:
```
// baseURL, esModuleShimsURL, aURL are provided

const workerScriptUrl = URL.createObjectURL(new Blob(
        [`importScripts('${new URL(esModuleShimsURL, baseURL).href}');importShim.setImportMap(${JSON.stringify(importShim.getImportMap())});importShim('${new URL(aURL, baseURL).href}').catch(e=>setTimeout(()=>{throw e}))`],
        { type: 'application/javascript' }))

const worker = new Worker(workerScriptUrl);
```