### PR TITLE
fix: reinstate DOMContentLoaded script attachments

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -499,8 +499,8 @@ if (hasDocument) {
   document.addEventListener('DOMContentLoaded', async () => {
     await initPromise;
     if (shimMode || !baselinePassthrough) {
-      domContentLoadedCheck();
       processScriptsAndPreloads();
+      domContentLoadedCheck();
     }
   });
 }

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -498,8 +498,10 @@ function domContentLoadedCheck () {
 if (hasDocument) {
   document.addEventListener('DOMContentLoaded', async () => {
     await initPromise;
-    if (shimMode || !baselinePassthrough)
+    if (shimMode || !baselinePassthrough) {
       domContentLoadedCheck();
+      processScriptsAndPreloads();
+    }
   });
 }
 


### PR DESCRIPTION
This reinstates a DOM iteration for DOMContentLoaded in case any script injections were missed by the mutation observers / initialization process.