### PR TITLE
fix: support ts passthrough for no typestripping

### DIFF
--- a/chompfile.toml
+++ b/chompfile.toml
@@ -44,7 +44,10 @@ ${amaroSource}
 const amaroTransformSync = module.exports.transformSync;
 export function transform(source, url) {
   try {
-    return amaroTransformSync(source, { filename: url, transform: { mode: 'strip-only', noEmptyExport: true } }).code;
+    const transformed = amaroTransformSync(source, { filename: url, transform: { mode: 'strip-only', noEmptyExport: true } }).code;
+    // Importantly, return undefined when there is no work to do
+    if (transformed !== source)
+      return transformed;
   } catch (e) {
     // This is needed pending figuring out why filename option above isn't working
     throw new SyntaxError(e.message.replace(',-', url + ' - '));

--- a/test/test-ts.html
+++ b/test/test-ts.html
@@ -32,4 +32,9 @@
   window.inlineTypescript as test = true;
 </script>
 
+<script type="module" lang="ts">
+  window.inlineTypescriptNoWork = window.inlineTypescriptNoWork || 0;
+  window.inlineTypescriptNoWork++;
+</script>
+
 <div id="mocha"></div>

--- a/test/typescript.js
+++ b/test/typescript.js
@@ -1,11 +1,17 @@
 suite('TypeScript loading tests', () => {
+  const timeoutInitPromise = new Promise(resolve => setTimeout(resolve, 1000));
   test('Inline lang=ts support', async function () {
-    await new Promise(resolve => setTimeout(resolve, 1000));
+    await timeoutInitPromise;
+    assert.ok(globalThis.inlineTypescriptNoWork === 1);
+  });
+
+  test('Inline lang=ts support for no work', async function () {
+    await timeoutInitPromise;
     assert.ok(globalThis.inlineTypescript === true);
   });
 
   test('Static TS script', async function () {
-    await new Promise(resolve => setTimeout(resolve, 1000));
+    await timeoutInitPromise;
     assert.ok(globalThis.executedTs === true);
   });
 


### PR DESCRIPTION
This fixes the edge case where the TypeStripping has no work to do and we end up with double execution - instead ensuring that we only reexecute when truly needed.