### PR TITLE
Verify feature detection message

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/es-module-shims.js",
   "exports": {
     ".": "./dist/es-module-shims.js",
+    "./debug": "./dist/es-module-shims.debug.js",
     "./wasm": "./dist/es-module-shims.wasm.js"
   },
   "types": "index.d.ts",


### PR DESCRIPTION
I was also running into intermittent feature detection failures similar to the ones mentioned in https://github.com/guybedford/es-module-shims/issues/368 once I upgraded to 1.7.1 on https://reflame.app, so I made a custom build with some additional logging on the message callback function and found a pretty big clue:

![Screenshot 2023-04-20 at 4 28 18 PM](https://user-images.githubusercontent.com/6934200/233509645-af77260f-b0ac-4ef8-ad22-ef80f03fe9db.png)

Looks like the root of the issue might be that we're not verifying the source of the message, so anything that calls postMessage before es-module-shims (in this case the react dev tools extension) can cause feature detection to fail, often non-deterministically due to races.

Looking at this [previous related issue](https://github.com/guybedford/es-module-shims/issues/363), I think this is the more likely cause for that one too rather than some security policy (i.e. something on the page called postMessage with `undefined` as the message). So I removed the previous branch where we continue to resolve feature detection even after failing validation, and instead opting to return early and wait for the next message. WDYT?

Also, I added the debug build as an exported module so it can be accessed from the npm package as well.