### PR TITLE
Change property readers to camelCasing

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -451,7 +451,7 @@ function getOrCreateLoad (url, fetchOpts, parent, source) {
       const { r, b } = await resolve(n, load.r || load.u);
       if (b && (!supportsImportMaps || importMapSrcOrLazy))
         load.n = true;
-      if (d !== -1) return;      
+      if (d !== -1) return;
       if (skip && skip(r)) return { b: r };
       if (childFetchOpts.integrity)
         childFetchOpts = Object.assign({}, childFetchOpts, { integrity: undefined });
@@ -477,11 +477,11 @@ function getFetchOpts (script) {
   const fetchOpts = {};
   if (script.integrity)
     fetchOpts.integrity = script.integrity;
-  if (script.referrerpolicy)
-    fetchOpts.referrerPolicy = script.referrerpolicy;
-  if (script.crossorigin === 'use-credentials')
+  if (script.referrerPolicy)
+    fetchOpts.referrerPolicy = script.referrerPolicy;
+  if (script.crossOrigin === 'use-credentials')
     fetchOpts.credentials = 'include';
-  else if (script.crossorigin === 'anonymous')
+  else if (script.crossOrigin === 'anonymous')
     fetchOpts.credentials = 'omit';
   else
     fetchOpts.credentials = 'same-origin';


### PR DESCRIPTION
The casing of the `<script>` element's [crossorigin][] and [referrerpolicy][] HTML _attributes_ differ from the casing of [HTMLScriptElement.crossOrigin][] and
[HTMLScriptElement.referrerPolicy][] _properties_.

Prior to this commit, the implementation erroneously attempted to read values from the _properties_ through names cased as if they were _attributes_.

This commit replaces the lower-cased accesses with camelCased ones.

[crossorigin]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-crossorigin
[referrerpolicy]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-referrerpolicy
[HTMLScriptElement.crossOrigin]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement#instance_properties
[HTMLScriptElement.referrerPolicy]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement/referrerPolicy