### PR TITLE
deprecate: globalLoadEvent, async resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,10 +588,8 @@ window.esmsInitOptions = {
   polyfillEnable: ['css-modules', 'json-modules'], // default empty
   // Custom CSP nonce
   nonce: 'n0nce', // default is automatic detection
-  // Don't retrigger load events on module scripts (DOMContentLoaded, domready)
+  // Don't retrigger load events on module scripts (DOMContentLoaded, domready, window 'onload')
   noLoadEventRetriggers: true, // default false
-  // Retrigger window 'load' event (will be combined into load event above on next major)
-  globalLoadEventRetrigger: true, // default false
   // Skip source analysis of certain URLs for full native passthrough
   skip: /^https:\/\/cdn\.com/, // defaults to null
   // Clean up blob URLs after execution
@@ -718,7 +716,7 @@ Alternatively, add a `blob:` URL policy with the CSP build to get CSP compatibil
 
 ### No Load Event Retriggers
 
-Because of the extra processing done by ES Module Shims it is possible for static module scripts to execute after the `DOMContentLoaded` or `readystatechange` events they expect, which can cause missed attachment.
+Because of the extra processing done by ES Module Shims it is possible for static module scripts to execute after the `DOMContentLoaded`, `readystatechange` or window `load` events they expect, which can cause missed attachment.
 
 In addition, script elements will also have their load events refired when polyfilled.
 
@@ -729,19 +727,12 @@ In such a case, this double event firing can be disabled with the `noLoadEventRe
 ```js
 <script type="esms-options">
 {
-  // do not re-trigger DOM events (onreadystatechange, DOMContentLoaded)
+  // do not re-trigger DOM events (onreadystatechange, DOMContentLoaded, window 'onload')
   "noLoadEventRetriggers": true
 }
 </script>
 <script async src="es-module-shims.js"></script>
 ```
-
-### Global Load Event Retrigger
-
-In ES Module Shims 1.x, load event retriggers only apply to `DOMContentLoaded` and `readystatechange` and not to the window `load` event.
-To enable the window / worker `'load'` event, set `globalLoadEventRetrigger: true`.
-
-In the next major version, this will be the default for load events, at which point only `noLoadEventRetriggers` will remain.
 
 ### Skip
 
@@ -898,10 +889,6 @@ If the resolve hook should apply for all modules in the entire module graph, mak
   }
 </script>
 ```
-
-Support for an asynchronous resolve hook has been deprecated as of 1.5.0 and will be removed in the next major.
-
-Instead async work should be done with the import hook.
 
 #### Meta Hook
 

--- a/README.md
+++ b/README.md
@@ -360,6 +360,8 @@ import 'b';
 
 The above will then correctly execute both `a` and `b`, with only the `b` importer being polyfilled.
 
+Note that shimmed graphs will always support correct mappings - the above rules only apply to the initial polyfill engagement.
+
 #### Reading current import map state
 
 To make it easy to keep track of import map state, es-module-shims provides a `importShim.getImportMap` utility function, available only in shim mode.

--- a/src/env.js
+++ b/src/env.js
@@ -31,7 +31,7 @@ if (!nonce && hasDocument) {
 
 export const onerror = globalHook(esmsInitOptions.onerror || noop);
 
-export const { revokeBlobURLs, noLoadEventRetriggers, globalLoadEventRetrigger, enforceIntegrity } = esmsInitOptions;
+export const { revokeBlobURLs, noLoadEventRetriggers, enforceIntegrity } = esmsInitOptions;
 
 function globalHook(name) {
   return typeof name === 'string' ? self[name] : name;

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -44,25 +44,28 @@ async function _resolve(id, parentUrl) {
       resolveImportMap(composedImportMap, urlResolved || id, parentUrl)
     );
   const resolved = composedResolved || firstResolved || throwUnresolved(id, parentUrl);
-  const out = {
-    r: resolved,
-    // u = uses URL mapping
-    u: urlResolved !== resolved,
-    // b = bare specifier (breaks without import maps = polyfill graph)
-    b: !urlResolved,
-    // m = composed resolution (breaks without multiple import maps = polyfill graph)
-    m: !urlResolved && !firstResolved
-  };
-  return out;
+  // needsShim, shouldShim per load record to set on parent
+  let n = false,
+    N = false;
+  if (!supportsImportMaps) {
+    // bare specifier -> needs shim
+    if (!urlResolved) n = true;
+    // url mapping -> should shim
+    else if (urlResolved !== resolved) N = true;
+  } else if (!supportsMultipleImportMaps) {
+    // bare specifier and not resolved by first import map -> needs shim
+    if (!urlResolved && !firstResolved) n = true;
+    // resolution doesn't match first import map -> should shim
+    if (firstResolved && resolved !== firstResolved) N = true;
+  }
+  return { r: resolved, n, N };
 }
 
 const resolve =
   resolveHook ?
-    async (id, parentUrl) => {
-      let result = resolveHook(id, parentUrl, defaultResolve);
-      // will be deprecated in next major
-      if (result && result.then) result = await result;
-      return result ? { r: result, b: !resolveIfNotPlainOrUrl(id, parentUrl) && !asURL(id) } : _resolve(id, parentUrl);
+    (id, parentUrl) => {
+      const result = resolveHook(id, parentUrl, defaultResolve);
+      return result ? { r: result, n: true, N: true } : _resolve(id, parentUrl);
     }
   : _resolve;
 
@@ -642,13 +645,13 @@ function linkLoad(load, fetchOpts) {
           )
             load.n = true;
           if (d !== -1 || !n) return;
-          const { r, b, m, u } = await resolve(n, load.r || load.u);
-          if ((b && !supportsImportMaps) || (m && !supportsMultipleImportMaps)) load.n = true;
-          if (d >= 0 || (u && !supportsImportMaps)) load.N = true;
+          const resolved = await resolve(n, load.r || load.u);
+          if (resolved.n) load.n = true;
+          if (d >= 0 || resolved.N) load.N = true;
           if (d !== -1) return;
-          if (skip && skip(r) && !sourcePhase) return { l: { b: r }, s: false };
+          if (skip && skip(resolved.r) && !sourcePhase) return { l: { b: resolved.r }, s: false };
           if (childFetchOpts.integrity) childFetchOpts = Object.assign({}, childFetchOpts, { integrity: undefined });
-          const child = { l: getOrCreateLoad(r, childFetchOpts, load.r, null), s: sourcePhase };
+          const child = { l: getOrCreateLoad(resolved.r, childFetchOpts, load.r, null), s: sourcePhase };
           if (!child.s) linkLoad(child.l, fetchOpts);
           // load, sourcePhase
           return child;

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -12,7 +12,6 @@ import {
   skip,
   revokeBlobURLs,
   noLoadEventRetriggers,
-  globalLoadEventRetrigger,
   cssModulesEnabled,
   jsonModulesEnabled,
   wasmModulesEnabled,
@@ -696,7 +695,7 @@ function domContentLoadedCheck() {
 }
 let loadCnt = 1;
 function loadCheck() {
-  if (--loadCnt === 0 && globalLoadEventRetrigger && !noLoadEventRetriggers && (shimMode || !baselinePassthrough)) {
+  if (--loadCnt === 0 && !noLoadEventRetriggers && (shimMode || !baselinePassthrough)) {
     if (self.ESMS_DEBUG) console.info(`es-module-shims: load refire`);
     window.dispatchEvent(new Event('load'));
   }


### PR DESCRIPTION
This implements the version 2 deprecation paths:

* `globalLoadEventRetrigger` is now on by default
* Support for an async resolve hook is removed