### PR TITLE
feat: add support for inline typescript

### DIFF
--- a/chompfile.toml
+++ b/chompfile.toml
@@ -43,7 +43,12 @@ function require(mod) {
 ${amaroSource}
 const amaroTransformSync = module.exports.transformSync;
 export function transform(source, url) {
-  return amaroTransformSync(source).code;
+  try {
+    return amaroTransformSync(source, { filename: url, transform: { mode: 'strip-only', noEmptyExport: true } }).code;
+  } catch (e) {
+    // This is needed pending figuring out why filename option above isn't working
+    throw new SyntaxError(e.message.replace(',-', url + ' - '));
+  }
 }
 `);
 '''

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "devDependencies": {
     "@rollup/plugin-replace": "^2.4.2",
-    "amaro": "^0.1.8",
+    "amaro": "^0.3.0",
     "es-module-lexer": "1.6.0",
     "kleur": "^4.1.4",
     "mime-types": "^2.1.33",

--- a/test/test-ts.html
+++ b/test/test-ts.html
@@ -27,8 +27,7 @@
   });
 </script>
 
-<!-- TODO: support this? -->
-<script type="application/typescript">
+<script type="module" lang="ts">
   type test = 'hi' | boolean;
   window.inlineTypescript as test = true;
 </script>

--- a/test/typescript.js
+++ b/test/typescript.js
@@ -1,12 +1,19 @@
 suite('TypeScript loading tests', () => {
+  test('Inline lang=ts support', async function () {
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    assert.ok(globalThis.inlineTypescript === true);
+  });
+
   test('Static TS script', async function () {
     await new Promise(resolve => setTimeout(resolve, 1000));
     assert.ok(globalThis.executedTs === true);
   });
+
   test('Basic type stripping', async function () {
     const { fn } = await importShim('/test/fixtures/test-dep.ts');
     assert.ok(fn() === 5);
   });
+
   test('TypeScript with CSS dependency', async function () {
     const { style, getStyle, p } = await importShim('/test/fixtures/ts-loading-css.ts');
     assert.ok(p === 50);


### PR DESCRIPTION
This adds support for an inline:

```
<script type="module" lang="ts">
export const typescript: boolean = true;
</script>
```

TypeScript support when combined with enabling the new TypeScript feature.

In addition error messages are improved, Amaro is updated, and Amaro options are refined.