### PR TITLE
fix: importMapSrcOrLazy polyfill bug

### DIFF
--- a/src/dynamic-import-csp.js
+++ b/src/dynamic-import-csp.js
@@ -5,7 +5,7 @@ window.addEventListener('error', _err => err = _err);
 function dynamicImportScript (url, { errUrl = url } = {}) {
   err = undefined;
   const src = createBlob(`import*as m from'${url}';self._esmsi=m`);
-  const s = Object.assign(document.createElement('script'), { type: 'module', src });
+  const s = Object.assign(document.createElement('script'), { type: 'module', src, ep: true });
   s.setAttribute('nonce', nonce);
   s.setAttribute('noshim', '');
   const p =  new Promise((resolve, reject) => {

--- a/src/env.js
+++ b/src/env.js
@@ -76,10 +76,10 @@ if (!shimMode) {
     let seenScript = false;
     for (const script of document.querySelectorAll('script[type=module],script[type=importmap]')) {
       if (!seenScript) {
-        if (script.type === 'module')
+        if (script.type === 'module' && !script.ep)
           seenScript = true;
       }
-      else if (script.type === 'importmap') {
+      else if (script.type === 'importmap' && seenScript) {
         importMapSrcOrLazy = true;
         break;
       }

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -3,7 +3,7 @@ import {
   resolveUrl,
   resolveImportMap,
   resolveIfNotPlainOrUrl,
-  isURL
+  isURL,
 } from './resolve.js'
 import {
   baseUrl as pageBaseUrl,


### PR DESCRIPTION
This fixes a bug where `importMapSrcOrLazy` was triggering incorrectly resulting in polyfilling when passthrough should have been possible.