### PR TITLE
feat: polyfill multiple import maps

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -21,28 +21,35 @@ import {
   enforceIntegrity,
   fromParent,
   esmsInitOptions,
-  hasDocument,
-  importMapSrcOrLazy,
-  setImportMapSrcOrLazy
+  hasDocument
 } from './env.js';
 import { dynamicImport, supportsDynamicImport } from './dynamic-import.js';
 import {
   supportsImportMeta,
   supportsImportMaps,
-  supportsCssAssertions,
-  supportsJsonAssertions,
+  supportsCssType,
+  supportsJsonType,
   supportsWasmModules,
   supportsSourcePhase,
+  supportsMultipleImportMaps,
   featureDetectionPromise
 } from './features.js';
 import * as lexer from '../node_modules/es-module-lexer/dist/lexer.asm.js';
 
 async function _resolve(id, parentUrl) {
   const urlResolved = resolveIfNotPlainOrUrl(id, parentUrl) || asURL(id);
+  let composedFallback = false;
+  const firstResolved = firstImportMap && resolveImportMap(firstImportMap, urlResolved || id, parentUrl);
+  const composedResolved =
+    composedImportMap === firstImportMap ? firstResolved : (
+      resolveImportMap(composedImportMap, urlResolved || id, parentUrl)
+    );
   return {
-    r: resolveImportMap(importMap, urlResolved || id, parentUrl) || throwUnresolved(id, parentUrl),
-    // b = bare specifier
-    b: !urlResolved && !asURL(id)
+    r: composedResolved || firstResolved || throwUnresolved(id, parentUrl),
+    // b = bare specifier (breaks without import maps = polyfill graph)
+    b: !urlResolved,
+    // m = composed resolution (breaks without multiple import maps = polyfill graph)
+    m: !urlResolved && !firstResolved
   };
 }
 
