### PR TITLE
Respect existing sourceURL when both sourceURL and sourceMappingURL exists

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -316,7 +316,8 @@ function resolveDeps (load, seen) {
   }
 
   let hasSourceURL = false;
-  resolvedSource = resolvedSource.replace(sourceMapURLRegEx, (match, isMapping, url) => (hasSourceURL = !isMapping, match.replace(url, () => new URL(url, load.r))));
+  resolvedSource = resolvedSource.replace(sourceURLRegEx, (match, url) => (hasSourceURL = true, match.replace(url, () => new URL(url, load.r))));
+  resolvedSource = resolvedSource.replace(sourceMapURLRegEx, (match, url) => match.replace(url, () => new URL(url, load.r)));
   if (!hasSourceURL)
     resolvedSource += '\n//# sourceURL=' + load.r;
 
@@ -326,7 +327,8 @@ function resolveDeps (load, seen) {
 
 // ; and // trailer support added for Ruby on Rails 7 source maps compatibility
 // https://github.com/guybedford/es-module-shims/issues/228
-const sourceMapURLRegEx = /\n\/\/# source(Mapping)?URL=([^\n]+)\s*((;|\/\/[^#][^\n]*)\s*)*$/;
+const sourceURLRegEx = /\n\/\/# sourceURL=([^\n]+)\s*((;|\/\/[^#][^\n]*)\s*)*(\n|$)/;
+const sourceMapURLRegEx = /\n\/\/# sourceMappingURL=([^\n]+)\s*((;|\/\/[^#][^\n]*)\s*)*(\n|$)/;
 
 const jsContentType = /^(text|application)\/(x-)?javascript(;|$)/;
 const jsonContentType = /^(text|application)\/json(;|$)/;

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -116,17 +116,6 @@ async function loadAll (load, seen) {
     load.n = load.d.some(dep => dep.n);
 }
 
-function replaceSourceComment (source, commentPrefix, commentStart, baseUrl) {
-  const urlStart = commentStart + commentPrefix.length
-
-  const commentEnd = source.indexOf('\n', urlStart)
-  const urlEnd = commentEnd !== -1 ? commentEnd : undefined
-
-  const url = new URL(source.slice(urlStart, urlEnd), baseUrl).toString()
-
-  return source.slice(0, urlStart) + url + (urlEnd ? source.slice(urlEnd) : '')
-}
-
 let importMap = { imports: {}, scopes: {} };
 let baselinePassthrough;
 
@@ -256,87 +245,102 @@ function resolveDeps (load, seen) {
   // edge doesnt execute sibling in order, so we fix this up by ensuring all previous executions are explicit dependencies
   let resolvedSource = edge && lastLoad ? `import '${lastLoad}';` : '';
 
-  if (!imports.length) {
-    resolvedSource += source;
-  }
-  else {
-    // once all deps have loaded we can inline the dependency resolution blobs
-    // and define this blob
-    let lastIndex = 0, depIndex = 0, dynamicImportEndStack = [];
-    function pushStringTo (originalIndex) {
-      while (dynamicImportEndStack[dynamicImportEndStack.length - 1] < originalIndex) {
-        const dynamicImportEnd = dynamicImportEndStack.pop();
-        resolvedSource += `${source.slice(lastIndex, dynamicImportEnd)}, ${urlJsString(load.r)}`;
-        lastIndex = dynamicImportEnd;
-      }
-      resolvedSource += source.slice(lastIndex, originalIndex);
-      lastIndex = originalIndex;
+  // once all deps have loaded we can inline the dependency resolution blobs
+  // and define this blob
+  let lastIndex = 0, depIndex = 0, dynamicImportEndStack = [];
+  function pushStringTo (originalIndex) {
+    while (dynamicImportEndStack[dynamicImportEndStack.length - 1] < originalIndex) {
+      const dynamicImportEnd = dynamicImportEndStack.pop();
+      resolvedSource += `${source.slice(lastIndex, dynamicImportEnd)}, ${urlJsString(load.r)}`;
+      lastIndex = dynamicImportEnd;
     }
-    for (const { s: start, ss: statementStart, se: statementEnd, d: dynamicImportIndex } of imports) {
-      // dependency source replacements
-      if (dynamicImportIndex === -1) {
-        let depLoad = load.d[depIndex++], blobUrl = depLoad.b, cycleShell = !blobUrl;
-        if (cycleShell) {
-          // circular shell creation
-          if (!(blobUrl = depLoad.s)) {
-            blobUrl = depLoad.s = createBlob(`export function u$_(m){${
-              depLoad.a[1].map(({ s, e }, i) => {
-                const q = depLoad.S[s] === '"' || depLoad.S[s] === "'";
-                return `e$_${i}=m${q ? `[` : '.'}${depLoad.S.slice(s, e)}${q ? `]` : ''}`;
-              }).join(',')
-            }}${
-              depLoad.a[1].length ? `let ${depLoad.a[1].map((_, i) => `e$_${i}`).join(',')};` : ''
-            }export {${
-              depLoad.a[1].map(({ s, e }, i) => `e$_${i} as ${depLoad.S.slice(s, e)}`).join(',')
-            }}\n//# sourceURL=${depLoad.r}?cycle`);
-          }
-        }
+    resolvedSource += source.slice(lastIndex, originalIndex);
+    lastIndex = originalIndex;
+  }
 
-        pushStringTo(start - 1);
-        resolvedSource += `/*${source.slice(start - 1, statementEnd)}*/${urlJsString(blobUrl)}`;
-
-        // circular shell execution
-        if (!cycleShell && depLoad.s) {
-          resolvedSource += `;import*as m$_${depIndex} from'${depLoad.b}';import{u$_ as u$_${depIndex}}from'${depLoad.s}';u$_${depIndex}(m$_${depIndex})`;
-          depLoad.s = undefined;
+  for (const { s: start, ss: statementStart, se: statementEnd, d: dynamicImportIndex } of imports) {
+    // dependency source replacements
+    if (dynamicImportIndex === -1) {
+      let depLoad = load.d[depIndex++], blobUrl = depLoad.b, cycleShell = !blobUrl;
+      if (cycleShell) {
+        // circular shell creation
+        if (!(blobUrl = depLoad.s)) {
+          blobUrl = depLoad.s = createBlob(`export function u$_(m){${
+            depLoad.a[1].map(({ s, e }, i) => {
+              const q = depLoad.S[s] === '"' || depLoad.S[s] === "'";
+              return `e$_${i}=m${q ? `[` : '.'}${depLoad.S.slice(s, e)}${q ? `]` : ''}`;
+            }).join(',')
+          }}${
+            depLoad.a[1].length ? `let ${depLoad.a[1].map((_, i) => `e$_${i}`).join(',')};` : ''
+          }export {${
+            depLoad.a[1].map(({ s, e }, i) => `e$_${i} as ${depLoad.S.slice(s, e)}`).join(',')
+          }}\n//# sourceURL=${depLoad.r}?cycle`);
         }
-        lastIndex = statementEnd;
       }
-      // import.meta
-      else if (dynamicImportIndex === -2) {
-        load.m = { url: load.r, resolve: metaResolve };
-        metaHook(load.m, load.u);
-        pushStringTo(start);
-        resolvedSource += `importShim._r[${urlJsString(load.u)}].m`;
-        lastIndex = statementEnd;
+
+      pushStringTo(start - 1);
+      resolvedSource += `/*${source.slice(start - 1, statementEnd)}*/${urlJsString(blobUrl)}`;
+
+      // circular shell execution
+      if (!cycleShell && depLoad.s) {
+        resolvedSource += `;import*as m$_${depIndex} from'${depLoad.b}';import{u$_ as u$_${depIndex}}from'${depLoad.s}';u$_${depIndex}(m$_${depIndex})`;
+        depLoad.s = undefined;
       }
-      // dynamic import
-      else {
-        pushStringTo(statementStart + 6);
-        resolvedSource += `Shim(`;
-        dynamicImportEndStack.push(statementEnd - 1);
-        lastIndex = start;
-      }
+      lastIndex = statementEnd;
     }
-
-    // support progressive cycle binding updates (try statement avoids tdz errors)
-    if (load.s)
-      resolvedSource += `\n;import{u$_}from'${load.s}';try{u$_({${exports.filter(e => e.ln).map(({ s, e, ln }) => `${source.slice(s, e)}:${ln}`).join(',')}})}catch(_){};\n`;
-
-    pushStringTo(source.length);
+    // import.meta
+    else if (dynamicImportIndex === -2) {
+      load.m = { url: load.r, resolve: metaResolve };
+      metaHook(load.m, load.u);
+      pushStringTo(start);
+      resolvedSource += `importShim._r[${urlJsString(load.u)}].m`;
+      lastIndex = statementEnd;
+    }
+    // dynamic import
+    else {
+      pushStringTo(statementStart + 6);
+      resolvedSource += `Shim(`;
+      dynamicImportEndStack.push(statementEnd - 1);
+      lastIndex = start;
+    }
   }
 
-  const sourceURLCommentStart = resolvedSource.lastIndexOf(sourceURLCommentPrefix)
-  if (sourceURLCommentStart !== -1) {
-    resolvedSource = replaceSourceComment(resolvedSource, sourceURLCommentPrefix, sourceURLCommentStart, load.r)
-  } else {
-    resolvedSource += sourceURLCommentPrefix + load.r;
+  // support progressive cycle binding updates (try statement avoids tdz errors)
+  if (load.s)
+    resolvedSource += `\n;import{u$_}from'${load.s}';try{u$_({${exports.filter(e => e.ln).map(({ s, e, ln }) => `${source.slice(s, e)}:${ln}`).join(',')}})}catch(_){};\n`;
+
+  function pushSourceURL (commentPrefix, commentStart) {
+    const urlStart = commentStart + commentPrefix.length;
+    const commentEnd = source.indexOf('\n', urlStart);
+    const urlEnd = commentEnd !== -1 ? commentEnd : source.length;
+    const url = new URL(source.slice(urlStart, urlEnd), load.r).toString();
+    resolvedSource += source.slice(lastIndex, urlStart) + url;
+    lastIndex = urlEnd;
   }
 
-  const sourceMapURLCommentStart = resolvedSource.lastIndexOf(sourceMapURLCommentPrefix)
+  let sourceURLCommentStart = source.lastIndexOf(sourceURLCommentPrefix);
+  let sourceMapURLCommentStart = source.lastIndexOf(sourceMapURLCommentPrefix);
+
+  // ignore sourceMap comments before already spliced code
+  if (sourceURLCommentStart < lastIndex) sourceURLCommentStart = -1;
+  if (sourceMapURLCommentStart < lastIndex) sourceMapURLCommentStart = -1;
+
+  // sourceURL first / only
+  if (sourceURLCommentStart !== -1 && (sourceMapURLCommentStart === -1 || sourceMapURLCommentStart > sourceURLCommentStart)) {
+    pushSourceURL(sourceURLCommentPrefix, sourceURLCommentStart);
+  }
+  // sourceMappingURL
   if (sourceMapURLCommentStart !== -1) {
-    resolvedSource = replaceSourceComment(resolvedSource, sourceMapURLCommentPrefix, sourceMapURLCommentStart, load.r)
+    pushSourceURL(sourceMapURLCommentPrefix, sourceMapURLCommentStart);
+    // sourceURL last
+    if (sourceURLCommentStart !== -1 && (sourceURLCommentStart > sourceMapURLCommentStart))
+      pushSourceURL(sourceURLCommentPrefix, sourceURLCommentStart);
   }
+
+  pushStringTo(source.length);
+
+  if (sourceURLCommentStart === -1)
+    resolvedSource += sourceURLCommentPrefix + load.r;
 
   load.b = lastLoad = createBlob(resolvedSource);
   load.S = undefined;

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -313,8 +313,8 @@ function resolveDeps (load, seen) {
     const urlStart = commentStart + commentPrefix.length;
     const commentEnd = source.indexOf('\n', urlStart);
     const urlEnd = commentEnd !== -1 ? commentEnd : source.length;
-    const url = new URL(source.slice(urlStart, urlEnd), load.r).toString();
-    resolvedSource += source.slice(lastIndex, urlStart) + url;
+    pushStringTo(urlStart);
+    resolvedSource += new URL(source.slice(urlStart, urlEnd), load.r).href;
     lastIndex = urlEnd;
   }
 

--- a/test/fixtures/es-modules/with-source-url-and-source-mapping-url.js
+++ b/test/fixtures/es-modules/with-source-url-and-source-mapping-url.js
@@ -1,0 +1,4 @@
+// This comment should not be affected by the sourceURL replacement: //# sourceURL=i-should-not-be-affected.no
+export var answer = 42;
+//# sourceURL=/with-source-url-and-source-mapping-url.js
+//# sourceMappingURL=https://example.com/module.js.map

--- a/test/shim.js
+++ b/test/shim.js
@@ -489,6 +489,19 @@ suite('Source maps', () => {
     // Should not touch any other occurrences of `//# sourceMappingURL=` in the code.
     assert(blobContent.includes('//# sourceMappingURL=i-should-not-be-affected.no'));
   });
+
+  test('should preserve existing sourceURL if both sourceURL and sourceMappingURL already exist', async () => {
+    const moduleURL = new URL('./fixtures/es-modules/with-source-url-and-source-mapping-url.js', location.href).href;
+    await importShim(moduleURL);
+    const moduleBlobURL = importShim._r[moduleURL].b;
+    const blobContent = await fetch(moduleBlobURL).then(r => r.text());
+    assert(blobContent.endsWith(
+        `//# sourceURL=${new URL('/with-source-url-and-source-mapping-url.js', window.location.origin)}\n//# sourceMappingURL=https://example.com/module.js.map`
+    ));
+
+    // Should not touch any other occurrences of `//# sourceURL=` in the code.
+    assert(blobContent.includes('//# sourceURL=i-should-not-be-affected.no'));
+  });
 });
 
 


### PR DESCRIPTION
Hey there! I started making use of sourceURL comments to preserve breakpoints across updates in [Reflame](https://reflame.app), and discovered that shim mode seems to ignore the existing sourceURL and adds its own if both sourceURL and sourceMappingURL exists.

I've captured this behavior in a new test. Here's the existing behavior:
![Screenshot 2023-05-11 at 6 51 14 PM](https://github.com/guybedford/es-module-shims/assets/6934200/ac4333d8-0c73-440f-98a4-8d2fd77c9bdb)
(note the 2 sourceURLs)

Here's the new behavior after my fix:
![Screenshot 2023-05-11 at 6 53 04 PM](https://github.com/guybedford/es-module-shims/assets/6934200/320fac73-a14f-4c8f-8456-7a0e4b88e028)

A few things contributed to the existing behavior:

- The regex we use matches for end of string, so will never actually match a sourceURL comment that's not at the last line
- `resolvedSource.replace` only executes once and only replaces the first instance, so it could never properly handle the case where both exist.

My fix splits the previous regex into 2, one for sourceURL and one for sourceMappingURL, and performs 2 replace passes to handle both independently. 

Not sure how significant this replacement pass is to the overall perf budget. If it is significant enough, it could be worth trying to optimize this a bit further?

Happy to iterate on this as needed. Cheers!