### PR TITLE
fix: support in environments without a document

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -223,8 +223,8 @@ const initPromise = featureDetectionPromise.then(() => {
         document.addEventListener('readystatechange', readyListener);
       }
     }
+    processScriptsAndPreloads();
   }
-  processScriptsAndPreloads();
   return lexer.init;
 });
 


### PR DESCRIPTION
Fixes another 2.0.0 regression where the `processScriptsAndPreloads` code which assumes a document must always be guarded by `hasDocument`.