### PR TITLE
fix cycle binding updates for expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ In shim mode, Wasm modules are always supported. In polyfill mode, Wasm modules 
 
 WebAssembly module exports are made available as module exports and WebAssembly module imports will be resolved using the browser module loader.
 
-When using the source phase import form, this must be enabled separately via the `polyfillEnabe: ['wasm-modules', 'source-phase']` [init option](#polyfill-enable-option) to support source imports to WebAssembly modules.
+When using the source phase import form, this must be enabled separately via the `polyfillEnable: ['wasm-modules', 'source-phase']` [init option](#polyfill-enable-option) to support source imports to WebAssembly modules.
 
 When enabling `'source-phase'`, `WebAssembly.Module` is also polyfilled to extend from `AbstractModuleSource` per the source phase proposal.
 

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -370,7 +370,7 @@ function resolveDeps (load, seen) {
   }
 
   // support progressive cycle binding updates (try statement avoids tdz errors)
-  if (load.s)
+  if (load.s && (imports.length === 0 || imports[imports.length - 1].d === -1))
     resolvedSource += `\n;import{u$_}from'${load.s}';try{u$_({${exports.filter(e => e.ln).map(({ s, e, ln }) => `${source.slice(s, e)}:${ln}`).join(',')}})}catch(_){};\n`;
 
   function pushSourceURL (commentPrefix, commentStart) {


### PR DESCRIPTION
Resolves https://github.com/guybedford/es-module-shims/issues/419 in ensuring the progressive binding update interleaving for cycles only applies after a declaration import.