### PR TITLE
feat: skip array option

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ In such a case, this double event firing can be disabled with the `noLoadEventRe
 
 When loading modules that you know will only use baseline modules features, it is possible to set a rule to explicitly opt-out modules from rewriting. This improves performance because those modules then do not need to be processed or transformed at all, so that only local application code is handled and not library code.
 
-The `skip` option supports a string regular expression, function or array of exact module URLs to check:
+The `skip` option supports a string regular expression or array of exact module URLs to check:
 
 ```js
 <script type="esms-options">

--- a/README.md
+++ b/README.md
@@ -626,12 +626,23 @@ In such a case, this double event firing can be disabled with the `noLoadEventRe
 
 When loading modules that you know will only use baseline modules features, it is possible to set a rule to explicitly opt-out modules from rewriting. This improves performance because those modules then do not need to be processed or transformed at all, so that only local application code is handled and not library code.
 
-This can be configured by providing a URL regular expression for the `skip` option:
+The `skip` option supports a string regular expression, function or array of exact module URLs to check:
 
 ```js
 <script type="esms-options">
 {
-  "skip": "/^https?:\/\/(cdn\.skypack\.dev|jspm\.dev)\//"
+  "skip": "^https?:\/\/(cdn\.skypack\.dev|jspm\.dev)\/"
+}
+</script>
+<script async src="es-module-shims.js"></script>
+```
+
+When passing an array, relative URLs or paths ending in `/` can be provided:
+
+```js
+<script type="esms-options">
+{
+  "skip": ["./app.js", "https://jspm.dev/"]
 }
 </script>
 <script async src="es-module-shims.js"></script>

--- a/src/env.js
+++ b/src/env.js
@@ -15,8 +15,6 @@ export const resolveHook = globalHook(shimMode && esmsInitOptions.resolve);
 export let fetchHook = esmsInitOptions.fetch ? globalHook(esmsInitOptions.fetch) : fetch;
 export const metaHook = esmsInitOptions.meta ? globalHook(shimMode && esmsInitOptions.meta) : noop;
 
-export const skip = esmsInitOptions.skip ? new RegExp(esmsInitOptions.skip) : null;
-
 export const mapOverrides = esmsInitOptions.mapOverrides;
 
 export let nonce = esmsInitOptions.nonce;
@@ -50,6 +48,15 @@ export const baseUrl = hasDocument
     : location.pathname}`;
 
 export const createBlob = (source, type = 'text/javascript') => URL.createObjectURL(new Blob([source], { type }));
+export let { skip } = esmsInitOptions;
+if (Array.isArray(skip)) {
+  const l = skip.map(s => new URL(s, baseUrl).href);
+  skip = s => l.some(i => i[i.length - 1] === '/' && s.startsWith(i) || s === i);
+}
+else if (typeof skip === 'string') {
+  const r = new RegExp(skip);
+  skip = s => s.test(r);
+}
 
 const eoop = err => setTimeout(() => { throw err });
 

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -451,6 +451,7 @@ function getOrCreateLoad (url, fetchOpts, parent, source) {
       const { r, b } = await resolve(n, load.r || load.u);
       if (b && (!supportsImportMaps || importMapSrcOrLazy))
         load.n = true;
+      if (d !== -1) return;      
       if (skip && skip.test(r)) return { b: r };
       if (childFetchOpts.integrity)
         childFetchOpts = Object.assign({}, childFetchOpts, { integrity: undefined });


### PR DESCRIPTION
Adds a new array value type to the `skip` option, corresponding to a list of exact URLs to skip or URL paths to skip. Can be relative or absolute URLs.