### PR TITLE
fix: native inline deduping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           CI_BROWSER: C:\Program Files\Firefox_${{ matrix.firefox }}\firefox.exe
           CI_BROWSER_FLAGS: -headless
-          CI_BROWSER_FLUSH: taskkill /IM C:\Program Files\Firefox_${{ matrix.firefox }}\firefox.exe /F
+          CI_BROWSER_FLUSH: taskkill /F /P
 
   test-chrome:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           CI_BROWSER: C:\Program Files\Firefox_${{ matrix.firefox }}\firefox.exe
           CI_BROWSER_FLAGS: -headless
-          CI_BROWSER_FLUSH: taskkill /F /P
+          CI_BROWSER_FLUSH: taskkill /F /IM
 
   test-chrome:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           CI_BROWSER: C:\Program Files\Firefox_${{ matrix.firefox }}\firefox.exe
           CI_BROWSER_FLAGS: -headless
-          CI_BROWSER_FLUSH: taskkill /IM firefox.exe /F
+          CI_BROWSER_FLUSH: taskkill /IM C:\Program Files\Firefox_${{ matrix.firefox }}\firefox.exe /F
 
   test-chrome:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           CI_BROWSER: C:\Program Files\Firefox_${{ matrix.firefox }}\firefox.exe
           CI_BROWSER_FLAGS: -headless
-          CI_BROWSER_FLUSH: taskkill /F /IM
+          CI_BROWSER_FLUSH: taskkill /F /IM firefox.exe
 
   test-chrome:
     runs-on: windows-latest

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -187,9 +187,9 @@ async function topLevelLoad (url, fetchOpts, source, nativelyLoaded, lastStaticL
   resolveDeps(load, seen);
   await lastStaticLoadPromise;
   if (source && !shimMode && !load.n && !self.ESMS_DEBUG) {
-    const module = await dynamicImport(createBlob(source), { errUrl: source });
+    if (nativelyLoaded) return;
     if (revokeBlobURLs) revokeObjectURLs(Object.keys(seen));
-    return module;
+    return await dynamicImport(createBlob(source), { errUrl: source });
   }
   if (firstPolyfillLoad && !shimMode && load.n && nativelyLoaded) {
     onpolyfill();

--- a/test/server.mjs
+++ b/test/server.mjs
@@ -167,8 +167,8 @@ async function start () {
   if (process.env.CI_BROWSER) {
     const args = process.env.CI_BROWSER_FLAGS ? process.env.CI_BROWSER_FLAGS.split(' ') : [];
     if (process.env.CI_BROWSER_FLUSH) {
-      console.log('Flushing browser: ' + process.env.CI_BROWSER_FLUSH + ' ' + spawnPs);
-      try { execSync(process.env.CI_BROWSER_FLUSH + ' ' + spawnPs) } catch (e) {
+      console.log('Flushing browser: ' + process.env.CI_BROWSER_FLUSH + ' ' + spawnPs.pid);
+      try { execSync(process.env.CI_BROWSER_FLUSH + ' ' + spawnPs.pid) } catch (e) {
         console.log(e);
       }
       await new Promise(resolve => setTimeout(resolve, 500));

--- a/test/server.mjs
+++ b/test/server.mjs
@@ -166,9 +166,9 @@ let baseURL;
 async function start () {
   if (process.env.CI_BROWSER) {
     const args = process.env.CI_BROWSER_FLAGS ? process.env.CI_BROWSER_FLAGS.split(' ') : [];
-    if (process.env.CI_BROWSER_FLUSH && spawnPs) {
-      console.log('Flushing browser: ' + process.env.CI_BROWSER_FLUSH + ' ' + spawnPs.spawnfile);
-      try { execSync(process.env.CI_BROWSER_FLUSH + ' ' + spawnPs.spawnfile) } catch (e) {
+    if (process.env.CI_BROWSER_FLUSH) {
+      console.log('Flushing browser: ' + process.env.CI_BROWSER_FLUSH);
+      try { execSync(process.env.CI_BROWSER_FLUSH) } catch (e) {
         console.log(e);
       }
       await new Promise(resolve => setTimeout(resolve, 500));

--- a/test/server.mjs
+++ b/test/server.mjs
@@ -167,8 +167,8 @@ async function start () {
   if (process.env.CI_BROWSER) {
     const args = process.env.CI_BROWSER_FLAGS ? process.env.CI_BROWSER_FLAGS.split(' ') : [];
     if (process.env.CI_BROWSER_FLUSH) {
-      console.log('Flushing browser: ' + process.env.CI_BROWSER_FLUSH);
-      try { execSync(process.env.CI_BROWSER_FLUSH) } catch (e) {
+      console.log('Flushing browser: ' + process.env.CI_BROWSER_FLUSH + ' ' + spawnPs);
+      try { execSync(process.env.CI_BROWSER_FLUSH + ' ' + spawnPs) } catch (e) {
         console.log(e);
       }
       await new Promise(resolve => setTimeout(resolve, 500));

--- a/test/server.mjs
+++ b/test/server.mjs
@@ -166,7 +166,7 @@ let baseURL;
 async function start () {
   if (process.env.CI_BROWSER) {
     const args = process.env.CI_BROWSER_FLAGS ? process.env.CI_BROWSER_FLAGS.split(' ') : [];
-    if (process.env.CI_BROWSER_FLUSH) {
+    if (process.env.CI_BROWSER_FLUSH && spawnPs) {
       console.log('Flushing browser: ' + process.env.CI_BROWSER_FLUSH + ' ' + spawnPs.spawnfile);
       try { execSync(process.env.CI_BROWSER_FLUSH + ' ' + spawnPs.spawnfile) } catch (e) {
         console.log(e);

--- a/test/server.mjs
+++ b/test/server.mjs
@@ -167,8 +167,8 @@ async function start () {
   if (process.env.CI_BROWSER) {
     const args = process.env.CI_BROWSER_FLAGS ? process.env.CI_BROWSER_FLAGS.split(' ') : [];
     if (process.env.CI_BROWSER_FLUSH) {
-      console.log('Flushing browser: ' + process.env.CI_BROWSER_FLUSH + ' ' + spawnPs.pid);
-      try { execSync(process.env.CI_BROWSER_FLUSH + ' ' + spawnPs.pid) } catch (e) {
+      console.log('Flushing browser: ' + process.env.CI_BROWSER_FLUSH + ' ' + spawnPs.spawnfile);
+      try { execSync(process.env.CI_BROWSER_FLUSH + ' ' + spawnPs.spawnfile) } catch (e) {
         console.log(e);
       }
       await new Promise(resolve => setTimeout(resolve, 500));


### PR DESCRIPTION
This fixes the case where an inline `<script type="module">import('./rel.js')</script>` would execute as a blob URL unexpectedly since the paths for a dynamic import and an inline module execution are currently overlapping.

Instead, in the case of an inline module execution, we explicitly avoid reexecution.

When dynamically importing an existing module with `importShim('./path.js')`, we can still risk reexecution but that is because we are using the shim loader instance specifically in this case.

This should avoid mixups like in https://github.com/guybedford/es-module-shims/issues/355. Some documentation updates are also included.