### PR TITLE
feat: handle streaming import maps, better import map errors

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -510,7 +510,8 @@ function readyStateCompleteCheck () {
     document.dispatchEvent(new Event('readystatechange'));
 }
 
-const epCheck = script => script.ep || !script.src && !script.innerHTML || !script.nextSibling && !script.parentNode.nextSibling || script.getAttribute('noshim') !== null || !(script.ep = true);
+const hasNext = script => script.nextSibling || script.parentNode && hasNext(script.parentNode);
+const epCheck = script => script.ep || !script.src && !script.innerHTML || !hasNext(script) || script.getAttribute('noshim') !== null || !(script.ep = true);
 
 function processImportMap (script) {
   if (epCheck(script)) return;

--- a/src/features.js
+++ b/src/features.js
@@ -46,7 +46,7 @@ export const featureDetectionPromise = Promise.resolve(supportsImportMaps || sup
           resolve();
         };
         const supportsSrcDoc = iframe.contentDocument.head.childNodes.length > 0;
-        const importMapTest = `<!doctype html><script type=importmap nonce="${nonce}">{"imports":{"x":"${createBlob('')}"}<${''}/script><script nonce="${nonce}">Promise.all([${
+        const importMapTest = `<!doctype html><script type=importmap nonce="${nonce}">{"imports":{"x":"${createBlob('')}"}}<${''}/script><script nonce="${nonce}">Promise.all([${
           supportsImportMaps ? 'true, true' : `'x', '${importMetaCheck}'`}, ${cssModulesEnabled ? `'${cssModulesCheck}'` : 'false'}, ${jsonModulesEnabled ? `'${jsonModulesCheck}'` : 'false'
         }].map(x => typeof x === 'string' ? import(x).then(x => !!x, () => false) : x)).then(a=>parent._$s.apply(null, a))<${''}/script>`;
         if (supportsSrcDoc)

--- a/test/fixtures/once.js
+++ b/test/fixtures/once.js
@@ -1,0 +1,2 @@
+window.cnt = window.cnt || 0;
+window.cnt++;

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -46,4 +46,10 @@ suite('Polyfill tests', () => {
     const result = await check();
     assert.equal(result, true);
   });
+
+  test('Polyfill engagement', async function () {
+    if (window.cnt > 1)
+      throw new Error(`Polyfill engaged despite native implementation`);
+    assert.equal(window.cnt, 1);
+  });
 });

--- a/test/test-csp.html
+++ b/test/test-csp.html
@@ -6,6 +6,7 @@
 <script type="importmap" nonce="asdf">
 {
   "imports": {
+    "once": "data:text/javascript,window.cnt=window.cnt || 0;window.cnt++;",
     "test": "/test/fixtures/es-modules/es6-file.js",
     "test/": "/test/fixtures/",
     "global1": "/test/fixtures/es-modules/global1.js",
@@ -30,6 +31,10 @@
 </script>
 <script nonce="asdf">
   window.import2 = import('data');
+</script>
+
+<script type="module" nonce="asdf">
+  import 'once';
 </script>
 
 <script type="module" src="../src/es-module-shims.js" nonce="asdf"></script>

--- a/test/test-csp.html
+++ b/test/test-csp.html
@@ -6,7 +6,7 @@
 <script type="importmap" nonce="asdf">
 {
   "imports": {
-    "once": "data:text/javascript,window.cnt=window.cnt || 0;window.cnt++;",
+    "once": "/test/fixtures/once.js",
     "test": "/test/fixtures/es-modules/es6-file.js",
     "test/": "/test/fixtures/",
     "global1": "/test/fixtures/es-modules/global1.js",

--- a/test/test-polyfill-wasm.html
+++ b/test/test-polyfill-wasm.html
@@ -5,7 +5,7 @@
 <script type="importmap">
 {
   "imports": {
-    "once": "data:text/javascript,window.cnt=window.cnt || 0;window.cnt++;",
+    "once": "/test/fixtures/once.js",
     "test": "/test/fixtures/es-modules/es6-file.js",
     "test/": "/test/fixtures/",
     "global1": "/test/fixtures/es-modules/global1.js",

--- a/test/test-polyfill-wasm.html
+++ b/test/test-polyfill-wasm.html
@@ -5,6 +5,7 @@
 <script type="importmap">
 {
   "imports": {
+    "once": "data:text/javascript,window.cnt=window.cnt || 0;window.cnt++;",
     "test": "/test/fixtures/es-modules/es6-file.js",
     "test/": "/test/fixtures/",
     "global1": "/test/fixtures/es-modules/global1.js",
@@ -22,6 +23,10 @@
 }
 </script>
 <script>window.esmsInitOptions = { polyfillEnable: ['json-modules', 'css-modules' ] }</script>
+
+<script type="module">
+  import 'once';
+</script>
 
 <script type="module" src="../dist/es-module-shims.wasm.js"></script>
 

--- a/test/test-polyfill.html
+++ b/test/test-polyfill.html
@@ -5,6 +5,7 @@
 <script type="importmap">
 {
   "imports": {
+    "once": "data:text/javascript,window.cnt=window.cnt || 0;window.cnt++;",
     "test": "/test/fixtures/es-modules/es6-file.js",
     "test/": "/test/fixtures/",
     "global1": "/test/fixtures/es-modules/global1.js",
@@ -22,6 +23,9 @@
 }
 </script>
 <script>window.esmsInitOptions = { polyfillEnable: ['json-modules', 'css-modules' ] }</script>
+<script type="module">
+  import 'once';
+</script>
 
 <script type="module" src="../src/es-module-shims.js"></script>
 

--- a/test/test-polyfill.html
+++ b/test/test-polyfill.html
@@ -5,7 +5,7 @@
 <script type="importmap">
 {
   "imports": {
-    "once": "data:text/javascript,window.cnt=window.cnt || 0;window.cnt++;",
+    "once": "/test/fixtures/once.js",
     "test": "/test/fixtures/es-modules/es6-file.js",
     "test/": "/test/fixtures/",
     "global1": "/test/fixtures/es-modules/global1.js",


### PR DESCRIPTION
This adds some better checks for reading streaming `<script>` tags for import maps and inline scripts to ensure the page is fully loaded before they are executed.

We also add a better error message for when import map parsing fails, logging the JSON error alongside the map that was being parsed.

A polyfill engagement check and fix is also added for when Firefox import maps support lands unflagged.