### PR TITLE
fix: safari import maps detection

### DIFF
--- a/src/features.js
+++ b/src/features.js
@@ -27,7 +27,7 @@ export const featureDetectionPromise = Promise.resolve(supportsImportMaps || sup
       // therefore, we need to first feature detect srcdoc support
       iframe.srcdoc = `<!doctype html><script nonce="${nonce}"><${''}/script>`;
       document.head.appendChild(iframe);
-      iframe.contentWindow.addEventListener('DOMContentLoaded', () => {
+      iframe.onload = () => {
         self._$s = v => {
           document.head.removeChild(iframe);
           supportsImportMaps = v;
@@ -40,7 +40,7 @@ export const featureDetectionPromise = Promise.resolve(supportsImportMaps || sup
           iframe.srcdoc = importMapTest;
         else
           iframe.contentDocument.write(importMapTest);
-      });
+      };
     }))
   ]);
 });

--- a/test/runMochaTests.js
+++ b/test/runMochaTests.js
@@ -1,6 +1,6 @@
 export function runMochaTests(suite) {
   mocha.setup({ ui: 'tdd' });
-  mocha.allowUncaught();
+  // mocha.allowUncaught();
   self.assert = function (val) {
     equal(!!val, true);
   };

--- a/test/shim.js
+++ b/test/shim.js
@@ -320,7 +320,8 @@ suite('Errors', function () {
 
   test('onerror hook worked correctly', async function () {
     await new Promise(resolve => setTimeout(resolve, 50));
-    assert.equal(window.e.toString(), 'ReferenceError: syntax is not defined');
+    assert.ok(window.e instanceof ReferenceError);
+    assert.ok(window.e.toString().includes('syntax'));
   });
 
   test('should give a plain name error', async function () {
@@ -399,7 +400,9 @@ suite('Errors', function () {
 
   test('Dynamic import map shim with override to the same mapping is allowed', async function () {
     const expectingNoError = new Promise((resolve, reject) => {
-      window.addEventListener('error', (event) => reject(event.error))
+      window.addEventListener('error', (event) => {
+        reject(event.error)
+      });
       // waiting for 1 sec should be enough to make sure the error didn't happen.
       setTimeout(resolve, 1000)
     })

--- a/test/test-shim.html
+++ b/test/test-shim.html
@@ -35,7 +35,7 @@
 </script>
 <script>
   window.order = [];
-  let count = 1
+  window.count = 1
 </script>
 <script type="module">
   count++;


### PR DESCRIPTION
Fixes a bug in the new import map detection from 1.5.7, introduced in https://github.com/guybedford/es-module-shims/pull/302.

Resolves https://github.com/guybedford/es-module-shims/issues/303.