### PR TITLE
Add response to response errors

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -38,14 +38,6 @@ import {
 } from './features.js';
 import * as lexer from '../node_modules/es-module-lexer/dist/lexer.asm.js';
 
-class ResponseError extends Error {
-  constructor(message, {cause, response}) {
-    super(message, {cause});
-    this.name = 'ResponseError';
-    this.response = response;
-  }
-}
-
 async function _resolve (id, parentUrl) {
   const urlResolved = resolveIfNotPlainOrUrl(id, parentUrl);
   return {
@@ -393,8 +385,12 @@ async function doFetch (url, fetchOpts, parent) {
   finally {
     popFetchPool();
   }
-  if (!res.ok)
-    throw new ResponseError(`${res.status} ${res.statusText} ${res.url}${fromParent(parent)}`, {response: res});
+
+  if (!res.ok) {
+    const error = new TypeError(`${res.status} ${res.statusText} ${res.url}${fromParent(parent)}`);
+    error.response = res;
+    throw error;
+  }
   return res;
 }
 

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -394,7 +394,7 @@ async function doFetch (url, fetchOpts, parent) {
     popFetchPool();
   }
   if (!res.ok)
-    throw Error(`${res.status} ${res.statusText} ${res.url}${fromParent(parent)}`);
+    throw new ResponseError(`${res.status} ${res.statusText} ${res.url}${fromParent(parent)}`, {response: res});
   return res;
 }
 

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -38,6 +38,14 @@ import {
 } from './features.js';
 import * as lexer from '../node_modules/es-module-lexer/dist/lexer.asm.js';
 
+class ResponseError extends Error {
+  constructor(message, {cause, response}) {
+    super(message, {cause});
+    this.name = 'ResponseError';
+    this.response = response;
+  }
+}
+
 async function _resolve (id, parentUrl) {
   const urlResolved = resolveIfNotPlainOrUrl(id, parentUrl);
   return {

--- a/test/shim.js
+++ b/test/shim.js
@@ -356,7 +356,7 @@ suite('Errors', function () {
 
   test('404 error', async function () {
     var err = await getImportError('./fixtures/es-modules/load-non-existent.js');
-    assert(err.toString().startsWith('Error: 404 Not Found ' + new URL('./fixtures/es-modules/non-existent.js', baseURL).href));
+    assert(err.toString().startsWith('ResponseError: 404 Not Found ' + new URL('./fixtures/es-modules/non-existent.js', baseURL).href));
   });
 
   test('network error should include response', async function () {

--- a/test/shim.js
+++ b/test/shim.js
@@ -359,6 +359,11 @@ suite('Errors', function () {
     assert(err.toString().startsWith('Error: 404 Not Found ' + new URL('./fixtures/es-modules/non-existent.js', baseURL).href));
   });
 
+  test('network error should include response', async function () {
+    var err = await getImportError('./fixtures/es-modules/load-non-existent.js');
+    assert(err.response instanceof Response);
+  });
+
   this.timeout(10000);
 
   test('Dynamic import map shim', async function () {

--- a/test/shim.js
+++ b/test/shim.js
@@ -327,7 +327,7 @@ suite('Errors', function () {
       await importShim(module);
     }
     catch(e) {
-      return e.toString();
+      return e;
     }
     throw new Error('Test supposed to fail');
   }
@@ -340,18 +340,18 @@ suite('Errors', function () {
 
   test('should give a plain name error', async function () {
     var err = await getImportError('plain-name');
-    assert.equal(err.indexOf('Error: Unable to resolve specifier \'plain-name\' imported from'), 0);
+    assert.equal(err.toString().indexOf('Error: Unable to resolve specifier \'plain-name\' imported from'), 0);
   });
 
   test('should throw if on syntax error', async function () {
     Mocha.process.removeListener('uncaughtException');
     var err = await getImportError('./fixtures/es-modules/main.js');
-    assert.equal(err.toString(), 'dep error');
+    assert.equal(err.toString().toString(), 'dep error');
   });
 
   test('should throw what the script throws', async function () {
     var err = await getImportError('./fixtures/es-modules/deperror.js');
-    assert.equal(err, 'dep error');
+    assert.equal(err.toString(), 'dep error');
   });
 
   test('404 error', async function () {

--- a/test/shim.js
+++ b/test/shim.js
@@ -356,7 +356,7 @@ suite('Errors', function () {
 
   test('404 error', async function () {
     var err = await getImportError('./fixtures/es-modules/load-non-existent.js');
-    assert(err.toString().startsWith('ResponseError: 404 Not Found ' + new URL('./fixtures/es-modules/non-existent.js', baseURL).href));
+    assert(err.toString().startsWith('TypeError: 404 Not Found ' + new URL('./fixtures/es-modules/non-existent.js', baseURL).href));
   });
 
   test('network error should include response', async function () {


### PR DESCRIPTION
Hey there!

(I couldn't find any notes on contributing so I assumed that PRs are welcome but if not, no worries)

I want to filter response errors throw in `es-module-shims` based off some criteria of their response. I find parsing the error message a bit brittle but I _could_ get the information from there. Before doing that I wanted to suggest sub-classing the `Error` class with a `ResponseError` which includes the actual response and then throwing that error when a response error occurs.

What do you think? I added a single test but I can add some more to increase confidence.