@@ -68,9 +75,9 @@ async function importHandler(id, ...args) {
   // needed for shim check
   await initPromise;
   if (importHook) await importHook(id, typeof args[1] !== 'string' ? args[1] : {}, parentUrl);
-  if (acceptingImportMaps || shimMode || !baselinePassthrough) {
-    if (hasDocument) processScriptsAndPreloads(true);
-    if (!shimMode) acceptingImportMaps = false;
+  if (shimMode || !baselinePassthrough) {
+    if (hasDocument) processScriptsAndPreloads();
+    legacyAcceptingImportMaps = false;
   }
   await importMapPromise;
   return (await resolve(id, parentUrl)).r;
@@ -99,7 +106,7 @@ self.importShim = importShim;
 
 function defaultResolve(id, parentUrl) {
   return (
-    resolveImportMap(importMap, resolveIfNotPlainOrUrl(id, parentUrl) || id, parentUrl) ||
+    resolveImportMap(composedImportMap, resolveIfNotPlainOrUrl(id, parentUrl) || id, parentUrl) ||
     throwUnresolved(id, parentUrl)
   );
 }
@@ -119,10 +126,10 @@ function metaResolve(id, parentUrl = this.url) {
 }
 
 importShim.resolve = resolveSync;
-importShim.getImportMap = () => JSON.parse(JSON.stringify(importMap));
+importShim.getImportMap = () => JSON.parse(JSON.stringify(composedImportMap));
 importShim.addImportMap = importMapIn => {
   if (!shimMode) throw new Error('Unsupported in polyfill mode.');
-  importMap = resolveAndComposeImportMap(importMapIn, pageBaseUrl, importMap);
+  composedImportMap = resolveAndComposeImportMap(importMapIn, pageBaseUrl, composedImportMap);
 };
 
 const registry = (importShim._r = {});
@@ -141,7 +148,11 @@ async function loadAll(load, seen) {
   if (!load.n) load.n = load.d.some(dep => dep.l.n);
 }
 
-let importMap = { imports: {}, scopes: {}, integrity: {} };
+let importMapSrc = false;
+let multipleImportMaps = false;
+let firstImportMap = null;
+// To support polyfilling multiple import maps, we separately track the composed import map from the first import map
+let composedImportMap = { imports: {}, scopes: {}, integrity: {} };
 let baselinePassthrough;
 
 const initPromise = featureDetectionPromise.then(() => {
@@ -150,11 +161,12 @@ const initPromise = featureDetectionPromise.then(() => {
     supportsDynamicImport &&
     supportsImportMeta &&
     supportsImportMaps &&
-    (!jsonModulesEnabled || supportsJsonAssertions) &&
-    (!cssModulesEnabled || supportsCssAssertions) &&
+    (!jsonModulesEnabled || supportsJsonType) &&
+    (!cssModulesEnabled || supportsCssType) &&
     (!wasmModulesEnabled || supportsWasmModules) &&
     (!sourcePhaseEnabled || supportsSourcePhase) &&
-    !importMapSrcOrLazy;
+    (!multipleImportMaps || supportsMultipleImportMaps) &&
+    !importMapSrc;
   if (self.ESMS_DEBUG)
     console.info(
       `es-module-shims: init ${shimMode ? 'shim mode' : 'polyfill mode'}, ${baselinePassthrough ? 'baseline passthrough' : 'polyfill engaged'}`
@@ -190,20 +202,7 @@ const initPromise = featureDetectionPromise.then(() => {
       HTMLScriptElement.supports = type => type === 'importmap' || supports(type);
     }
     if (shimMode || !baselinePassthrough) {
-      new MutationObserver(mutations => {
-        for (const mutation of mutations) {
-          if (mutation.type !== 'childList') continue;
-          for (const node of mutation.addedNodes) {
-            if (node.tagName === 'SCRIPT') {
-              if (node.type === (shimMode ? 'module-shim' : 'module')) processScript(node, true);
-              if (node.type === (shimMode ? 'importmap-shim' : 'importmap')) processImportMap(node, true);
-            } else if (node.tagName === 'LINK' && node.rel === (shimMode ? 'modulepreload-shim' : 'modulepreload')) {
-              processPreload(node);
-            }
-          }
-        }
-      }).observe(document, { childList: true, subtree: true });
-      processScriptsAndPreloads();
+      attachMutationObserver();
       if (document.readyState === 'complete') {
         readyStateCompleteCheck();
       } else {
@@ -219,14 +218,37 @@ const initPromise = featureDetectionPromise.then(() => {
       }
     }
   }
+  processScriptsAndPreloads();
   return lexer.init;
 });
+
+function attachMutationObserver() {
+  new MutationObserver(mutations => {
+    for (const mutation of mutations) {
+      if (mutation.type !== 'childList') continue;
+      for (const node of mutation.addedNodes) {
+        if (node.tagName === 'SCRIPT') {
+          if (node.type === (shimMode ? 'module-shim' : 'module') && !node.ep) processScript(node, true);
+          if (node.type === (shimMode ? 'importmap-shim' : 'importmap') && !node.ep) processImportMap(node, true);
+        } else if (
+          node.tagName === 'LINK' &&
+          node.rel === (shimMode ? 'modulepreload-shim' : 'modulepreload') &&
+          !node.ep
+        ) {
+          processPreload(node);
+        }
+      }
+    }
+  }).observe(document, { childList: true, subtree: true });
+  processScriptsAndPreloads();
+}
+
 let importMapPromise = initPromise;
 let firstPolyfillLoad = true;
-let acceptingImportMaps = true;
+let legacyAcceptingImportMaps = true;
 
 async function topLevelLoad(url, fetchOpts, source, nativelyLoaded, lastStaticLoadPromise) {
-  if (!shimMode) acceptingImportMaps = false;
+  legacyAcceptingImportMaps = false;
   await initPromise;
   await importMapPromise;
   if (importHook) await importHook(url, typeof fetchOpts !== 'string' ? fetchOpts : {}, '');
@@ -237,7 +259,9 @@ async function topLevelLoad(url, fetchOpts, source, nativelyLoaded, lastStaticLo
     // for polyfill case, only dynamic import needs a return value here, and dynamic import will never pass nativelyLoaded
     if (nativelyLoaded) return null;
     await lastStaticLoadPromise;
-    return dynamicImport(source ? createBlob(source) : url, { errUrl: url || source });
+    return dynamicImport(source ? createBlob(source) : url, {
+      errUrl: url || source
+    });
   }
   const load = getOrCreateLoad(url, fetchOpts, null, source);
   linkLoad(load, fetchOpts);
@@ -292,6 +316,14 @@ function resolveDeps(load, seen) {
 
   for (const { l: dep, s: sourcePhase } of load.d) {
     if (!sourcePhase) resolveDeps(dep, seen);
+  }
+
+  // use native loader whenever possible via executable subgraph passthrough
+  // so long as the module doesn't use dynamic import
+  if (!shimMode && !load.n) {
+    load.b = lastLoad = load.u;
+    load.S = undefined;
+    return;
   }
 
   const [imports, exports] = load.a;
@@ -471,7 +503,7 @@ async function doFetch(url, fetchOpts, parent) {
 }
 
 async function fetchModule(url, fetchOpts, parent) {
-  const mapIntegrity = importMap.integrity[url];
+  const mapIntegrity = composedImportMap.integrity[url];
   const res = await doFetch(
     url,
     mapIntegrity && !fetchOpts.integrity ? Object.assign({}, fetchOpts, { integrity: mapIntegrity }) : fetchOpts,
@@ -564,8 +596,8 @@ function getOrCreateLoad(url, fetchOpts, parent, source) {
         )
           throw featErr(`${t}-modules`);
         if (
-          (t === 'css' && !supportsCssAssertions) ||
-          (t === 'json' && !supportsJsonAssertions) ||
+          (t === 'css' && !supportsCssType) ||
+          (t === 'json' && !supportsJsonType) ||
           (t === 'wasm' && !supportsWasmModules)
         )
           load.n = true;
@@ -603,8 +635,8 @@ function linkLoad(load, fetchOpts) {
           )
             load.n = true;
           if (d !== -1 || !n) return;
-          const { r, b } = await resolve(n, load.r || load.u);
-          if (b && (!supportsImportMaps || importMapSrcOrLazy)) load.n = true;
+          const { r, b, m } = await resolve(n, load.r || load.u);
+          if ((b && !supportsImportMaps) || (m && !supportsMultipleImportMaps)) load.n = true;
           if (d !== -1) return;
           if (skip && skip(r) && !sourcePhase) return { l: { b: r }, s: false };
           if (childFetchOpts.integrity) childFetchOpts = Object.assign({}, childFetchOpts, { integrity: undefined });
@@ -618,16 +650,19 @@ function linkLoad(load, fetchOpts) {
   });
 }
 
-function processScriptsAndPreloads(mapsOnly = false) {
+function processScriptsAndPreloads() {
   if (self.ESMS_DEBUG) console.info(`es-module-shims: processing scripts`);
-  if (!mapsOnly)
-    for (const link of document.querySelectorAll(shimMode ? 'link[rel=modulepreload-shim]' : 'link[rel=modulepreload]'))
-      processPreload(link);
-  for (const script of document.querySelectorAll(shimMode ? 'script[type=importmap-shim]' : 'script[type=importmap]'))
-    processImportMap(script);
-  if (!mapsOnly)
-    for (const script of document.querySelectorAll(shimMode ? 'script[type=module-shim]' : 'script[type=module]'))
-      processScript(script);
+  for (const link of document.querySelectorAll(shimMode ? 'link[rel=modulepreload-shim]' : 'link[rel=modulepreload]')) {
+    if (!link.ep) processPreload(link);
+  }
+  for (const script of document.querySelectorAll('script[type]')) {
+    if (script.type === 'importmap' + (shimMode ? '-shim' : '')) {
+      if (!script.ep) processImportMap(script);
+    } else if (script.type === 'module' + (shimMode ? '-shim' : '')) {
+      legacyAcceptingImportMaps = false;
+      if (!script.ep) processScript(script);
+    }
+  }
 }
 
 function getFetchOpts(script) {
@@ -686,28 +721,35 @@ const epCheck = (script, ready) =>
 
 function processImportMap(script, ready = readyStateCompleteCnt > 0) {
   if (epCheck(script, ready)) return;
-  // we dont currently support multiple, external or dynamic imports maps in polyfill mode to match native
+  // we dont currently support external import maps in polyfill mode to match native
   if (script.src) {
     if (!shimMode) return;
-    setImportMapSrcOrLazy();
+    importMapSrc = true;
   }
-  if (acceptingImportMaps) {
-    importMapPromise = importMapPromise
-      .then(async () => {
-        importMap = resolveAndComposeImportMap(
-          script.src ? await (await doFetch(script.src, getFetchOpts(script))).json() : JSON.parse(script.innerHTML),
-          script.src || pageBaseUrl,
-          importMap
-        );
-      })
-      .catch(e => {
-        console.log(e);
-        if (e instanceof SyntaxError)
-          e = new Error(`Unable to parse import map ${e.message} in: ${script.src || script.innerHTML}`);
-        throwError(e);
-      });
-    if (!shimMode) acceptingImportMaps = false;
+  importMapPromise = importMapPromise
+    .then(async () => {
+      composedImportMap = resolveAndComposeImportMap(
+        script.src ? await (await doFetch(script.src, getFetchOpts(script))).json() : JSON.parse(script.innerHTML),
+        script.src || pageBaseUrl,
+        composedImportMap
+      );
+      if (!firstImportMap && legacyAcceptingImportMaps) firstImportMap = composedImportMap;
+    })
+    .catch(e => {
+      console.log(e);
+      if (e instanceof SyntaxError)
+        e = new Error(`Unable to parse import map ${e.message} in: ${script.src || script.innerHTML}`);
+      throwError(e);
+    });
+  if (!legacyAcceptingImportMaps && !multipleImportMaps) {
+    multipleImportMaps = true;
+    if (baselinePassthrough && !supportsMultipleImportMaps) {
+      if (self.ESMS_DEBUG) console.info(`es-module-shims: disabling baseline passthrough due to multiple import maps`);
+      baselinePassthrough = false;
+      if (hasDocument) attachMutationObserver();
+    }
   }
+  legacyAcceptingImportMaps = false;
 }
 
 function processScript(script, ready = readyStateCompleteCnt > 0) {
@@ -736,7 +778,6 @@ function processScript(script, ready = readyStateCompleteCnt > 0) {
 
 const fetchCache = {};
 function processPreload(link) {
-  if (link.ep) return;
   link.ep = true;
   if (fetchCache[link.href]) return;
   fetchCache[link.href] = fetchModule(link.href, getFetchOpts(link));

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -645,7 +645,7 @@ function linkLoad(load, fetchOpts) {
           if (d !== -1 || !n) return;
           const { r, b, m, u } = await resolve(n, load.r || load.u);
           if ((b && !supportsImportMaps) || (m && !supportsMultipleImportMaps)) load.n = true;
-          if (d >= 0 || u && !supportsImportMaps) load.N = true;
+          if (d >= 0 || (u && !supportsImportMaps)) load.N = true;
           if (d !== -1) return;
           if (skip && skip(r) && !sourcePhase) return { l: { b: r }, s: false };
           if (childFetchOpts.integrity) childFetchOpts = Object.assign({}, childFetchOpts, { integrity: undefined });

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -163,9 +163,10 @@ function resolveAndComposePackages(packages, outPackages, baseUrl, parentMap) {
       outPackages[resolvedLhs] &&
       outPackages[resolvedLhs] !== packages[resolvedLhs]
     ) {
-      throw Error(
-        `Rejected map override "${resolvedLhs}" from ${outPackages[resolvedLhs]} to ${packages[resolvedLhs]}.`
+      console.warn(
+        `es-module-shims: Rejected map override "${resolvedLhs}" from ${outPackages[resolvedLhs]} to ${packages[resolvedLhs]}.`
       );
+      continue;
     }
     let target = packages[p];
     if (typeof target !== 'string') continue;
@@ -174,7 +175,7 @@ function resolveAndComposePackages(packages, outPackages, baseUrl, parentMap) {
       outPackages[resolvedLhs] = mapped;
       continue;
     }
-    console.warn(`Mapping "${p}" -> "${packages[p]}" does not resolve`);
+    console.warn(`es-module-shims: Mapping "${p}" -> "${packages[p]}" does not resolve`);
   }
 }
 
@@ -186,8 +187,8 @@ function resolveAndComposeIntegrity(integrity, outIntegrity, baseUrl) {
       outIntegrity[resolvedLhs] &&
       outIntegrity[resolvedLhs] !== integrity[resolvedLhs]
     ) {
-      throw Error(
-        `Rejected map integrity override "${resolvedLhs}" from ${outIntegrity[resolvedLhs]} to ${integrity[resolvedLhs]}.`
+      console.warn(
+        `es-module-shims: Rejected map integrity override "${resolvedLhs}" from ${outIntegrity[resolvedLhs]} to ${integrity[resolvedLhs]}.`
       );
     }
     outIntegrity[resolvedLhs] = integrity[p];

--- a/test/fixtures/css-assertion.js
+++ b/test/fixtures/css-assertion.js
@@ -1,4 +1,4 @@
-import css from './sheet.css' assert { type: 'css' };
+import css from './sheet.css' with { type: 'css' };
 
 window.cssAssertion = css.cssRules[0].selectorText === 'body';
 

--- a/test/fixtures/json-assertion.js
+++ b/test/fixtures/json-assertion.js
@@ -1,3 +1,3 @@
-import json from './json.json' assert { type: 'json' };
+import json from './json.json' with { type: 'json' };
 
 export const m = json.json;

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -32,6 +32,10 @@ suite('Polyfill tests', () => {
     throw new Error('Should fail');
   });
 
+  test('should support multiple import maps', async function () {
+    await import('global1');
+  });
+
   test('should support json imports', async function () {
     const { m } = await importShim('./fixtures/json-assertion.js');
     assert.equal(m, 'module');
@@ -39,11 +43,7 @@ suite('Polyfill tests', () => {
 
   test('URL mappings do not cause double execution', async function () {
     await importShim('./fixtures/es-modules/dynamic-parent.js');
-    if (window.dynamic)
-      console.log('POLYFILL');
-    if (window.dynamicUrlMap)
-      console.log('NATIVE');
-    assert.equal(window.dynamic || window.dynamicUrlMap, true);
+    assert.equal(window.dynamicUrlMap, true);
     assert.equal(Boolean(window.dynamic && window.dynamicUrlMap), false);
   });
 

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -33,7 +33,7 @@ suite('Polyfill tests', () => {
   });
 
   test('should support multiple import maps', async function () {
-    await import('global1');
+    await importShim('global1');
   });
 
   test('should support json imports', async function () {

--- a/test/shim.js
+++ b/test/shim.js
@@ -399,27 +399,6 @@ suite('Errors', function () {
     assert.ok(lodash);
   });
 
-  test('Dynamic import map shim with override attempt', async function () {
-    const listeningForError = new Promise((resolve, reject) => {
-      window.addEventListener('error', (event) => resolve(event.error))
-      // ensure we don't wait forever in the test if the error never comes
-      setTimeout(reject, 5000)
-    })
-
-    const removeImportMap = insertDynamicImportMap({
-      "imports": {
-        "global1": "data:text/javascript,throw new Error('Shim should not allow dynamic import map to override existing entries');"
-      }
-    });
-
-    const error = await listeningForError;
-    console.log('got error');
-
-    removeImportMap();
-
-    assert(error.message.match(new RegExp(String.raw`Rejected map override \"global1\" from http://[^/]+/test/fixtures/es-modules/global1.js to data:text/javascript,throw new Error\('Shim should not allow dynamic import map to override existing entries'\);\.`)));
-  });
-
   test('Dynamic import map shim with override to the same mapping is allowed', async function () {
     const expectingNoError = new Promise((resolve, reject) => {
       window.addEventListener('error', (event) => {

--- a/test/test-early-module-load.html
+++ b/test/test-early-module-load.html
@@ -13,7 +13,7 @@
 <script type="importmap">
 {
   "imports": {
-    "app": "data:text/javascript,if (calledPolyfillHook) fetch('/done')"
+    "app": "data:text/javascript,console.log(typeof calledPolyfillHook === \"undefined\" ? \"NATIVE\" : \"POLYFILL\"); fetch(\"/done\");"
   }
 }
 </script>

--- a/test/test-polyfill.html
+++ b/test/test-polyfill.html
@@ -8,7 +8,6 @@
     "once": "/test/fixtures/once.js",
     "test": "/test/fixtures/es-modules/es6-file.js",
     "test/": "/test/fixtures/",
-    "global1": "/test/fixtures/es-modules/global1.js",
     "/test/fixtures/es-modules/dynamic.js": "/test/fixtures/es-modules/dynamic-url-map.js",
     "a": "/test/fixtures/instance-case-a.js",
     "b": "/test/fixtures/instance-case-b.js"
@@ -18,7 +17,7 @@
 <script type="importmap">
 {
   "imports": {
-    "global1": "data:text/javascript,throw new Error('Polyfill should not support multiple import maps');"
+    "global1": "/test/fixtures/es-modules/global1.js"
   }
 }
 </script>


### PR DESCRIPTION
This implements a polyfill for the new multiple import maps feature in Chrome (https://groups.google.com/a/chromium.org/g/blink-dev/c/4JWXZilDG6w).

I've tested this in Canary and can confirm it works correctly with the baseline passthrough mode engagement.

Multiple import maps actually flip the logic on the previous native subgraph passthrough feature that was formerly disabled in https://github.com/guybedford/es-module-shims/pull/208. With multiple import maps it is now possible to start out on baseline import maps support fully on the native loader, but then later on switch into polyfilling some graphs as needed if multiple import maps are later used.

This PR supports this new ability to "swich off" baseline passthrough as soon as multiple import maps come into play, and then in order to preserve instancing now reenables subgraph native passthrough.

The changes for this are documented in the readme and the multiple import maps feature also includes its own caveats.