### PR TITLE
fix: resolve cycle handling for polyfill checks

### DIFF
--- a/resources/testharness.js
+++ b/resources/testharness.js
@@ -4998,7 +4998,7 @@ window.addEventListener = function (evt, callback) {
 
 (async () => {
 try {
-    await import('./fixtures/tla.js');
+    await eval("import('./fixtures/tla.js');");
 } catch (e) {
     // Does not support TLA -> skip test
     await fetch('/TLA UNSUPPORTED');

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -1,7 +1,7 @@
 const supportsTlaPromise = (async () => {
   let supportsTla = false;
   try {
-    await import('./fixtures/tla.js');
+    await eval("import('./fixtures/tla.js');");
     supportsTla = true;
   } catch (e) {
     console.log(e);


### PR DESCRIPTION
This resolves a bug where the polyfill checks for whether a given module needs to be polyfilled were not being properly proagated in cycles. The resolution is to propagate the checks on the second graph pass not the first, so that cycle edges are fully included.

This bug was exposed by the new passthrough behaviour in the 2.0.0 version, and this now fixes for example polyfilling JS/Wasm cycles with passthrough.