### PR TITLE
feat: simplify feature detections csp policies

### DIFF
--- a/src/dynamic-import.js
+++ b/src/dynamic-import.js
@@ -7,9 +7,10 @@ try {
   eval('');
 }
 catch (e) {
-  throw new Error(`The ES Module Shims Wasm build will not work without eval. Either use the alternative CSP-compatible build or make sure to add both the "unsafe-eval" and "unsafe-wasm-eval" CSP policies.`);
+  throw new Error(`The ES Module Shims Wasm build will not work without eval support. Either use the alternative CSP-compatible build or make sure to add both the "unsafe-eval" and "unsafe-wasm-eval" CSP policies.`);
 }
 
+// polyfill dynamic import if not supported
 export let dynamicImport;
 try {
   dynamicImport = (0, eval)('u=>import(u)');
@@ -25,7 +26,6 @@ if (hasDocument && !supportsDynamicImportCheck) {
     const src = createBlob(`import*as m from'${url}';self._esmsi=m;`);
     const s = Object.assign(document.createElement('script'), { type: 'module', src });
     s.setAttribute('noshim', '');
-    s.setAttribute('nonce', nonce);
     document.head.appendChild(s);
     return new Promise((resolve, reject) => {
       s.addEventListener('load', () => {

--- a/src/dynamic-import.js
+++ b/src/dynamic-import.js
@@ -2,6 +2,14 @@ import { createBlob, baseUrl, nonce, hasDocument } from './env.js';
 
 export let supportsDynamicImportCheck = false;
 
+// first check basic eval support
+try {
+  eval('');
+}
+catch (e) {
+  throw new Error(`The ES Module Shims Wasm build will not work without eval. Either use the alternative CSP-compatible build or make sure to add both the "unsafe-eval" and "unsafe-wasm-eval" CSP policies.`);
+}
+
 export let dynamicImport;
 try {
   dynamicImport = (0, eval)('u=>import(u)');

--- a/src/dynamic-import.js
+++ b/src/dynamic-import.js
@@ -1,4 +1,4 @@
-import { createBlob, baseUrl, nonce, hasDocument } from './env.js';
+import { createBlob, baseUrl, hasDocument } from './env.js';
 
 export let supportsDynamicImportCheck = false;
 

--- a/src/env.js
+++ b/src/env.js
@@ -17,10 +17,9 @@ export const metaHook = esmsInitOptions.meta ? globalHook(shimModule && esmsInit
 
 export const skip = esmsInitOptions.skip ? new RegExp(esmsInitOptions.skip) : null;
 
-export let nonce = esmsInitOptions.nonce;
-
 export const mapOverrides = esmsInitOptions.mapOverrides;
 
+export let nonce = esmsInitOptions.nonce;
 if (!nonce && hasDocument) {
   const nonceElement = document.querySelector('script[nonce]');
   if (nonceElement)

--- a/src/features.js
+++ b/src/features.js
@@ -19,12 +19,6 @@ export const featureDetectionPromise = Promise.resolve(supportsImportMaps || sup
     cssModulesEnabled && dynamicImport(createBlob(`import"${createBlob('', 'text/css')}"assert{type:"css"}`)).then(() => supportsCssAssertions = true, noop),
     jsonModulesEnabled && dynamicImport(createBlob(`import"${createBlob('{}', 'text/json')}"assert{type:"json"}`)).then(() => supportsJsonAssertions = true, noop),
     supportsImportMaps || hasDocument && (HTMLScriptElement.supports || new Promise(resolve => {
-      self._$s = v => {
-        document.head.removeChild(iframe);
-        supportsImportMaps = v;
-        delete self._$s;
-        resolve();
-      };
       const iframe = document.createElement('iframe');
       iframe.style.display = 'none';
       iframe.setAttribute('nonce', nonce);
@@ -34,8 +28,14 @@ export const featureDetectionPromise = Promise.resolve(supportsImportMaps || sup
       iframe.srcdoc = `<!doctype html><script nonce="${nonce}"><${''}/script>`;
       document.head.appendChild(iframe);
       iframe.contentWindow.addEventListener('DOMContentLoaded', () => {
+        self._$s = v => {
+          document.head.removeChild(iframe);
+          supportsImportMaps = v;
+          delete self._$s;
+          resolve();
+        };
         const supportsSrcDoc = iframe.contentDocument.head.childNodes.length > 0;
-        const importMapTest = `<!doctype html><script type=importmap nonce="${nonce}">{"imports":{"x":"${createBlob('')}"}<${''}/script><script nonce="${nonce}">import('x').then(()=>true,()=>false).then(v=>parent._$s(v))<${''}/script>`;
+        const importMapTest = `<!doctype html><script type=importmap nonce="${nonce}">{"imports":{"x":"${createBlob('')}"}<${''}/script><script nonce="${nonce}">import('x').catch(() => {}).then(v=>parent._$s(!!v))<${''}/script>`;
         if (supportsSrcDoc)
           iframe.srcdoc = importMapTest;
         else

--- a/src/features.js
+++ b/src/features.js
@@ -16,23 +16,31 @@ export const featureDetectionPromise = Promise.resolve(supportsImportMaps || sup
 
   return Promise.all([
     supportsImportMaps || dynamicImport(createBlob('import.meta')).then(() => supportsImportMeta = true, noop),
-    cssModulesEnabled && dynamicImport(createBlob('import"data:text/css,{}"assert{type:"css"}')).then(() => supportsCssAssertions = true, noop),
-    jsonModulesEnabled && dynamicImport(createBlob('import"data:text/json,{}"assert{type:"json"}')).then(() => supportsJsonAssertions = true, noop),
-    supportsImportMaps || (hasDocument && new Promise(resolve => {
+    cssModulesEnabled && dynamicImport(createBlob(`import"${createBlob('', 'text/css')}"assert{type:"css"}`)).then(() => supportsCssAssertions = true, noop),
+    jsonModulesEnabled && dynamicImport(createBlob(`import"${createBlob('{}', 'text/json')}"assert{type:"json"}`)).then(() => supportsJsonAssertions = true, noop),
+    supportsImportMaps || hasDocument && (HTMLScriptElement.supports || new Promise(resolve => {
       self._$s = v => {
         document.head.removeChild(iframe);
-        if (v) supportsImportMaps = true;
+        supportsImportMaps = v;
         delete self._$s;
         resolve();
       };
       const iframe = document.createElement('iframe');
       iframe.style.display = 'none';
       iframe.setAttribute('nonce', nonce);
-      document.head.appendChild(iframe);
-      // we use document.write here because eg Weixin built-in browser doesn't support setting srcdoc
       // setting src to a blob URL results in a navigation event in webviews
       // setting srcdoc is not supported in React native webviews on iOS
-      iframe.contentWindow.document.write(`<script type=importmap nonce="${nonce}">{"imports":{"x":"data:text/javascript,"}}<${''}/script><script nonce="${nonce}">import('x').then(()=>1,()=>0).then(v=>parent._$s(v))<${''}/script>`);
+      // therefore, we need to first feature detect srcdoc support
+      iframe.srcdoc = `<!doctype html><script nonce="${nonce}"><${''}/script>`;
+      document.head.appendChild(iframe);
+      iframe.contentWindow.addEventListener('DOMContentLoaded', () => {
+        const supportsSrcDoc = iframe.contentDocument.head.childNodes.length > 0;
+        const importMapTest = `<!doctype html><script type=importmap nonce="${nonce}">{"imports":{"x":"${createBlob('')}"}<${''}/script><script nonce="${nonce}">import('x').then(()=>true,()=>false).then(v=>parent._$s(v))<${''}/script>`;
+        if (supportsSrcDoc)
+          iframe.srcdoc = importMapTest;
+        else
+          iframe.contentDocument.write(importMapTest);
+      });
     }))
   ]);
 });


### PR DESCRIPTION
This fixes CSP support with a number of enhancements:

* Fixing the case where `HTMLScriptElement.supports('importmap') === false` skips the import map detection as it should have been doing already
* Updating the internal feature detections to use blobs instead of data URIs so that it's only necessary to add `blob:` to the policy and not both `blob:` and `data:` for easier usage
* The document.write path in the iframe feature detection is again modified to attempt a srcdoc approach first before falling back to document.write. This avoids a bunch of warnings and possible issues with using document.write by default. Hopefully this finally gets us to a middle ground on that case.
* A new clear error message is thrown by the Wasm build when eval is not supported, to avoid possible obscure errors.