### PR TITLE
feat: split wasm-modules into wasm-modules-sources and wasm-module-instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,9 +521,11 @@ In shim mode, Wasm modules are always supported. In polyfill mode, Wasm modules 
 
 WebAssembly module exports are made available as module exports and WebAssembly module imports will be resolved using the browser module loader.
 
-When using the source phase import form, this must be enabled separately via the `polyfillEnable: ['wasm-modules', 'source-phase']` [init option](#polyfill-enable-option) to support source imports to WebAssembly modules.
+By default Wasm support will look for both source phase syntax as well as instance Wasm imports, resulting in full analysis of the module graph when either is unsupported.
 
-When enabling `'source-phase'`, `WebAssembly.Module` is also polyfilled to extend from `AbstractModuleSource` per the source phase proposal.
+If only using Wasm modules in the source phase set `polyfillEnable: ['wasm-module-sources']` [init option](#polyfill-enable-option) to ensure full native passthrough without the extra code analysis when Chrome ships the source phase.
+
+When enabling the source phase feature either way, `WebAssembly.Module` is also polyfilled to extend from `AbstractModuleSource` per the source phase proposal.
 
 WebAssembly modules require native top-level await support to be polyfilled, see the [compatibility table](#browser-support) above.
 
@@ -687,7 +689,7 @@ DOM `load` events are fired for all `"module-shim"` scripts both for success and
 
 The `polyfillEnable` option allows enabling polyfill features which are newer and would otherwise result in unnecessary polyfilling in modern browsers that haven't yet updated.
 
-This options supports `"css-modules"`, `"json-modules"`, `"wasm-modules"`, `"source-phase"`.
+This options supports `"css-modules"`, `"json-modules"`, `"wasm-modules"`, `"wasm-module-sources"` and `"wasm-module-instances"`.
 
 ```html
 <script type="esms-options">

--- a/src/env.js
+++ b/src/env.js
@@ -50,8 +50,10 @@ const enableAll = esmsInitOptions.polyfillEnable === 'all' || enable.includes('a
 const enableLatest = esmsInitOptions.polyfillEnable === 'latest' || enable.includes('latest');
 export const cssModulesEnabled = enable.includes('css-modules') || enableAll || enableLatest;
 export const jsonModulesEnabled = enable.includes('json-modules') || enableAll || enableLatest;
-export const wasmInstancePhaseEnabled = enable.includes('wasm-modules') || enable.includes('wasm-module-instances') || enableAll;
-export const wasmSourcePhaseEnabled = enable.includes('wasm-modules') || enable.includes('wasm-module-sources') || enableAll;
+export const wasmInstancePhaseEnabled =
+  enable.includes('wasm-modules') || enable.includes('wasm-module-instances') || enableAll;
+export const wasmSourcePhaseEnabled =
+  enable.includes('wasm-modules') || enable.includes('wasm-module-sources') || enableAll;
 export const typescriptEnabled = enable.includes('typescript') || enableAll;
 
 export const onpolyfill =

--- a/src/env.js
+++ b/src/env.js
@@ -50,8 +50,8 @@ const enableAll = esmsInitOptions.polyfillEnable === 'all' || enable.includes('a
 const enableLatest = esmsInitOptions.polyfillEnable === 'latest' || enable.includes('latest');
 export const cssModulesEnabled = enable.includes('css-modules') || enableAll || enableLatest;
 export const jsonModulesEnabled = enable.includes('json-modules') || enableAll || enableLatest;
-export const wasmModulesEnabled = enable.includes('wasm-modules') || enableAll;
-export const sourcePhaseEnabled = enable.includes('source-phase') || enableAll;
+export const wasmInstancePhaseEnabled = enable.includes('wasm-modules') || enable.includes('wasm-module-instances') || enableAll;
+export const wasmSourcePhaseEnabled = enable.includes('wasm-modules') || enable.includes('wasm-module-sources') || enableAll;
 export const typescriptEnabled = enable.includes('typescript') || enableAll;
 
 export const onpolyfill =

--- a/src/features.js
+++ b/src/features.js
@@ -70,19 +70,19 @@ export let featureDetectionPromise = (async function () {
     window.addEventListener('message', cb, false);
 
     // Feature checking with careful avoidance of unnecessary work - all gated on initial import map supports check. JSON gates on CSS feature check, Wasm instance phase gates on wasm source phase check.
-    const importMapTest = `<script nonce=${nonce || ''}>b=(s,type='text/javascript')=>URL.createObjectURL(new Blob([s],{type}));c=u=>import(b(u)).then(()=>true,()=>false);i=innerText=>document.head.appendChild(Object.assign(document.createElement('script'),{type:'importmap',nonce:"${nonce}",innerText}));i(\`{"imports":{"x":"\${b('')}"}}\`);i(\`{"imports":{"y":"\${b('')}"}}\`);cm=${
-      supportsImportMaps && cssModulesEnabled ? `c(\`import"\${b('','text/css')}"with{type:"css"}\`)` : 'false'
+    const importMapTest = `<script nonce=${nonce || ''}>b=(s,type='text/javascript')=>URL.createObjectURL(new Blob([s],{type}));c=u=>import(u).then(()=>true,()=>false);i=innerText=>document.head.appendChild(Object.assign(document.createElement('script'),{type:'importmap',nonce:"${nonce}",innerText}));i(\`{"imports":{"x":"\${b('')}"}}\`);i(\`{"imports":{"y":"\${b('')}"}}\`);cm=${
+      supportsImportMaps && cssModulesEnabled ? `c(b(\`import"\${b('','text/css')}"with{type:"css"}\`))` : 'false'
     };sp=${
       supportsImportMaps && wasmSourcePhaseEnabled ?
-        `c(\`import source x from "\${b(new Uint8Array(${JSON.stringify(wasmBytes)}),'application/wasm')\}"\`)`
+        `c(b(\`import source x from "\${b(new Uint8Array(${JSON.stringify(wasmBytes)}),'application/wasm')\}"\`))`
       : 'false'
-    };Promise.all([${supportsImportMaps ? 'true' : "import('x')"},${supportsImportMaps ? "'y'" : false},cm,${
+    };Promise.all([${supportsImportMaps ? 'true' : "c('x')"},${supportsImportMaps ? "c('y')" : false},cm,${
       supportsImportMaps && jsonModulesEnabled ?
-        `${cssModulesEnabled ? 'cm.then(s=>s?' : ''}c(\`import"\${b('{}','text/json')\}"with{type:"json"}\`)${cssModulesEnabled ? ':false)' : ''}`
+        `${cssModulesEnabled ? 'cm.then(s=>s?' : ''}c(b(\`import"\${b('{}','text/json')\}"with{type:"json"}\`))${cssModulesEnabled ? ':false)' : ''}`
       : 'false'
     },sp,${
       supportsImportMaps && wasmInstancePhaseEnabled ?
-        `${wasmSourcePhaseEnabled ? 'sp.then(s=>s?' : ''}c(\`import"\${b(new Uint8Array(${JSON.stringify(wasmBytes)}),'application/wasm')\}"\`)${wasmSourcePhaseEnabled ? ':false)' : ''}`
+        `${wasmSourcePhaseEnabled ? 'sp.then(s=>s?' : ''}c(b(\`import"\${b(new Uint8Array(${JSON.stringify(wasmBytes)}),'application/wasm')\}"\`))${wasmSourcePhaseEnabled ? ':false)' : ''}`
       : 'false'
     }]).then(a=>parent.postMessage(['esms'].concat(a),'*'))<${''}/script>`;
 

--- a/src/features.js
+++ b/src/features.js
@@ -4,8 +4,8 @@ import {
   nonce,
   cssModulesEnabled,
   jsonModulesEnabled,
-  wasmModulesEnabled,
-  sourcePhaseEnabled,
+  wasmInstancePhaseEnabled,
+  wasmSourcePhaseEnabled,
   hasDocument
 } from './env.js';
 
@@ -16,8 +16,8 @@ export let supportsCssType = false;
 const supports = hasDocument && HTMLScriptElement.supports;
 
 export let supportsImportMaps = supports && supports.name === 'supports' && supports('importmap');
-export let supportsWasmModules = false;
-export let supportsSourcePhase = false;
+export let supportsWasmInstancePhase = false;
+export let supportsWasmSourcePhase = false;
 export let supportsMultipleImportMaps = false;
 
 const wasmBytes = [0, 97, 115, 109, 1, 0, 0, 0];
@@ -35,15 +35,14 @@ export let featureDetectionPromise = (async function () {
           () => (supportsJsonType = true),
           noop
         ),
-      wasmModulesEnabled &&
+      wasmInstancePhaseEnabled &&
         import(createBlob(`import"${createBlob(new Uint8Array(wasmBytes), 'application/wasm')}"`)).then(
-          () => (supportsWasmModules = true),
+          () => (supportsWasmInstancePhase = true),
           noop
         ),
-      wasmModulesEnabled &&
-        sourcePhaseEnabled &&
+      wasmSourcePhaseEnabled &&
         import(createBlob(`import source x from"${createBlob(new Uint8Array(wasmBytes), 'application/wasm')}"`)).then(
-          () => (supportsSourcePhase = true),
+          () => (supportsWasmSourcePhase = true),
           noop
         )
     ]);
@@ -61,8 +60,8 @@ export let featureDetectionPromise = (async function () {
         supportsMultipleImportMaps,
         supportsCssType,
         supportsJsonType,
-        supportsWasmModules,
-        supportsSourcePhase
+        supportsWasmInstancePhase,
+        supportsWasmSourcePhase
       ] = data;
       resolve();
       document.head.removeChild(iframe);
@@ -70,19 +69,21 @@ export let featureDetectionPromise = (async function () {
     }
     window.addEventListener('message', cb, false);
 
-    const importMapTest = `<script nonce=${nonce || ''}>b=(s,type='text/javascript')=>URL.createObjectURL(new Blob([s],{type}));i=innerText=>document.head.appendChild(Object.assign(document.createElement('script'),{type:'importmap',nonce:"${nonce}",innerText}));i(\`{"imports":{"x":"\${b('')}"}}\`);i(\`{"imports":{"y":"\${b('')}"}}\`);Promise.all([${
-      supportsImportMaps ? 'true' : "'x'"
-    },${supportsImportMaps ? "'y'" : false},${supportsImportMaps && cssModulesEnabled ? `b(\`import"\${b('','text/css')}"with{type:"css"}\`)` : 'false'}, ${
-      supportsImportMaps && jsonModulesEnabled ? `b(\`import"\${b('{}','text/json')\}"with{type:"json"}\`)` : 'false'
+    const importMapTest = `<script nonce=${nonce || ''}>b=(s,type='text/javascript')=>URL.createObjectURL(new Blob([s],{type}));c=u=>import(b(u)).then(()=>true,()=>false);i=innerText=>document.head.appendChild(Object.assign(document.createElement('script'),{type:'importmap',nonce:"${nonce}",innerText}));i(\`{"imports":{"x":"\${b('')}"}}\`);i(\`{"imports":{"y":"\${b('')}"}}\`);${
+      ``
+    };Promise.all([${
+      supportsImportMaps ? 'true' : "import('x')"
+    },${supportsImportMaps ? "'y'" : false},${supportsImportMaps && cssModulesEnabled ? `c(\`import"\${b('','text/css')}"with{type:"css"}\`)` : 'false'}, ${
+      supportsImportMaps && jsonModulesEnabled ? `c(\`import"\${b('{}','text/json')\}"with{type:"json"}\`)` : 'false'
     },${
-      supportsImportMaps && wasmModulesEnabled ?
-        `b(\`import"\${b(new Uint8Array(${JSON.stringify(wasmBytes)}),'application/wasm')\}"\`)`
+      supportsImportMaps && wasmInstancePhaseEnabled ?
+        `c(\`import"\${b(new Uint8Array(${JSON.stringify(wasmBytes)}),'application/wasm')\}"\`)`
       : 'false'
     },${
-      supportsImportMaps && wasmModulesEnabled && sourcePhaseEnabled ?
-        `b(\`import source x from "\${b(new Uint8Array(${JSON.stringify(wasmBytes)}),'application/wasm')\}"\`)`
+      supportsImportMaps && wasmSourcePhaseEnabled ?
+        `c(\`import source x from "\${b(new Uint8Array(${JSON.stringify(wasmBytes)}),'application/wasm')\}"\`)`
       : 'false'
-    }].map(x =>typeof x==='string'?import(x).then(()=>true,()=>false):x)).then(a=>parent.postMessage(['esms'].concat(a),'*'))<${''}/script>`;
+    }]).then(a=>parent.postMessage(['esms'].concat(a),'*'))<${''}/script>`;
 
     // Safari will call onload eagerly on head injection, but we don't want the Wechat
     // path to trigger before setting srcdoc, therefore we track the timing
@@ -122,6 +123,6 @@ export let featureDetectionPromise = (async function () {
 if (self.ESMS_DEBUG)
   featureDetectionPromise = featureDetectionPromise.then(() => {
     console.info(
-      `es-module-shims: detected native support - module types: (${[...(supportsJsonType ? ['json'] : []), ...(supportsCssType ? ['css'] : []), ...(supportsWasmModules ? ['wasm'] : [])].join(', ')}), ${supportsSourcePhase ? 'source phase' : 'no source phase'}, ${supportsMultipleImportMaps ? '' : 'no '}multiple import maps, ${supportsImportMaps ? '' : 'no '}import maps`
+      `es-module-shims: detected native support - module types: (${[...(supportsJsonType ? ['json'] : []), ...(supportsCssType ? ['css'] : []), ...(supportsWasmInstancePhase ? ['wasm'] : [])].join(', ')}), ${supportsWasmSourcePhase ? 'source phase' : 'no source phase'}, ${supportsMultipleImportMaps ? '' : 'no '}multiple import maps, ${supportsImportMaps ? '' : 'no '}import maps`
     );
   });


### PR DESCRIPTION
Currently we have one main `wasm-modules` feature, this splits this feature into separate `wasm-module-sources` and `wasm-module-instances` features which can be enabled independently.

This way, setting `wasm-module-sources` will enable Wasm modules without instance support, allowing baseline passthrough on the upcoming source phase integration in Chrome.