### PR TITLE
Revert #466 readme change

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ And for the source phase:
 ```html
 <script type="module">
 import source mod from './app.wasm';
-const instance = new WebAssembly.Instance(mod, { /* ...imports */ });
+const instance = await WebAssembly.instantiate(mod, { /* ...imports */ });
 </script>
 ```
 


### PR DESCRIPTION
This switches back to the `await WebAssembly.instantiate(...)` advice due to the 8MB warning message we still get (pending https://issues.chromium.org/issues/398265337).

//cc @tomayac 