### PR TITLE
fix: timing fix follow-ups from #320

### DIFF
--- a/chompfile.toml
+++ b/chompfile.toml
@@ -59,3 +59,10 @@ name = 'test:#'
 serial = true
 deps = ['npm:install', 'dist/es-module-shims.js', 'dist/es-module-shims.wasm.js', 'test/test-#.html']
 run = 'node test/server.mjs test-${{ MATCH }}'
+
+[[task]]
+name = 'test:firefox'
+env = { BROWSER = 'firefox' }
+serial = true
+deps = ['npm:install', 'dist/es-module-shims.js', 'dist/es-module-shims.wasm.js', 'test/test-#.html']
+run = 'node test/server.mjs test-${{ MATCH }}'

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -491,7 +491,7 @@ function getFetchOpts (script) {
 let lastStaticLoadPromise = Promise.resolve();
 
 let domContentLoadedCnt = 1;
-async function domContentLoadedCheck () {
+function domContentLoadedCheck () {
   if (--domContentLoadedCnt === 0 && !noLoadEventRetriggers)
     document.dispatchEvent(new Event('DOMContentLoaded'));
 }
@@ -554,6 +554,7 @@ function processScript (script) {
 
 const fetchCache = {};
 function processPreload (link) {
+  if (link.ep) return;
   link.ep = true;
   if (fetchCache[link.href])
     return;

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -70,7 +70,7 @@ async function importShim (id, ...args) {
   if (importHook) await importHook(id, typeof args[1] !== 'string' ? args[1] : {}, parentUrl);
   if (acceptingImportMaps || shimMode || !baselinePassthrough) {
     if (hasDocument)
-      processImportMaps();
+      processScriptsAndPreloads(true);
     if (!shimMode)
       acceptingImportMaps = false;
   }
@@ -138,12 +138,12 @@ const initPromise = featureDetectionPromise.then(() => {
               if (node.type === (shimMode ? 'importmap-shim' : 'importmap'))
                 processImportMap(node);
             }
-            else if (node.tagName === 'LINK' && node.rel === (shimMode ? 'modulepreload-shim' : 'modulepreload'))
+            else if (node.tagName === 'LINK' && node.rel === (shimMode ? 'modulepreload-shim' : 'modulepreload')) {
               processPreload(node);
+            }
           }
         }
       }).observe(document, {childList: true, subtree: true});
-      processImportMaps();
       processScriptsAndPreloads();
       if (document.readyState === 'complete') {
         readyStateCompleteCheck();
@@ -151,7 +151,7 @@ const initPromise = featureDetectionPromise.then(() => {
       else {
         async function readyListener() {
           await initPromise;
-          processImportMaps();
+          processScriptsAndPreloads();
           if (document.readyState === 'complete') {
             readyStateCompleteCheck();
             document.removeEventListener('readystatechange', readyListener);
@@ -462,16 +462,15 @@ function getOrCreateLoad (url, fetchOpts, parent, source) {
   return load;
 }
 
-function processScriptsAndPreloads () {
-  for (const script of document.querySelectorAll(shimMode ? 'script[type=module-shim]' : 'script[type=module]'))
-    processScript(script);
-  for (const link of document.querySelectorAll(shimMode ? 'link[rel=modulepreload-shim]' : 'link[rel=modulepreload]'))
-    processPreload(link);
-}
-
-function processImportMaps () {
-  for (const script of document.querySelectorAll(shimMode ? 'script[type="importmap-shim"]' : 'script[type="importmap"]'))
+function processScriptsAndPreloads (mapsOnly = false) {
+  if (!mapsOnly)
+    for (const link of document.querySelectorAll(shimMode ? 'link[rel=modulepreload-shim]' : 'link[rel=modulepreload]'))
+      processPreload(link);
+  for (const script of document.querySelectorAll(shimMode ? 'script[type=importmap-shim]' : 'script[type=importmap]'))
     processImportMap(script);
+  if (!mapsOnly)
+    for (const script of document.querySelectorAll(shimMode ? 'script[type=module-shim]' : 'script[type=module]'))
+      processScript(script);
 }
 
 function getFetchOpts (script) {
@@ -492,7 +491,7 @@ function getFetchOpts (script) {
 let lastStaticLoadPromise = Promise.resolve();
 
 let domContentLoadedCnt = 1;
-function domContentLoadedCheck () {
+async function domContentLoadedCheck () {
   if (--domContentLoadedCnt === 0 && !noLoadEventRetriggers)
     document.dispatchEvent(new Event('DOMContentLoaded'));
 }
@@ -500,11 +499,8 @@ function domContentLoadedCheck () {
 if (hasDocument) {
   document.addEventListener('DOMContentLoaded', async () => {
     await initPromise;
-    domContentLoadedCheck();
-    if (shimMode || !baselinePassthrough) {
-      processImportMaps();
-      processScriptsAndPreloads();
-    }
+    if (shimMode || !baselinePassthrough)
+      domContentLoadedCheck();
   });
 }
 
@@ -515,10 +511,8 @@ function readyStateCompleteCheck () {
 }
 
 function processImportMap (script) {
-  if (script.ep) // ep marker = script processed
-    return;
   // empty inline scripts sometimes show before domready
-  if (!script.src && !script.innerHTML)
+  if (script.ep || !script.src && !script.innerHTML)
     return;
   script.ep = true;
   // we dont currently support multiple, external or dynamic imports maps in polyfill mode to match native
@@ -539,14 +533,12 @@ function processImportMap (script) {
 }
 
 function processScript (script) {
-  if (script.ep) // ep marker = script processed
-    return;
-  if (script.getAttribute('noshim') !== null)
-    return;
   // empty inline scripts sometimes show before domready
-  if (!script.src && !script.innerHTML)
+  if (script.ep || !script.src && !script.innerHTML)
     return;
   script.ep = true;
+  if (script.getAttribute('noshim') !== null)
+    return;
   // does this load block readystate complete
   const isBlockingReadyScript = script.getAttribute('async') === null && readyStateCompleteCnt > 0;
   // does this load block DOMContentLoaded
@@ -562,8 +554,6 @@ function processScript (script) {
 
 const fetchCache = {};
 function processPreload (link) {
-  if (link.ep) // ep marker = processed
-    return;
   link.ep = true;
   if (fetchCache[link.href])
     return;

--- a/test/server.mjs
+++ b/test/server.mjs
@@ -169,7 +169,7 @@ function start () {
     spawnPs = spawn(process.env.CI_BROWSER, [...args, `${baseURL}/test/${testName}.html`]);
   }
   else {
-    open(`${baseURL}/test/${testName}.html`, { app: { name: open.apps.chrome } });
+    open(`${baseURL}/test/${testName}.html`, { app: { name: open.apps[process.env.BROWSER || 'chrome'] } });
   }
 }
 


### PR DESCRIPTION
This provides some follow up on the recent timing work from #320:

* The iframe feature detection promise is fixed to properly resolve on feature detection completion
* DOMContentLoaded should no longer fire twice when the polyfill doesn't kick in
* The additional DOM parse in DOMContentLoaded is removed since we already have init and readystatechange parses as well as mutation observers, DOMContentLoaded should provide no new timing interception point we don't already cater to
* `processImportMaps` and `processScriptsAndPreloads` are combined into the same function as a refactoring