### PR TITLE
fix: always show polyfill message for typescript

### DIFF
--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -798,6 +798,10 @@ function processScript(script, ready = readyStateCompleteCnt > 0) {
     return initTs()
       .then(() => {
         const transformed = esmsTsTransform(source, pageBaseUrl);
+        if (transformed !== undefined) {
+          onpolyfill();
+          firstPolyfillLoad = false;
+        }
         return topLevelLoad(
           pageBaseUrl,
           getFetchOpts(script),


### PR DESCRIPTION
Fixes a bug where the "module errors are polyfilled" message would not show for top-level inline TypeScript polyfill cases.