### PR TITLE
Fix the `skip` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,7 +49,7 @@ interface ESMSInitOptions {
    * By default, this expression supports jspm.dev, dev.jspm.io and
    * cdn.pika.dev.
    */
-  skip?: RegExp;
+  skip?: RegExp | string[] | string
 
   /**
    * #### Error hook

--- a/src/env.js
+++ b/src/env.js
@@ -56,6 +56,8 @@ if (Array.isArray(skip)) {
 else if (typeof skip === 'string') {
   const r = new RegExp(skip);
   skip = s => r.test(s);
+} else if (skip instanceof RegExp) {
+  skip = s => skip.test(s);
 }
 
 const eoop = err => setTimeout(() => { throw err });


### PR DESCRIPTION
Fixes #384.

This change starts accepting a regular expression proper as a `skip` option. This seems to have been indicated by the existing types and counter-intuitively the types that are actually accepted aren't represented in the TypeScript declaration.

This pull request adds the `string[] | string` types to the `skip` property in the options type and creates a `skip` wrapper in case the variable passed in is a regular expression.