### PR TITLE
fix: add mutation observer only to head not body

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,13 +297,13 @@ In polyfill mode, multiple import maps are supported.
 Support for dynamically injecting import maps with JavaScript via e.g.:
 
 ```js
-document.body.appendChild(Object.assign(document.createElement('script'), {
+document.head.appendChild(Object.assign(document.createElement('script'), {
   type: 'importmap',
   innerHTML: JSON.stringify({ imports: { x: './y.js' } }),
 }));
 ```
 
-is also provided using mutation observers.
+is also provided using mutation observers. Note, only `document.head` appending of scripts, importmaps and preloads is supported - we do not observe body mutations to `document.body` for performance reasons.
 
 The caveat for multiple import map support polyfill support in browsers that only support a single import map is per the usual "polyfill rule" for es-module-shims - only those top-level graphs with static import feailures can be polyfilled.
 

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -251,7 +251,6 @@ function attachMutationObserver() {
     }
   });
   observer.observe(document.head, { childList: true });
-  observer.observe(document.body, { childList: true });
   processScriptsAndPreloads();
 }
 

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -237,6 +237,8 @@ function attachMutationObserver() {
     for (const mutation of mutations) {
       if (mutation.type !== 'childList') continue;
       for (const node of mutation.addedNodes) {
+        if (node.tagName === 'BODY' && node.parentNode === document)
+          observer.observer(node);
         if (node.tagName === 'SCRIPT') {
           if (node.type === (shimMode ? 'module-shim' : 'module') && !node.ep) processScript(node, true);
           if (node.type === (shimMode ? 'importmap-shim' : 'importmap') && !node.ep) processImportMap(node, true);
@@ -250,7 +252,9 @@ function attachMutationObserver() {
       }
     }
   });
+  observer.observe(document, { childList: true });
   observer.observe(document.head, { childList: true });
+  if (document.body) observer.observer(document.body, { childList: true });
   processScriptsAndPreloads();
 }
 

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -237,8 +237,6 @@ function attachMutationObserver() {
     for (const mutation of mutations) {
       if (mutation.type !== 'childList') continue;
       for (const node of mutation.addedNodes) {
-        if (node.tagName === 'BODY' && node.parentNode === document)
-          observer.observer(node);
         if (node.tagName === 'SCRIPT') {
           if (node.type === (shimMode ? 'module-shim' : 'module') && !node.ep) processScript(node, true);
           if (node.type === (shimMode ? 'importmap-shim' : 'importmap') && !node.ep) processImportMap(node, true);
@@ -254,7 +252,6 @@ function attachMutationObserver() {
   });
   observer.observe(document, { childList: true });
   observer.observe(document.head, { childList: true });
-  if (document.body) observer.observer(document.body, { childList: true });
   processScriptsAndPreloads();
 }
 

--- a/test/shim.js
+++ b/test/shim.js
@@ -425,8 +425,8 @@ suite('Errors', function () {
       type: 'importmap-shim',
       innerHTML: JSON.stringify(importMap),
     });
-    document.body.appendChild(script);
-    return () => document.body.removeChild(script);
+    document.head.appendChild(script);
+    return () => document.head.removeChild(script);
   }
 });
 


### PR DESCRIPTION
This removes the mutation observer on the body, which would not attach if the body had not already been created when es-module-shims is loaded.

While browsers support scripts being anywhere, we can take a strict polyfill policy that only head injections are supported.

Resolves https://github.com/guybedford/es-module-shims/issues/451.