### PR TITLE
fix: iframe sandbox detections

### DIFF
--- a/src/dynamic-import.js
+++ b/src/dynamic-import.js
@@ -26,10 +26,10 @@ if (hasDocument && !supportsDynamicImportCheck) {
     const src = createBlob(`import*as m from'${url}';self._esmsi=m;`);
     const s = Object.assign(document.createElement('script'), { type: 'module', src });
     s.setAttribute('noshim', '');
-    document.head.appendChild(s);
+    document.appendChild(s);
     return new Promise((resolve, reject) => {
       s.addEventListener('load', () => {
-        document.head.removeChild(s);
+        document.removeChild(s);
         if (self._esmsi) {
           resolve(_esmsi, baseUrl);
           _esmsi = null;

--- a/src/dynamic-import.js
+++ b/src/dynamic-import.js
@@ -26,10 +26,10 @@ if (hasDocument && !supportsDynamicImportCheck) {
     const src = createBlob(`import*as m from'${url}';self._esmsi=m;`);
     const s = Object.assign(document.createElement('script'), { type: 'module', src });
     s.setAttribute('noshim', '');
-    document.appendChild(s);
+    document.head.appendChild(s);
     return new Promise((resolve, reject) => {
       s.addEventListener('load', () => {
-        document.removeChild(s);
+        document.head.removeChild(s);
         if (self._esmsi) {
           resolve(_esmsi, baseUrl);
           _esmsi = null;

--- a/src/env.js
+++ b/src/env.js
@@ -49,9 +49,7 @@ export const baseUrl = hasDocument
     ? location.pathname.slice(0, location.pathname.lastIndexOf('/') + 1) 
     : location.pathname}`;
 
-export function createBlob (source, type = 'text/javascript') {
-  return URL.createObjectURL(new Blob([source], { type }));
-}
+export const createBlob = (source, type = 'text/javascript') => URL.createObjectURL(new Blob([source], { type }));
 
 const eoop = err => setTimeout(() => { throw err });
 

--- a/src/features.js
+++ b/src/features.js
@@ -41,9 +41,9 @@ export const featureDetectionPromise = Promise.resolve(supportsImportMaps || sup
       }
       window.addEventListener('message', cb, false);
 
-      const importMapTest = `<script>const createBlob=(s,type='text/javascript')=>URL.createObjectURL(new Blob([s],{type}));document.head.appendChild(Object.assign(document.createElement('script'),{type:'importmap',nonce:"${nonce}",innerText:\`{"imports":{"x":"\${createBlob('')}"}}\`}));Promise.all([${
+      const importMapTest = `<script nonce=${nonce}>const createBlob=(s,type='text/javascript')=>URL.createObjectURL(new Blob([s],{type}));document.head.appendChild(Object.assign(document.createElement('script'),{type:'importmap',nonce:"${nonce}",innerText:\`{"imports":{"x":"\${createBlob('')}"}}\`}));Promise.all([${
         supportsImportMaps ? 'true, true' : `'x',createBlob('${importMetaCheck}')`}, ${cssModulesEnabled ? `createBlob('${cssModulesCheck}'.replace('x',createBlob('','text/css')))` : 'false'}, ${
-        jsonModulesEnabled ? `createBlob('${jsonModulesCheck}'.replace('x',createBlob('{}','text/json')))` : 'false'}].map(x => typeof x === 'string' ? import(x).then(x => !!x, () => false) : x)).then(a=>parent.postMessage(a,'*'))<${''}/script>`;
+        jsonModulesEnabled ? `createBlob('${jsonModulesCheck}'.replace('x',createBlob('{}','text/json')))` : 'false'}].map(x =>typeof x==='string'?import(x).then(x =>!!x,()=>false):x)).then(a=>parent.postMessage(a,'*'))<${''}/script>`;
       // setting srcdoc is not supported in React native webviews on iOS
       // setting src to a blob URL results in a navigation event in webviews
       // document.write gives usability warnings

--- a/src/features.js
+++ b/src/features.js
@@ -41,9 +41,9 @@ export const featureDetectionPromise = Promise.resolve(supportsImportMaps || sup
       }
       window.addEventListener('message', cb, false);
 
-      const importMapTest = `<script nonce=${nonce}>const createBlob=(s,type='text/javascript')=>URL.createObjectURL(new Blob([s],{type}));document.head.appendChild(Object.assign(document.createElement('script'),{type:'importmap',nonce:"${nonce}",innerText:\`{"imports":{"x":"\${createBlob('')}"}}\`}));Promise.all([${
-        supportsImportMaps ? 'true, true' : `'x',createBlob('${importMetaCheck}')`}, ${cssModulesEnabled ? `createBlob('${cssModulesCheck}'.replace('x',createBlob('','text/css')))` : 'false'}, ${
-        jsonModulesEnabled ? `createBlob('${jsonModulesCheck}'.replace('x',createBlob('{}','text/json')))` : 'false'}].map(x =>typeof x==='string'?import(x).then(x =>!!x,()=>false):x)).then(a=>parent.postMessage(a,'*'))<${''}/script>`;
+      const importMapTest = `<script nonce=${nonce}>const b=(s,type='text/javascript')=>URL.createObjectURL(new Blob([s],{type}));document.head.appendChild(Object.assign(document.createElement('script'),{type:'importmap',nonce:"${nonce}",innerText:\`{"imports":{"x":"\${b('')}"}}\`}));Promise.all([${
+        supportsImportMaps ? 'true,true' : `'x',b('${importMetaCheck}')`}, ${cssModulesEnabled ? `b('${cssModulesCheck}'.replace('x',b('','text/css')))` : 'false'}, ${
+        jsonModulesEnabled ? `b('${jsonModulesCheck}'.replace('x',b('{}','text/json')))` : 'false'}].map(x =>typeof x==='string'?import(x).then(x =>!!x,()=>false):x)).then(a=>parent.postMessage(a,'*'))<${''}/script>`;
       // setting srcdoc is not supported in React native webviews on iOS
       // setting src to a blob URL results in a navigation event in webviews
       // document.write gives usability warnings

--- a/test/frame.html
+++ b/test/frame.html
@@ -1,0 +1,19 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <script type="importmap">
+  {
+    "imports": {
+      "x": "/test/fixtures/test-dep.js"
+    }
+  }
+  </script>
+  <script type="module" src="../src/es-module-shims.js" crossorigin="anonymous"></script>
+  <script type="module">
+    import 'x';
+    window.parent.postMessage('OK', '*');
+  </script>
+</head>
+<body>
+</body>
+</html>

--- a/test/server.mjs
+++ b/test/server.mjs
@@ -152,7 +152,7 @@ const server = http.createServer(async function (req, res) {
     mime = mimes[path.extname(filePath)] || 'text/plain';
 
   const headers = filePath.endsWith('content-type-none.json') ?
-    {} : { 'content-type': mime, 'Cache-Control': 'no-cache' }
+    {} : { 'Access-Control-Allow-Origin': '*', 'Content-Type': mime, 'Cache-Control': 'no-cache' }
 
   res.writeHead(200, headers);
   fileStream.pipe(res);

--- a/test/test-iframe-sandbox.html
+++ b/test/test-iframe-sandbox.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type" />
+    <meta content="utf-8" http-equiv="encoding" />
+  </head>
+  <body>
+    <script>
+      window.addEventListener('message', ({ data }) => {
+        if (data === 'OK')
+          fetch('/done');
+      });
+    </script>
+    <iframe sandbox="allow-scripts allow-forms" id="output-iframe" src="frame.html"></iframe>
+  </body>
+</html>


### PR DESCRIPTION
This resolves https://github.com/guybedford/es-module-shims/issues/324 in ensuring that es-module-shims can be supported itself in a sandboxed iframe.

We update the iframe communication to use postMessage, and ensure that the feature detection source blobs are generated in the frame doing the feature detection.