### PR TITLE
fix: early shim mode detection

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -41,10 +41,6 @@ const enable = Array.isArray(esmsInitOptions.polyfillEnable) ? esmsInitOptions.p
 export const cssModulesEnabled = enable.includes('css-modules');
 export const jsonModulesEnabled = enable.includes('json-modules');
 
-export function setShimMode () {
-  shimMode = true;
-}
-
 export const edge = !navigator.userAgentData && !!navigator.userAgent.match(/Edge\/\d+\.\d+/);
 
 export const baseUrl = hasDocument
@@ -63,4 +59,26 @@ export const throwError = err => { (self.reportError || hasWindow && window.safa
 
 export function fromParent (parent) {
   return parent ? ` imported from ${parent}` : '';
+}
+
+export let importMapSrcOrLazy = false;
+
+// shim mode is determined on initialization, no late shim mode
+if (!shimMode) {
+  if (document.querySelectorAll('script[type=module-shim],script[type=importmap-shim],link[rel=modulepreload-shim]').length) {
+    shimMode = true;
+  }
+  else {
+    let seenScript = false;
+    for (const script of document.querySelectorAll('script[type=module],script[type=importmap]')) {
+      if (!seenScript) {
+        if (script.type === 'module')
+          seenScript = true;
+      }
+      else if (script.type === 'importmap') {
+        importMapSrcOrLazy = true;
+        break;
+      }
+    }
+  }
 }

--- a/src/env.js
+++ b/src/env.js
@@ -63,6 +63,10 @@ export function fromParent (parent) {
 
 export let importMapSrcOrLazy = false;
 
+export function setImportMapSrcOrLazy () {
+  importMapSrcOrLazy = true;
+}
+
 // shim mode is determined on initialization, no late shim mode
 if (!shimMode) {
   if (document.querySelectorAll('script[type=module-shim],script[type=importmap-shim],link[rel=modulepreload-shim]').length) {

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -25,7 +25,8 @@ import {
   fromParent,
   esmsInitOptions,
   hasDocument,
-  importMapSrcOrLazy
+  importMapSrcOrLazy,
+  setImportMapSrcOrLazy,
 } from './env.js';
 import { dynamicImport } from './dynamic-import-csp.js';
 import {
@@ -519,7 +520,7 @@ function processImportMap (script) {
   if (script.src) {
     if (!shimMode)
       return;
-    importMapSrcOrLazy = true;
+    setImportMapSrcOrLazy();
   }
   if (acceptingImportMaps) {
     importMapPromise = importMapPromise

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -121,7 +121,7 @@ let importMap = { imports: {}, scopes: {} };
 let importMapSrcOrLazy = false;
 let baselinePassthrough;
 
-const initPromise = featureDetectionPromise.then(() => {
+const initPromise = (async () => {
   // shim mode is determined on initialization, no late shim mode
   if (!shimMode) {
     if (document.querySelectorAll('script[type=module-shim],script[type=importmap-shim],link[rel=modulepreload-shim]').length) {
@@ -141,6 +141,9 @@ const initPromise = featureDetectionPromise.then(() => {
       }
     }
   }
+
+  await featureDetectionPromise;
+
   baselinePassthrough = esmsInitOptions.polyfillEnable !== true && supportsDynamicImport && supportsImportMeta && supportsImportMaps && (!jsonModulesEnabled || supportsJsonAssertions) && (!cssModulesEnabled || supportsCssAssertions) && !importMapSrcOrLazy && !self.ESMS_DEBUG;
   if (hasDocument) {
     if (!supportsImportMaps) {
@@ -183,7 +186,7 @@ const initPromise = featureDetectionPromise.then(() => {
     }
   }
   return lexer.init;
-});
+})();
 let importMapPromise = initPromise;
 let firstPolyfillLoad = true;
 let acceptingImportMaps = true;

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -24,7 +24,8 @@ import {
   enforceIntegrity,
   fromParent,
   esmsInitOptions,
-  hasDocument
+  hasDocument,
+  importMapSrcOrLazy
 } from './env.js';
 import { dynamicImport } from './dynamic-import-csp.js';
 import {
@@ -117,7 +118,6 @@ async function loadAll (load, seen) {
 }
 
 let importMap = { imports: {}, scopes: {} };
-let importMapSrcOrLazy = false;
 let baselinePassthrough;
 
 const initPromise = featureDetectionPromise.then(() => {


### PR DESCRIPTION
Fixes https://github.com/guybedford/es-module-shims/issues/305 in ensuring that the shim mode detection and `importMapSrcOrLazy` checks are done early before ES Module Shims injects its own scripts, which were interfering with the results in the case of an import map in the body of the HTML.