### PR TITLE
fix: polyfill initialization ordering bug from #317

### DIFF
--- a/src/dynamic-import-csp.js
+++ b/src/dynamic-import-csp.js
@@ -33,4 +33,4 @@ export const dynamicImport = (url, opts) => inject(Object.assign(document.create
 }), opts && opts.errUrl || url);
 
 // This is done as a script so we don't trigger module loading too early for any loading import maps
-export const supportsDynamicImportCheck = inject(Object.assign(document.createElement('script'), { src: createBlob('u => import(u)') })).then(() => true, () => false);
+export const supportsDynamicImportCheck = inject(Object.assign(document.createElement('script'), { src: createBlob('self._esmsi=u => import(u)') })).then(() => true, () => false);

--- a/src/features.js
+++ b/src/features.js
@@ -14,33 +14,44 @@ export const featureDetectionPromise = Promise.resolve(supportsImportMaps || sup
     return;
   supportsDynamicImport = true;
 
-  return Promise.all([
-    supportsImportMaps || dynamicImport(createBlob('import.meta')).then(() => supportsImportMeta = true, noop),
-    cssModulesEnabled && dynamicImport(createBlob(`import"${createBlob('', 'text/css')}"assert{type:"css"}`)).then(() => supportsCssAssertions = true, noop),
-    jsonModulesEnabled && dynamicImport(createBlob(`import"${createBlob('{}', 'text/json')}"assert{type:"json"}`)).then(() => supportsJsonAssertions = true, noop),
-    supportsImportMaps || hasDocument && (HTMLScriptElement.supports || new Promise(resolve => {
-      const iframe = document.createElement('iframe');
-      iframe.style.display = 'none';
-      iframe.setAttribute('nonce', nonce);
-      // setting src to a blob URL results in a navigation event in webviews
-      // setting srcdoc is not supported in React native webviews on iOS
-      // therefore, we need to first feature detect srcdoc support
-      iframe.srcdoc = `<!doctype html><script nonce="${nonce}"><${''}/script>`;
-      document.head.appendChild(iframe);
-      iframe.onload = () => {
-        self._$s = v => {
-          document.head.removeChild(iframe);
-          supportsImportMaps = v;
-          delete self._$s;
-          resolve();
-        };
-        const supportsSrcDoc = iframe.contentDocument.head.childNodes.length > 0;
-        const importMapTest = `<!doctype html><script type=importmap nonce="${nonce}">{"imports":{"x":"${createBlob('')}"}<${''}/script><script nonce="${nonce}">import('x').catch(() => {}).then(v=>parent._$s(!!v))<${''}/script>`;
-        if (supportsSrcDoc)
-          iframe.srcdoc = importMapTest;
-        else
-          iframe.contentDocument.write(importMapTest);
+  if (!supportsImportMaps || cssModulesEnabled || jsonModulesEnabled) {
+    const importMetaCheck = createBlob('import.meta');
+    const cssModulesCheck = createBlob(`import"${createBlob('', 'text/css')}"assert{type:"css"}`);
+    const jsonModulesCheck = createBlob(`import"${createBlob('{}', 'text/json')}"assert{type:"json"}`);
+
+    if (!hasDocument)
+      return Promise.all([
+        supportsImportMaps || dynamicImport(importMetaCheck).then(() => supportsImportMeta = true, noop),
+        cssModulesEnabled && dynamicImport(cssModulesCheck).then(() => supportsCssAssertions = true, noop),
+        jsonModulesEnabled && dynamicImport(jsonModulescheck).then(() => supportsJsonAssertions = true, noop),
+      ]);
+
+    const iframe = document.createElement('iframe');
+    iframe.style.display = 'none';
+    iframe.setAttribute('nonce', nonce);
+    // setting src to a blob URL results in a navigation event in webviews
+    // setting srcdoc is not supported in React native webviews on iOS
+    // therefore, we need to first feature detect srcdoc support
+    iframe.srcdoc = `<!doctype html><script nonce="${nonce}"><${''}/script>`;
+    document.head.appendChild(iframe);
+    iframe.onload = () => {
+      self._$s = (a, b, c, d) => {
+        document.head.removeChild(iframe);
+        supportsImportMaps = a;
+        supportsImportMeta = b;
+        supportsCssAssertions = c;
+        supportsJsonAssertions = d;
+        delete self._$s;
+        resolve();
       };
-    }))
-  ]);
+      const supportsSrcDoc = iframe.contentDocument.head.childNodes.length > 0;
+      const importMapTest = `<!doctype html><script type=importmap nonce="${nonce}">{"imports":{"x":"${createBlob('')}"}<${''}/script><script nonce="${nonce}">Promise.all([${
+        supportsImportMaps ? 'true, true' : `'x', '${importMetaCheck}'`}, ${cssModulesEnabled ? `'${cssModulesCheck}'` : 'false'}, ${jsonModulesEnabled ? `'${jsonModulesCheck}'` : 'false'
+      }].map(x => typeof x === 'string' ? import(x).then(x => !!x, () => false) : x)).then(a=>parent._$s.apply(null, a))<${''}/script>`;
+      if (supportsSrcDoc)
+        iframe.srcdoc = importMapTest;
+      else
+        iframe.contentDocument.write(importMapTest);
+    };
+  }
 });

--- a/src/features.js
+++ b/src/features.js
@@ -9,12 +9,12 @@ export let supportsImportMaps = hasDocument && HTMLScriptElement.supports ? HTML
 export let supportsImportMeta = supportsImportMaps;
 export let supportsDynamicImport = false;
 
-export const featureDetect = async () => {
-  if (!(supportsImportMaps || await supportsDynamicImportCheck))
+export const featureDetectionPromise = Promise.resolve(supportsImportMaps || supportsDynamicImportCheck).then(_supportsDynamicImport => {
+  if (!_supportsDynamicImport)
     return;
   supportsDynamicImport = true;
 
-  await Promise.all([
+  return Promise.all([
     supportsImportMaps || dynamicImport(createBlob('import.meta')).then(() => supportsImportMeta = true, noop),
     cssModulesEnabled && dynamicImport(createBlob(`import"${createBlob('', 'text/css')}"assert{type:"css"}`)).then(() => supportsCssAssertions = true, noop),
     jsonModulesEnabled && dynamicImport(createBlob(`import"${createBlob('{}', 'text/json')}"assert{type:"json"}`)).then(() => supportsJsonAssertions = true, noop),
@@ -43,4 +43,4 @@ export const featureDetect = async () => {
       };
     }))
   ]);
-};
+});


### PR DESCRIPTION
Fixes an initialization bug introduced in https://github.com/guybedford/es-module-shims/pull/317 that would inhibit polyfilling when es-module-shims loads after DOMContentLoaded.

Feature detections are kept early, but done in an iframe so that any module loads will not interfere with the main frame map phases.