### PR TITLE
Run tests in Firefox 115 because there's probably integrity check problem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
           '67.0', # import(), import.meta
           '89.0',  # top-level await
           '108.0',
+          '115.0',
           '126.0', # before integrity
         ]
     name: Firefox Browser Tests


### PR DESCRIPTION
We have strange errors in Firefox 115. Even when I run your tests in Firefox 115 I see error:

```
Should import a module via a relative path re-mapped with importmap's scopes
[‣](http://localhost:8080/test/test-shim.html?grep=Basic%20loading%20tests%20Should%20import%20a%20module%20via%20a%20relative%20path%20re%5Cx2dmapped%20with%20importmap%27s%20scopes)

TypeError: Unable to fetch http://localhost:8080/test/fixtures/es-modules/es6-dep.js imported from http://localhost:8080/test/fixtures/es-modules/es6-withdep.js - see network log for details.
NetworkError when attempting to fetch resource.
```

There's also error in console:

```
None of the “sha384” hashes in the integrity attribute match the content of the subresource. The computed hash is “St7RQt/YC0ARekmGQTSeF0WZ5RVtZ8rNAKHXNS7dwROC5uQAYq+k8e9Tsw6DFJsQ”.
```

The error is gone when I remove the `integrity` key from `fetchOpts`