### PR TITLE
fix: early hoisting tdz errors

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -306,9 +306,9 @@ function resolveDeps (load, seen) {
       }
     }
 
-    // support progressive cycle binding updates
+    // support progressive cycle binding updates (try statement avoids tdz errors)
     if (load.s)
-      resolvedSource += `\n;import{u$_}from'${load.s}';u$_({ ${exports.filter(e => e.ln).map(({ s, e, ln }) => `${source.slice(s, e)}: ${ln}`).join(',')} });\n`;
+      resolvedSource += `\n;import{u$_}from'${load.s}';try{u$_({${exports.filter(e => e.ln).map(({ s, e, ln }) => `${source.slice(s, e)}: ${ln}`).join(',')}})}catch(_){};\n`;
 
     pushStringTo(source.length);
   }

--- a/test/fixtures/es-modules/tdz.js
+++ b/test/fixtures/es-modules/tdz.js
@@ -1,0 +1,7 @@
+import { tdz as ownTdz } from './tdz.js';
+
+export function checkTDZ () {
+  return ownTdz;
+}
+
+export let tdz = 'tdz';

--- a/test/shim.js
+++ b/test/shim.js
@@ -175,6 +175,11 @@ suite('Basic loading tests', () => {
 });
 
 suite('Circular dependencies', function() {
+  test('Should handle self-import tdzs', async function () {
+    var m = await importShim('./fixtures/es-modules/tdz.js');
+    assert.equal(m.checkTDZ(), 'tdz');
+  });
+
   test('should resolve circular dependencies', async function () {
     var m = await importShim('./fixtures/test-cycle.js');
     assert.equal(m.default, 'f');


### PR DESCRIPTION
The cycle hoisting work in https://github.com/guybedford/es-module-shims/pull/311 opened up a new class of TDZ errors, where hoisted bindings that are in TDZ would throw at access in this hoisting.

This resolves https://github.com/guybedford/es-module-shims/issues/331, as described there, by wrapping the early cycle hoisting process in a try-catch to avoid these errors. Because the post-update hook will still catch the binding updates nothing is lost. More fine-grained hoisting approaches are still possible based on better analysis in future, but let's see those cases come up first.