### PR TITLE
feat: enable json-modules by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ If using more modern features like CSS Modules or JSON Modules, these need to be
 
 ```html
 <script>
-window.esmsInitOptions = { polyfillEnable: ['css-modules', 'json-modules', 'wasm-modules', 'typescript'] }
+window.esmsInitOptions = { polyfillEnable: ['css-modules', 'wasm-modules', 'typescript'] }
 </script>
 ```
 
@@ -254,7 +254,7 @@ Browser compatibility **without** ES Module Shims:
 | [modulepreload](#modulepreload)               | 66+                | 115+               | 17.5+              |
 | [Import Maps](#import-maps)                   | 89+                | 108+               | 16.4+              |
 | [Import Map Integrity](#import-map-integrity) | 127+               | :x:                | :x:                |
-| [Multiple Import Maps](#multiple-import-maps) | Pending            | :x:                | :x:                |
+| [Multiple Import Maps](#multiple-import-maps) | 135+               | :x:                | :x:                |
 | [JSON Modules](#json-modules)                 | 123+               | :x:                | 17.2+              |
 | [CSS Modules](#css-modules)                   | 123+               | :x:                | :x:                |
 | [Wasm Modules](#wasm-modules)                 | Pending            | :x:                | :x:                |
@@ -483,11 +483,13 @@ Note integrity can only be validated when in shim mode or when the polyfill is d
 
 ### JSON Modules
 
-> Stability: WhatWG Standard, Single Browser Implementer
+> Stability: WhatWG Standard, Stable, Multiple Browser Implementers
 
-In shim mode, JSON modules are always supported. In polyfill mode, JSON modules require the `polyfillEnable: ['json-modules']` [init option](#polyfill-enable-option).
+JSON modules are now enabled by default in ES Module Shims with 85% browser support for native where the polyfill won't engage at all.
 
-JSON Modules are currently supported in Chrome when using them via an import assertion:
+In shim mode, JSON modules are always supported.
+
+JSON Modules are supported in Chrome and Safari when using them via an import assertion:
 
 ```html
 <script type="module">
@@ -632,7 +634,7 @@ window.esmsInitOptions = {
   // Enable Shim Mode
   shimMode: true, // default false
   // Enable newer modules features
-  polyfillEnable: ['css-modules', 'json-modules'], // default empty
+  polyfillEnable: ['css-modules'], // default empty
   // Custom CSP nonce
   nonce: 'n0nce', // default is automatic detection
   // Don't retrigger load events on module scripts (DOMContentLoaded, domready, window 'onload')
@@ -671,7 +673,7 @@ window.esmsInitOptions = {
 <script type="esms-options">
 {
   "shimMode": true,
-  "polyfillEnable": ["css-modules", "json-modules"],
+  "polyfillEnable": ["css-modules"],
   "nonce": "n0nce",
   "onpolyfill": "polyfill"
 }
@@ -700,9 +702,9 @@ DOM `load` events are fired for all `"module-shim"` scripts both for success and
 
 The `polyfillEnable` option allows enabling polyfill features which are newer and would otherwise result in unnecessary polyfilling in modern browsers that haven't yet updated.
 
-This options supports `"css-modules"`, `"json-modules"`, `"wasm-modules"`, `"wasm-module-sources"`, `"wasm-module-instances"` and `"import-defer"`.
+This options supports `"css-modules"`, `"wasm-modules"`, `"wasm-module-sources"`, `"wasm-module-instances"` and `"import-defer"`.
 
-In adddition, the `"all"` option will enable all features and the `"latest"` option will implement the latest supported browser features (currently `"css-modules"` and `"json-modules"`).
+In adddition, the `"all"` option will enable all features and the `"latest"` option will implement the latest edge of browser features (currently only `"css-modules"`).
 
 ```html
 <script type="esms-options">

--- a/src/env.js
+++ b/src/env.js
@@ -49,7 +49,6 @@ const enable = Array.isArray(esmsInitOptions.polyfillEnable) ? esmsInitOptions.p
 const enableAll = esmsInitOptions.polyfillEnable === 'all' || enable.includes('all');
 const enableLatest = esmsInitOptions.polyfillEnable === 'latest' || enable.includes('latest');
 export const cssModulesEnabled = enable.includes('css-modules') || enableAll || enableLatest;
-export const jsonModulesEnabled = enable.includes('json-modules') || enableAll || enableLatest;
 export const wasmInstancePhaseEnabled =
   enable.includes('wasm-modules') || enable.includes('wasm-module-instances') || enableAll;
 export const wasmSourcePhaseEnabled =

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -681,7 +681,7 @@ function linkLoad(load, fetchOpts) {
         const sourcePhase = phaseImport && t < 6;
         if (phaseImport) {
           if (!shimMode && (sourcePhase ? !wasmSourcePhaseEnabled : !deferPhaseEnabled))
-            throw featErr(sourcePhase ? 'source-phase' : 'defer-phase');
+            throw featErr(sourcePhase ? 'wasm-module-sources' : 'import-defer');
           if (!sourcePhase || !supportsWasmSourcePhase) load.n = true;
         }
         let source = undefined;

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -14,7 +14,6 @@ import {
   revokeBlobURLs,
   noLoadEventRetriggers,
   cssModulesEnabled,
-  jsonModulesEnabled,
   wasmInstancePhaseEnabled,
   wasmSourcePhaseEnabled,
   deferPhaseEnabled,
@@ -173,7 +172,7 @@ const initPromise = featureDetectionPromise.then(() => {
   baselinePassthrough =
     esmsInitOptions.polyfillEnable !== true &&
     supportsImportMaps &&
-    (!jsonModulesEnabled || supportsJsonType) &&
+    supportsJsonType &&
     (!cssModulesEnabled || supportsCssType) &&
     (!wasmInstancePhaseEnabled || supportsWasmInstancePhase) &&
     (!wasmSourcePhaseEnabled || supportsWasmSourcePhase) &&
@@ -594,7 +593,6 @@ async function fetchModule(url, fetchOpts, parent) {
 function isUnsupportedType(type) {
   if (
     (type === 'css' && !cssModulesEnabled) ||
-    (type === 'json' && !jsonModulesEnabled) ||
     (type === 'wasm' && !wasmInstancePhaseEnabled && !wasmSourcePhaseEnabled) ||
     (type === 'ts' && !typescriptEnabled)
   )
@@ -681,7 +679,7 @@ function linkLoad(load, fetchOpts) {
           if (!sourcePhase || !supportsWasmSourcePhase) load.n = true;
         }
         if (a > 0) {
-          if (!shimMode && !cssModulesEnabled && !jsonModulesEnabled) throw featErr('css-modules / json-modules');
+          if (!shimMode && !cssModulesEnabled) throw featErr('css-modules');
           if (!supportsCssType && !supportsJsonType) load.n = true;
         }
         if (d !== -1 || !n) return;

--- a/src/features.js
+++ b/src/features.js
@@ -3,7 +3,6 @@ import {
   noop,
   nonce,
   cssModulesEnabled,
-  jsonModulesEnabled,
   wasmInstancePhaseEnabled,
   wasmSourcePhaseEnabled,
   hasDocument
@@ -58,8 +57,8 @@ export let featureDetectionPromise = (async function () {
         ,
         supportsImportMaps,
         supportsMultipleImportMaps,
-        supportsCssType,
         supportsJsonType,
+        supportsCssType,
         supportsWasmSourcePhase,
         supportsWasmInstancePhase
       ] = data;
@@ -69,16 +68,16 @@ export let featureDetectionPromise = (async function () {
     }
     window.addEventListener('message', cb, false);
 
-    // Feature checking with careful avoidance of unnecessary work - all gated on initial import map supports check. JSON gates on CSS feature check, Wasm instance phase gates on wasm source phase check.
+    // Feature checking with careful avoidance of unnecessary work - all gated on initial import map supports check. CSS gates on JSON feature check, Wasm instance phase gates on wasm source phase check.
     const importMapTest = `<script nonce=${nonce || ''}>b=(s,type='text/javascript')=>URL.createObjectURL(new Blob([s],{type}));c=u=>import(u).then(()=>true,()=>false);i=innerText=>document.head.appendChild(Object.assign(document.createElement('script'),{type:'importmap',nonce:"${nonce}",innerText}));i(\`{"imports":{"x":"\${b('')}"}}\`);i(\`{"imports":{"y":"\${b('')}"}}\`);cm=${
-      supportsImportMaps && cssModulesEnabled ? `c(b(\`import"\${b('','text/css')}"with{type:"css"}\`))` : 'false'
+      supportsImportMaps ? `c(b(\`import"\${b('{}','text/json')}"with{type:"json"}\`))` : 'false'
     };sp=${
       supportsImportMaps && wasmSourcePhaseEnabled ?
         `c(b(\`import source x from "\${b(new Uint8Array(${JSON.stringify(wasmBytes)}),'application/wasm')\}"\`))`
       : 'false'
     };Promise.all([${supportsImportMaps ? 'true' : "c('x')"},${supportsImportMaps ? "c('y')" : false},cm,${
-      supportsImportMaps && jsonModulesEnabled ?
-        `${cssModulesEnabled ? 'cm.then(s=>s?' : ''}c(b(\`import"\${b('{}','text/json')\}"with{type:"json"}\`))${cssModulesEnabled ? ':false)' : ''}`
+      supportsImportMaps && cssModulesEnabled ?
+        `cm.then(s=>s?c(b(\`import"\${b('','text/css')\}"with{type:"css"}\`)):false)`
       : 'false'
     },sp,${
       supportsImportMaps && wasmInstancePhaseEnabled ?


### PR DESCRIPTION
This PR enables JSON Modules by default in es-module-shims, allowing applications to polyfill this syntax without needing it to be explicitly enabled as a feature.

JSON modules have 85% browser support now, so most browsers will get baseline passthrough under this default enabling.

One repercussion though is that since JSON modules aren't implemented in Firefox, applications will always have their graphs analyzed for JSON usage.

To avoid this, it could be worth updating this PR to also support a new `polyfillDisable` option supporting `polyfillDisable: ['json-modules']` so that passthrough can still happen in Firefox when users know the application won't use JSON modules. I'm not sure if the benefits outweigh the costs for that yet though.