### PR TITLE
Fix top-level CSS/JSON direct import polyfill

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -654,11 +654,15 @@ function linkLoad(load, fetchOpts) {
   load.L = load.f.then(async () => {
     let childFetchOpts = fetchOpts;
     load.d = load.a[0]
-      .map(({ n, d, t }) => {
+      .map(({ n, d, t, a }) => {
         const sourcePhase = t >= 4;
         if (sourcePhase) {
           if (!sourcePhaseEnabled) throw featErr('source-phase');
           if (!supportsSourcePhase) load.n = true;
+        }
+        if (a > 0) {
+          if (!cssModulesEnabled && !jsonModulesEnabled) throw featErr('css-modules / json-modules');
+          if (!supportsCssType && !supportsJsonType) load.n = true;
         }
         if (d !== -1 || !n) return;
         const resolved = resolve(n, load.r || load.u);

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -176,7 +176,12 @@ const initPromise = featureDetectionPromise.then(() => {
     (!multipleImportMaps || supportsMultipleImportMaps) &&
     !importMapSrc &&
     !typescriptEnabled;
-  if (!shimMode && sourcePhaseEnabled && typeof WebAssembly !== 'undefined' && !Object.getPrototypeOf(WebAssembly.Module).name) {
+  if (
+    !shimMode &&
+    sourcePhaseEnabled &&
+    typeof WebAssembly !== 'undefined' &&
+    !Object.getPrototypeOf(WebAssembly.Module).name
+  ) {
     const s = Symbol();
     const brand = m =>
       Object.defineProperty(m, s, { writable: false, configurable: false, value: 'WebAssembly.Module' });
@@ -560,7 +565,10 @@ async function fetchModule(url, fetchOpts, parent) {
       )});export default s;`,
       t: 'css'
     };
-  } else if ((shimMode || typescriptEnabled) && (tsContentType.test(contentType) || url.endsWith('.ts') || url.endsWith('.mts'))) {
+  } else if (
+    (shimMode || typescriptEnabled) &&
+    (tsContentType.test(contentType) || url.endsWith('.ts') || url.endsWith('.mts'))
+  ) {
     const source = await res.text();
     // if we don't have a ts transform hook, try to load it
     if (!esmsTsTransform) {

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -97,7 +97,7 @@ async function importShim(id, opts, parentUrl) {
     typeof opts === 'object' && typeof opts.with === 'object' && typeof opts.with.type === 'string' ?
       `export{default}from'${url}'with{type:"${opts.with.type}"}`
     : null;
-  return topLevelLoad(url, { credentials: 'same-origin' }, source);
+  return topLevelLoad(url + '?entry', { credentials: 'same-origin' }, source);
 }
 
 // import.source()

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -92,12 +92,13 @@ async function importShim(id, opts, parentUrl) {
   }
   // we mock import('./x.css', { with: { type: 'css' }}) support via an inline static reexport
   // because we can't syntactically pass through to dynamic import with a second argument in this libarary
-  const url = await importHandler(id, opts, parentUrl, false);
-  const source =
-    typeof opts === 'object' && typeof opts.with === 'object' && typeof opts.with.type === 'string' ?
-      `export{default}from'${url}'with{type:"${opts.with.type}"}`
-    : null;
-  return topLevelLoad(url + '?entry', { credentials: 'same-origin' }, source);
+  let url = await importHandler(id, opts, parentUrl, false);
+  let source = null;
+  if (typeof opts === 'object' && typeof opts.with === 'object' && typeof opts.with.type === 'string') {
+    source = `export{default}from'${url}'with{type:"${opts.with.type}"}`;
+    url += '?entry';
+  }
+  return topLevelLoad(url, { credentials: 'same-origin' }, source);
 }
 
 // import.source()

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -36,6 +36,11 @@ suite('Polyfill tests', () => {
     await importShim('global1');
   });
 
+  test('should support css imports', async function () {
+    const { default: style } = await importShim('./fixtures/sheet.css', { with: { type: 'css' } });
+    assert.ok(style instanceof CSSStyleSheet);
+  });
+
   test('should support json imports', async function () {
     const { m } = await importShim('./fixtures/json-assertion.js');
     assert.equal(m.json, 'module');

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -37,7 +37,7 @@ suite('Polyfill tests', () => {
   });
 
   test('should support css imports', async function () {
-    const { default: style } = await importShim('./fixtures/sheet.css', { with: { type: 'css' } });
+    const { default: style } = await importShim('./fixtures/sheet.css', { 'with': { type: 'css' } });
     assert.ok(style instanceof CSSStyleSheet);
   });
 

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -37,8 +37,8 @@ suite('Polyfill tests', () => {
   });
 
   test('should support css imports', async function () {
-    const { default: style } = await importShim('./fixtures/sheet.css', { 'with': { type: 'css' } });
-    assert.ok(style instanceof CSSStyleSheet);
+    const m = await importShim('./fixtures/sheet.css', { 'with': { type: 'css' } });
+    assert.ok(m['default'] instanceof CSSStyleSheet);
   });
 
   test('should support json imports', async function () {

--- a/test/test-csp.html
+++ b/test/test-csp.html
@@ -2,7 +2,7 @@
 <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'nonce-asdf' 'unsafe-eval' unpkg.com;" />
 <link rel="stylesheet" type="text/css" href="../node_modules/mocha/mocha.css"/>
 <script src="../node_modules/mocha/mocha.js"></script>
-<script src="https://unpkg.com/construct-style-sheets-polyfill@3.0.0/dist/adoptedStyleSheets.js"></script>
+<script src="https://unpkg.com/construct-style-sheets-polyfill@3.1.0/dist/adoptedStyleSheets.js" nonce="asdf"></script>
 <script type="importmap" nonce="asdf">
 {
   "imports": {


### PR DESCRIPTION
Resolves https://github.com/guybedford/es-module-shims/issues/454, testing and ensuring that a top-level import attribute case can be polyfilled in `importShim()` calls.