### PR TITLE
fix: feature detection, add debug build

### DIFF
--- a/chompfile.toml
+++ b/chompfile.toml
@@ -2,8 +2,6 @@ version = 0.1
 
 extensions = ['chomp@0.1:footprint', 'chomp@0.1:npm']
 
-default-task = 'build'
-
 [server]
 port = 8080
 root = "."
@@ -18,7 +16,7 @@ run = 'rm -rf bench/results'
 
 [[task]]
 name = 'build'
-targets = ['dist/es-module-shims.js', 'dist/es-module-shims.wasm.js']
+targets = ['dist/es-module-shims.js', 'dist/es-module-shims.wasm.js', 'dist/es-module-shims.debug.js']
 deps = ['src/*.js', 'npm:install', 'README.md']
 run = 'rollup -c'
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,7 +20,7 @@ function config (isWasm, isDebug) {
       format: 'iife',
       strict: false,
       sourcemap: false,
-      banner: `/* ES Module Shims ${isWasm ? 'Wasm ' : ''}${version} */`
+      banner: `/* ES Module Shims ${isWasm ? 'Wasm ' : ''}${isDebug ? 'DEBUG BUILD ' : ''}${version} */`
     },
     plugins: [
       {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,17 +5,18 @@ import path from 'path';
 const version = JSON.parse(fs.readFileSync('package.json')).version;
 
 export default [
-  config(true),
-  config(false),
+  config(true, false),
+  config(false, false),
+  config(false, true),
 ];
 
-function config (isWasm) {
+function config (isWasm, isDebug) {
   const name = 'es-module-shims'
 
   return {
     input: `src/${name}.js`,
     output: {
-      file: `dist/${name}${isWasm ? '.wasm' : ''}.js`,
+      file: `dist/${name}${isWasm ? '.wasm' : ''}${isDebug ? '.debug' : ''}.js`,
       format: 'iife',
       strict: false,
       sourcemap: false,
@@ -29,7 +30,7 @@ function config (isWasm) {
         }
       },
       replace({
-        'self.ESMS_DEBUG': 'false',
+        'self.ESMS_DEBUG': isDebug.toString(),
         preventAssignment: true
       }),
     ]

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -120,7 +120,6 @@ let importMap = { imports: {}, scopes: {} };
 let baselinePassthrough;
 
 const initPromise = featureDetectionPromise.then(() => {
-  if (self.ESMS_DEBUG) console.info(`es-module-shims: detected native support - ${supportsDynamicImport ? '' : 'no '}dynamic import, ${supportsImportMeta ? '' : 'no '}import meta, ${supportsImportMap ? '' : 'no '}import maps`);
   baselinePassthrough = esmsInitOptions.polyfillEnable !== true && supportsDynamicImport && supportsImportMeta && supportsImportMaps && (!jsonModulesEnabled || supportsJsonAssertions) && (!cssModulesEnabled || supportsCssAssertions) && !importMapSrcOrLazy;
   if (self.ESMS_DEBUG) console.info(`es-module-shims: init ${shimMode ? 'shim mode' : 'polyfill mode'}, ${baselinePassthrough ? 'baseline passthrough' : 'polyfill engaged'}`);
   if (hasDocument) {

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -120,7 +120,7 @@ let importMap = { imports: {}, scopes: {} };
 let baselinePassthrough;
 
 const initPromise = featureDetectionPromise.then(() => {
-  if (self.ESMS_DEBUG) console.info(`es-module-shims: detected native support - ${supportsDynamicImport ? '' : 'no '}dynamic import, ${supportsImportMeta ? '' : 'no '}import meta, ${supportsImportMap ? '' : 'no '}import maps, ${supportsJsonAssertions ? '' : 'no '}JSON modules, ${supportsCssAssertions ? '' : 'no '}CSS modules`);
+  if (self.ESMS_DEBUG) console.info(`es-module-shims: detected native support - ${supportsDynamicImport ? '' : 'no '}dynamic import, ${supportsImportMeta ? '' : 'no '}import meta, ${supportsImportMap ? '' : 'no '}import maps`);
   baselinePassthrough = esmsInitOptions.polyfillEnable !== true && supportsDynamicImport && supportsImportMeta && supportsImportMaps && (!jsonModulesEnabled || supportsJsonAssertions) && (!cssModulesEnabled || supportsCssAssertions) && !importMapSrcOrLazy;
   if (self.ESMS_DEBUG) console.info(`es-module-shims: init ${shimMode ? 'shim mode' : 'polyfill mode'}, ${baselinePassthrough ? 'baseline passthrough' : 'polyfill engaged'}`);
   if (hasDocument) {

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -120,6 +120,7 @@ let importMap = { imports: {}, scopes: {} };
 let baselinePassthrough;
 
 const initPromise = featureDetectionPromise.then(() => {
+  if (self.ESMS_DEBUG) console.info(`es-module-shims: detected native support - ${supportsDynamicImport ? '' : 'no '}dynamic import, ${supportsImportMeta ? '' : 'no '}import meta, ${supportsImportMap ? '' : 'no '}import maps, ${supportsJsonAssertions ? '' : 'no '}JSON modules, ${supportsCssAssertions ? '' : 'no '}CSS modules`);
   baselinePassthrough = esmsInitOptions.polyfillEnable !== true && supportsDynamicImport && supportsImportMeta && supportsImportMaps && (!jsonModulesEnabled || supportsJsonAssertions) && (!cssModulesEnabled || supportsCssAssertions) && !importMapSrcOrLazy;
   if (self.ESMS_DEBUG) console.info(`es-module-shims: init ${shimMode ? 'shim mode' : 'polyfill mode'}, ${baselinePassthrough ? 'baseline passthrough' : 'polyfill engaged'}`);
   if (hasDocument) {

--- a/src/features.js
+++ b/src/features.js
@@ -5,7 +5,9 @@ import { createBlob, noop, nonce, cssModulesEnabled, jsonModulesEnabled, hasDocu
 export let supportsJsonAssertions = false;
 export let supportsCssAssertions = false;
 
-export let supportsImportMaps = hasDocument && HTMLScriptElement.supports ? HTMLScriptElement.supports('importmap') : false;
+const supports = HTMLScriptElement.supports;
+
+export let supportsImportMaps = hasDocument && supports ? supports.name === 'supports' && supports('importmap') : false;
 export let supportsImportMeta = supportsImportMaps;
 
 const importMetaCheck = 'import.meta';

--- a/src/features.js
+++ b/src/features.js
@@ -25,9 +25,6 @@ export let featureDetectionPromise = Promise.resolve(dynamicImportCheck).then(()
       jsonModulesEnabled && dynamicImport(createBlob(jsonModulescheck.replace('x', createBlob('{}', 'text/json')))).then(() => supportsJsonAssertions = true, noop),
     ]);
 
-  if (supports || (!cssModulesEnabled && !jsonModulesEnabled))
-    return;
-
   return new Promise(resolve => {
     if (self.ESMS_DEBUG) console.info(`es-module-shims: performing feature detections for ${`${supportsImportMaps ? '' : 'import maps, '}${cssModulesEnabled ? 'css modules, ' : ''}${jsonModulesEnabled ? 'json modules, ' : ''}`.slice(0, -2)}`);
     const iframe = document.createElement('iframe');
@@ -47,6 +44,7 @@ export let featureDetectionPromise = Promise.resolve(dynamicImportCheck).then(()
     const importMapTest = `<script nonce=${nonce || ''}>b=(s,type='text/javascript')=>URL.createObjectURL(new Blob([s],{type}));document.head.appendChild(Object.assign(document.createElement('script'),{type:'importmap',nonce:"${nonce}",innerText:\`{"imports":{"x":"\${b('')}"}}\`}));Promise.all([${
       supportsImportMaps ? 'true,true' : `'x',b('${importMetaCheck}')`}, ${cssModulesEnabled ? `b('${cssModulesCheck}'.replace('x',b('','text/css')))` : 'false'}, ${
       jsonModulesEnabled ? `b('${jsonModulesCheck}'.replace('x',b('{}','text/json')))` : 'false'}].map(x =>typeof x==='string'?import(x).then(x =>!!x,()=>false):x)).then(a=>parent.postMessage(a,'*'))<${''}/script>`;
+    if (self.ESMS_DEBUG) console.info(`RUNNING FEATURE DETECTION TEST SCRIPT:\n${importMapTest}\n\n`);
 
     iframe.onload = () => {
       // WeChat browser doesn't support setting srcdoc scripts

--- a/src/features.js
+++ b/src/features.js
@@ -45,7 +45,7 @@ export let featureDetectionPromise = Promise.resolve(dynamicImportCheck).then(()
     }
     window.addEventListener('message', cb, false);
 
-    const importMapTest = `<script nonce=${nonce || ''}>self.b=(s,type='text/javascript')=>URL.createObjectURL(new Blob([s],{type}));document.head.appendChild(Object.assign(document.createElement('script'),{type:'importmap',nonce:"${nonce}",innerText:\`{"imports":{"x":"\${b('')}"}}\`}));Promise.all([${
+    const importMapTest = `<script nonce=${nonce || ''}>b=(s,type='text/javascript')=>URL.createObjectURL(new Blob([s],{type}));document.head.appendChild(Object.assign(document.createElement('script'),{type:'importmap',nonce:"${nonce}",innerText:\`{"imports":{"x":"\${b('')}"}}\`}));Promise.all([${
       supportsImportMaps ? 'true,true' : `'x',b('${importMetaCheck}')`}, ${cssModulesEnabled ? `b('${cssModulesCheck}'.replace('x',b('','text/css')))` : 'false'}, ${
       jsonModulesEnabled ? `b('${jsonModulesCheck}'.replace('x',b('{}','text/json')))` : 'false'}].map(x =>typeof x==='string'?import(x).then(x =>!!x,()=>false):x)).then(a=>parent.postMessage(a,'*'))<${''}/script>`;
 

--- a/src/features.js
+++ b/src/features.js
@@ -26,6 +26,7 @@ export const featureDetectionPromise = Promise.resolve(dynamicImportCheck).then(
     ]);
 
   return new Promise(resolve => {
+    if (self.ESMS_DEBUG) console.info(`es-module-shims: performing feature detections for ${`${supportsImportMaps ? 'import maps, ' : ''}${cssModulesEnabled ? 'css modules, ' : ''}${jsonModulesEnabled ? 'json modules, ' : ''}`.slice(0, -2)}`);
     const iframe = document.createElement('iframe');
     iframe.style.display = 'none';
     iframe.setAttribute('nonce', nonce);
@@ -34,6 +35,7 @@ export const featureDetectionPromise = Promise.resolve(dynamicImportCheck).then(
       supportsImportMeta = b;
       supportsCssAssertions = c;
       supportsJsonAssertions = d;
+      if (self.ESMS_DEBUG) console.info(`es-module-shims: detected native support - ${supportsDynamicImport ? '' : 'no '}dynamic import, ${supportsImportMeta ? '' : 'no '}import meta, ${supportsImportMap ? '' : 'no '}import maps`);
       resolve();
       document.head.removeChild(iframe);
       window.removeEventListener('message', cb, false);

--- a/src/features.js
+++ b/src/features.js
@@ -8,7 +8,7 @@ export let supportsCssAssertions = false;
 const supports = hasDocument && HTMLScriptElement.supports;
 
 export let supportsImportMaps = supports && supports.name === 'supports' && supports('importmap');
-export let supportsImportMeta = !!supports;
+export let supportsImportMeta = supportsDynamicImport;
 
 const importMetaCheck = 'import.meta';
 const cssModulesCheck = `import"x"assert{type:"css"}`;
@@ -30,23 +30,33 @@ export let featureDetectionPromise = Promise.resolve(dynamicImportCheck).then(()
     const iframe = document.createElement('iframe');
     iframe.style.display = 'none';
     iframe.setAttribute('nonce', nonce);
-    function cb ({ data: [a, b, c, d] }) {
-      supportsImportMaps = a;
-      supportsImportMeta = b;
-      supportsCssAssertions = c;
-      supportsJsonAssertions = d;
+    function cb ({ data }) {
+      // failed feature detection (security policy) -> revert to default assumptions
+      if (Array.isArray(data)) {
+        supportsImportMaps = data[0];
+        supportsImportMeta = data[1];
+        supportsCssAssertions = data[2];
+        supportsJsonAssertions = data[3];
+      }
+      else if (self.ESMS_DEBUG) console.info(`es-module-shims: feature detection failure, using defaults`);
       resolve();
       document.head.removeChild(iframe);
       window.removeEventListener('message', cb, false);
     }
     window.addEventListener('message', cb, false);
 
-    const importMapTest = `<script nonce=${nonce || ''}>b=(s,type='text/javascript')=>URL.createObjectURL(new Blob([s],{type}));document.head.appendChild(Object.assign(document.createElement('script'),{type:'importmap',nonce:"${nonce}",innerText:\`{"imports":{"x":"\${b('')}"}}\`}));Promise.all([${
+    const importMapTest = `<script nonce=${nonce || ''}>self.b=(s,type='text/javascript')=>URL.createObjectURL(new Blob([s],{type}));document.head.appendChild(Object.assign(document.createElement('script'),{type:'importmap',nonce:"${nonce}",innerText:\`{"imports":{"x":"\${b('')}"}}\`}));Promise.all([${
       supportsImportMaps ? 'true,true' : `'x',b('${importMetaCheck}')`}, ${cssModulesEnabled ? `b('${cssModulesCheck}'.replace('x',b('','text/css')))` : 'false'}, ${
       jsonModulesEnabled ? `b('${jsonModulesCheck}'.replace('x',b('{}','text/json')))` : 'false'}].map(x =>typeof x==='string'?import(x).then(x =>!!x,()=>false):x)).then(a=>parent.postMessage(a,'*'))<${''}/script>`;
-    if (self.ESMS_DEBUG) console.info(`RUNNING FEATURE DETECTION TEST SCRIPT:\n${importMapTest}\n\n`);
 
-    iframe.onload = () => {
+    // Safari will call onload eagerly on head injection, but we don't want the Wechat
+    // path to trigger before setting srcdoc, therefore we track the timing
+    let readyForOnload = false, onloadCalledWhileNotReady = false;
+    function doOnload () {
+      if (!readyForOnload) {
+        onloadCalledWhileNotReady = true;
+        return;
+      }
       // WeChat browser doesn't support setting srcdoc scripts
       // But iframe sandboxes don't support contentDocument so we do this as a fallback
       const doc = iframe.contentDocument;
@@ -57,16 +67,22 @@ export let featureDetectionPromise = Promise.resolve(dynamicImportCheck).then(()
         s.innerHTML = importMapTest.slice(15 + (nonce ? nonce.length : 0), -9);
         doc.head.appendChild(s);
       }
-    };
+    }
+
+    iframe.onload = doOnload;
     // WeChat browser requires append before setting srcdoc
     document.head.appendChild(iframe);
+
     // setting srcdoc is not supported in React native webviews on iOS
     // setting src to a blob URL results in a navigation event in webviews
     // document.write gives usability warnings
+    readyForOnload = true;
     if ('srcdoc' in iframe)
       iframe.srcdoc = importMapTest;
     else
       iframe.contentDocument.write(importMapTest);
+    // retrigger onload for Safari only if necessary
+    if (onloadCalledWhileNotReady) doOnload();
   });
 });
 

--- a/src/features.js
+++ b/src/features.js
@@ -26,7 +26,8 @@ export const featureDetectionPromise = Promise.resolve(dynamicImportCheck).then(
     ]);
 
   return new Promise(resolve => {
-    if (self.ESMS_DEBUG) console.info(`es-module-shims: performing feature detections for ${`${supportsImportMaps ? 'import maps, ' : ''}${cssModulesEnabled ? 'css modules, ' : ''}${jsonModulesEnabled ? 'json modules, ' : ''}`.slice(0, -2)}`);
+    if (self.ESMS_DEBUG) if (supportsImportMaps) console.info(`es-module-shims: import maps supported from HTMLScriptElement check`);
+    if (self.ESMS_DEBUG) console.info(`es-module-shims: performing feature detections for ${`${supportsImportMaps ? '' : 'import maps, '}${cssModulesEnabled ? 'css modules, ' : ''}${jsonModulesEnabled ? 'json modules, ' : ''}`.slice(0, -2)}`);
     const iframe = document.createElement('iframe');
     iframe.style.display = 'none';
     iframe.setAttribute('nonce', nonce);
@@ -35,7 +36,7 @@ export const featureDetectionPromise = Promise.resolve(dynamicImportCheck).then(
       supportsImportMeta = b;
       supportsCssAssertions = c;
       supportsJsonAssertions = d;
-      if (self.ESMS_DEBUG) console.info(`es-module-shims: detected native support - ${supportsDynamicImport ? '' : 'no '}dynamic import, ${supportsImportMeta ? '' : 'no '}import meta, ${supportsImportMap ? '' : 'no '}import maps`);
+      if (self.ESMS_DEBUG) console.info(`es-module-shims: detected native support - ${supportsDynamicImport ? '' : 'no '}dynamic import, ${supportsImportMeta ? '' : 'no '}import meta, ${supportsImportMaps ? '' : 'no '}import maps`);
       resolve();
       document.head.removeChild(iframe);
       window.removeEventListener('message', cb, false);

--- a/test/test-shim-map-overrides.html
+++ b/test/test-shim-map-overrides.html
@@ -25,8 +25,6 @@
     shimMode: true,
     mapOverrides: true,
   };
-
-  window.ESMS_DEBUG = true;
 </script>
 <script type="module" src="../src/es-module-shims.js"></script>
 <script type="module" noshim>

--- a/test/test-shim.html
+++ b/test/test-shim.html
@@ -77,8 +77,6 @@
     },
     onerror: e => window.e = e,
   };
-
-  window.ESMS_DEBUG = true;
 </script>
 <script type="module" src="../src/es-module-shims.js"></script>
 <script type="module" noshim>


### PR DESCRIPTION
This PR fixes #363, where the feature detection script in Safari in some special cases, handling undefined return from feature detection possibly due to security policy, and also more carefully guarding the Wechat fallback path.

Includes a debug build for diagnosing similar cases in future where we don't necessarily have a replication but need detailed debugging information.