### PR TITLE
feat: support import defer polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The following modules features are polyfilled:
 * [Import Maps](#import-maps) polyfill.
 * [JSON](#json-modules) and [CSS modules](#css-modules) with import assertions when enabled.
 * [Wasm modules](#wasm-modules) with support for Source Phase Imports when enabled.
+* [Import defer](#import-defer) via syntax stripping to allow usage in modern browsers with a polyfill fallback when enabled.
 * [TypeScript](#typescript-type-stripping) type stripping when enabled.
 
 When running in shim mode, module rewriting is applied for all users and custom [resolve](#resolve-hook) and [fetch](#fetch-hook) hooks can be implemented allowing for custom resolution and streaming in-browser transform workflows.
@@ -235,28 +236,29 @@ Works in all browsers with [baseline ES module support](https://caniuse.com/#fea
 
 Browser Compatibility on baseline ES modules support **with** ES Module Shims:
 
-| ES Modules Features                             | Chrome (63+)                         | Firefox (67+)                        | Safari (11.1+)                       |
-| ----------------------------------------------- | ------------------------------------ | ------------------------------------ | ------------------------------------ |
-| [modulepreload](#modulepreload)                 | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
-| [Import Maps](#import-maps)                     | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
-| [Import Map Integrity](#import-map-integrity)   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
-| [Multiple Import Maps](#multiple-import-maps)   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
-| [JSON Modules](#json-modules)                   | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
-| [CSS Modules](#css-modules)                     | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
-| [Wasm Modules](#wasm-modules)                   | 89+                                  | 89+                                  | 15+                                  |
+| ES Modules Features                              | Chrome (63+)                         | Firefox (67+)                        | Safari (11.1+)                       |
+| ------------------------------------------------ | ------------------------------------ | ------------------------------------ | ------------------------------------ |
+| [modulepreload](#modulepreload)                  | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
+| [Import Maps](#import-maps)                      | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
+| [Import Map Integrity](#import-map-integrity)    | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
+| [Multiple Import Maps](#multiple-import-maps)    | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
+| [JSON Modules](#json-modules)                    | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
+| [CSS Modules](#css-modules)                      | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
+| [Wasm Modules](#wasm-modules)                    | 89+                                  | 89+                                  | 15+                                  |
+| [Import Defer](#import-defer) (syntax-stripping) | :heavy_check_mark:                   | :heavy_check_mark:                   | :heavy_check_mark:                   |
 
 Browser compatibility **without** ES Module Shims:
 
 | ES Modules Features                           | Chrome             | Firefox            | Safari             |
 | --------------------------------------------- | ------------------ | ------------------ | ------------------ |
 | [modulepreload](#modulepreload)               | 66+                | 115+               | 17.5+              |
-| [import.meta.url](#importmetaurl)             | ~76+               | ~67+               | ~12+               |
 | [Import Maps](#import-maps)                   | 89+                | 108+               | 16.4+              |
 | [Import Map Integrity](#import-map-integrity) | 127+               | :x:                | :x:                |
 | [Multiple Import Maps](#multiple-import-maps) | Pending            | :x:                | :x:                |
 | [JSON Modules](#json-modules)                 | 123+               | :x:                | 17.2+              |
 | [CSS Modules](#css-modules)                   | 123+               | :x:                | :x:                |
-| [Wasm Modules](#wasm-modules)                 | :x:                | :x:                | :x:                |
+| [Wasm Modules](#wasm-modules)                 | Pending            | :x:                | :x:                |
+| [Import Defer](#import-defer)                 | Pending            | :x:                | :x:                |
 | import.meta.resolve                           | 105+               | 106+               | 16.4+              |
 | [Module Workers](#module-workers)             | ~68+               | ~113+              | 15+                |
 | Top-Level Await                               | 89+                | 89+                | 15+                |
@@ -545,6 +547,14 @@ const instance = await WebAssembly.instantiate(mod, { /* ...imports */ });
 ```
 
 If using CSP, make sure to add `'unsafe-wasm-eval'` to `script-src` which is needed when the shim or polyfill engages, note this policy is much much safer than eval due to the Wasm secure sandbox. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_webassembly_execution.
+
+### Import Defer
+
+> Stability: Stage 3 Standard, Pending Shipping
+
+Implements the [Import Defer TC39 Proposal](https://github.com/tc39/proposal-defer-import-eval), including support for `import defer * as mod from './mod.js'`.
+
+The polyfill is simply just a defer syntax stripping, allowing environments that do support import defer to benefit from the performance benefits, while still supporting the syntax in older browsers.
 
 ### TypeScript Type Stripping
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@rollup/plugin-replace": "^2.4.2",
     "amaro": "0.3.2",
-    "es-module-lexer": "1.6.0",
+    "es-module-lexer": "1.7.0",
     "kleur": "^4.1.4",
     "mime-types": "^2.1.33",
     "mocha": "^9.1.1",

--- a/src/env.js
+++ b/src/env.js
@@ -54,6 +54,7 @@ export const wasmInstancePhaseEnabled =
   enable.includes('wasm-modules') || enable.includes('wasm-module-instances') || enableAll;
 export const wasmSourcePhaseEnabled =
   enable.includes('wasm-modules') || enable.includes('wasm-module-sources') || enableAll;
+export const deferPhaseEnabled = enable.includes('import-defer') || enableAll;
 export const typescriptEnabled = enable.includes('typescript') || enableAll;
 
 export const onpolyfill =

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -121,8 +121,7 @@ if (shimMode || wasmSourcePhaseEnabled)
   };
 
 // import.defer() is just a proxy for import(), since we can't actually defer
-if (shimMode || deferPhaseEnabled)
-  importShim.defer = importShim;
+if (shimMode || deferPhaseEnabled) importShim.defer = importShim;
 
 self.importShim = importShim;
 
@@ -387,7 +386,7 @@ function resolveDeps(load, seen) {
     // defer phase stripping
     else if (t === 6) {
       pushStringTo(statementStart);
-      resolvedSource += source.slice(statementStart, statementEnd).replace('defer', '    ');
+      resolvedSource += source.slice(statementStart, statementEnd).replace('defer', '');
       lastIndex = statementEnd;
     }
     // dependency source replacements
@@ -680,7 +679,8 @@ function linkLoad(load, fetchOpts) {
         const phaseImport = t >= 4;
         const sourcePhase = phaseImport && t < 6;
         if (phaseImport) {
-          if (!shimMode && (sourcePhase ? !wasmSourcePhaseEnabled : !deferPhaseEnabled)) throw featErr(sourcePhase ? 'source-phase' : 'defer-phase');
+          if (!shimMode && (sourcePhase ? !wasmSourcePhaseEnabled : !deferPhaseEnabled))
+            throw featErr(sourcePhase ? 'source-phase' : 'defer-phase');
           if (!sourcePhase || !supportsWasmSourcePhase) load.n = true;
         }
         if (a > 0) {

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -383,14 +383,14 @@ function resolveDeps(load, seen) {
       resolvedSource += `/*${source.slice(start - 1, end + 1)}*/'${createBlob(`export default importShim._s[${urlJsString(depLoad.r)}]`)}'`;
       lastIndex = end + 1;
     }
-    // defer phase stripping
-    else if (t === 6) {
-      pushStringTo(statementStart);
-      resolvedSource += source.slice(statementStart, statementEnd).replace('defer', '');
-      lastIndex = statementEnd;
-    }
     // dependency source replacements
     else if (dynamicImportIndex === -1) {
+      // defer phase stripping
+      if (t === 6) {
+        pushStringTo(statementStart);
+        resolvedSource += source.slice(statementStart, start - 1).replace('defer', '');
+        lastIndex = start;
+      }
       let { l: depLoad } = load.d[depIndex++],
         blobUrl = depLoad.b,
         cycleShell = !blobUrl;
@@ -485,6 +485,7 @@ function resolveDeps(load, seen) {
   }
 
   pushStringTo(source.length);
+  console.log(resolvedSource);
 
   if (sourceURLCommentStart === -1) resolvedSource += sourceURLCommentPrefix + load.r;
 

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -377,10 +377,7 @@ function resolveDeps(load, seen) {
     if (t === 4) {
       let { l: depLoad } = load.d[depIndex++];
       pushStringTo(statementStart);
-      resolvedSource += 'import ';
-      lastIndex = statementStart + 14;
-      pushStringTo(start - 1);
-      resolvedSource += `/*${source.slice(start - 1, end + 1)}*/'${createBlob(`export default importShim._s[${urlJsString(depLoad.r)}]`)}'`;
+      resolvedSource += `${source.slice(statementStart, start - 1).replace('source', '')}/*${source.slice(start - 1, end + 1)}*/'${createBlob(`export default importShim._s[${urlJsString(depLoad.r)}]`)}'`;
       lastIndex = end + 1;
     }
     // dependency source replacements

--- a/test/fixtures/test-defer-dynamic.js
+++ b/test/fixtures/test-defer-dynamic.js
@@ -1,0 +1,3 @@
+export function test () {
+  return import.defer('test');
+}

--- a/test/fixtures/test-defer.js
+++ b/test/fixtures/test-defer.js
@@ -1,0 +1,2 @@
+import defer * as mod from 'test';
+export const deferMod = mod;

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -67,6 +67,17 @@ suite('Polyfill tests', () => {
     assert.equal(typeof add, 'function');
   });
 
+  test('should support defer phase imports', async function () {
+    const mod = await importShim('./fixtures/test-defer.js');
+    assert.equal(typeof mod.deferMod.default, 'number');
+  });
+
+  test('should support dynamic defer phase imports', async function () {
+    const { test } = await importShim('./fixtures/test-defer-dynamic.js');
+    const deferMod = await test();
+    assert.equal(typeof deferMod.default, 'number');
+  });
+
   test('should support source phase imports', async function () {
     const supportsTla = await supportsTlaPromise;
     if (!supportsTla) return;
@@ -77,7 +88,7 @@ suite('Polyfill tests', () => {
   test('should support dynamic source phase imports', async function () {
     const supportsTla = await supportsTlaPromise;
     if (!supportsTla) return;
-    const { add } = await importShim('./fixtures/source-phase-import.js');
+    const { add } = await importShim('./fixtures/source-phase-dynamic.js');
     assert.equal(typeof add, 'function');
   });
 

--- a/test/test-csp.html
+++ b/test/test-csp.html
@@ -28,7 +28,7 @@
 <script nonce="asdf">
   window.noEval = true;
   window.esmsInitOptions = {
-    polyfillEnable: ['css-modules', 'json-modules', 'wasm-modules', 'source-phase']
+    polyfillEnable: ['css-modules', 'json-modules', 'wasm-modules', 'source-phase', 'import-defer']
   };
   window.domLoad = 0;
   document.addEventListener('DOMContentLoaded', () => {

--- a/test/test-polyfill-wasm.html
+++ b/test/test-polyfill-wasm.html
@@ -25,7 +25,7 @@
 
 <script>
   window.esmsInitOptions = {
-    polyfillEnable: ['css-modules', 'json-modules', 'wasm-modules', 'source-phase']
+    polyfillEnable: ['css-modules', 'json-modules', 'wasm-modules', 'source-phase', 'import-defer']
   };
   window.domLoad = 0;
   document.addEventListener('DOMContentLoaded', () => {

--- a/test/test-polyfill.html
+++ b/test/test-polyfill.html
@@ -27,7 +27,7 @@
 
 <script>
   window.esmsInitOptions = {
-    polyfillEnable: ['css-modules', 'json-modules', 'wasm-modules', 'source-phase'],
+    polyfillEnable: ['css-modules', 'json-modules', 'wasm-modules', 'import-defer'],
   };
   window.domLoad = 0;
   document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
This adds support for the new `import defer` proposal as a form of syntax stripping in the polyfill.

All we do, is that when the `import-defer` feature is enabled, we replace `import defer * as ns from 'foo'` with `import * as ns from 'foo'`.

This can enable a useful polyfill for defer though:

* Use modern `import defer` syntax for modern browser users with defer support, getting the performance benefits.
* On older browsers without this support, module loading fails on this syntax error.
* This syntax error gets polyfilled via this simple stripping from es-module-shims, allowing the app to fully work on older browsers.

// cc @nicolo-ribaudo for reference