### PR TITLE
feat: TypeScript auto-enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The following modules features are polyfilled:
 * [JSON](#json-modules) and [CSS modules](#css-modules) with import assertions when enabled.
 * [Wasm modules](#wasm-modules) with support for Source Phase Imports when enabled.
 * [Import defer](#import-defer) via syntax stripping to allow usage in modern browsers with a polyfill fallback when enabled.
-* [TypeScript](#typescript-type-stripping) type stripping when enabled.
+* [TypeScript](#typescript-type-stripping) type stripping.
 
 When running in shim mode, module rewriting is applied for all users and custom [resolve](#resolve-hook) and [fetch](#fetch-hook) hooks can be implemented allowing for custom resolution and streaming in-browser transform workflows.
 
@@ -192,7 +192,7 @@ If using more modern features like CSS Modules or JSON Modules, these need to be
 
 ```html
 <script>
-window.esmsInitOptions = { polyfillEnable: ['css-modules', 'wasm-modules', 'typescript'] }
+window.esmsInitOptions = { polyfillEnable: ['css-modules', 'wasm-modules'] }
 </script>
 ```
 
@@ -562,21 +562,21 @@ The polyfill is simply just a defer syntax stripping, allowing environments that
 
 Node.js recently [added support for automatically executing TypeScript with type stripping](https://nodejs.org/api/typescript.html). We support the exact same approach in ES Module Shims.
 
-Once enabled, the separate `es-module-shims-typescript.js` extension must be available as a sibling asset to `es-module-shims.js` and will then be loaded on demand when a `.ts`, `.mts` file is loaded or when a file is served with the `application/typescript` MIME type.
-
-Example:
+To trigger TypeScript support, import a top-level `.ts` or `.mts` extension, write an inline `<script lang="ts" type="module">`, or import content served with MIME type `application/typescript`:
 
 ```html
-<script async src="https://ga.jspm.io/npm:es-module-shims@2.1.2/dist/es-module-shims.js"></script>
-<script type="esms-options">
-{
-  "polyfillEnable": "all"
-}
+<script type="module" src="app.ts"></script>
+<script type="module" lang="ts">
+const ts: boolean = true;
+console.log('TypeScript!');
 </script>
-<script type="module" src="test.ts"></script>
 ```
 
+When one of these **top-level** TypeScript patterns is found, the separate `es-module-shims-typescript.js` extension must be available as a sibling asset to `es-module-shims.js` and will then be loaded on demand.
+
 Note that runtime TypeScript features such as enums are not supported, and type only imports should be used where possible, per the Node.js guidance for TypeScript.
+
+_TypeScript must be used at the top-level in order to be supported - we do not feature detect it down the module graph like other polyfill features for performance._
 
 ### Module Workers
 

--- a/src/env.js
+++ b/src/env.js
@@ -54,7 +54,6 @@ export const wasmInstancePhaseEnabled =
 export const wasmSourcePhaseEnabled =
   enable.includes('wasm-modules') || enable.includes('wasm-module-sources') || enableAll;
 export const deferPhaseEnabled = enable.includes('import-defer') || enableAll;
-export const typescriptEnabled = enable.includes('typescript') || enableAll;
 
 export const onpolyfill =
   esmsInitOptions.onpolyfill ?

--- a/test/test-csp.html
+++ b/test/test-csp.html
@@ -28,7 +28,7 @@
 <script nonce="asdf">
   window.noEval = true;
   window.esmsInitOptions = {
-    polyfillEnable: ['css-modules', 'json-modules', 'wasm-modules', 'source-phase', 'import-defer']
+    polyfillEnable: ['css-modules', 'wasm-modules', 'source-phase', 'import-defer']
   };
   window.domLoad = 0;
   document.addEventListener('DOMContentLoaded', () => {

--- a/test/test-polyfill-wasm.html
+++ b/test/test-polyfill-wasm.html
@@ -25,7 +25,7 @@
 
 <script>
   window.esmsInitOptions = {
-    polyfillEnable: ['css-modules', 'json-modules', 'wasm-modules', 'source-phase', 'import-defer']
+    polyfillEnable: ['css-modules', 'wasm-modules', 'source-phase', 'import-defer']
   };
   window.domLoad = 0;
   document.addEventListener('DOMContentLoaded', () => {

--- a/test/test-polyfill.html
+++ b/test/test-polyfill.html
@@ -27,7 +27,7 @@
 
 <script>
   window.esmsInitOptions = {
-    polyfillEnable: ['css-modules', 'json-modules', 'wasm-modules', 'import-defer'],
+    polyfillEnable: ['css-modules', 'wasm-modules', 'import-defer'],
   };
   window.domLoad = 0;
   document.addEventListener('DOMContentLoaded', () => {

--- a/test/test-ts.html
+++ b/test/test-ts.html
@@ -11,7 +11,7 @@
 </script>
 <script type="esms-options">
 {
-  "polyfillEnable": ["typescript", "css-modules"]
+  "polyfillEnable": ["css-modules"]
 }
 </script>
 <script type="module" src="../dist/es-module-shims.js"></script>

--- a/test/test-ts.html
+++ b/test/test-ts.html
@@ -15,7 +15,7 @@
 }
 </script>
 <script type="module" src="../dist/es-module-shims.js"></script>
-<script type="module" src="/test/fixtures/test.ts"></script>
+<script type="module" src="/test/fixtures/test.ts" lang="ts"></script>
 <script type="module" noshim>
   import { runMochaTests } from "./runMochaTests.js";
   import('../dist/es-module-shims-typescript.js').then(() => {

--- a/test/typescript.js
+++ b/test/typescript.js
@@ -16,12 +16,12 @@ suite('TypeScript loading tests', () => {
   });
 
   test('Basic type stripping', async function () {
-    const { fn } = await importShim('/test/fixtures/test-dep.ts');
+    const { fn } = await importShim('/test/fixtures/test-dep.ts', { lang: 'ts' });
     assert.ok(fn() === 5);
   });
 
   test('TypeScript with CSS dependency', async function () {
-    const { style, getStyle, p } = await importShim('/test/fixtures/ts-loading-css.ts');
+    const { style, getStyle, p } = await importShim('/test/fixtures/ts-loading-css.ts', { lang: 'ts' });
     assert.ok(p === 50);
     assert.ok((await getStyle()).default instanceof CSSStyleSheet);
   });


### PR DESCRIPTION
This converts the TypeScript handling to instead of being a global feature, to be a graph-level option via setting the `lang="ts"` attribute to opt-in to TypeScript processing.

This feels a more natural integration than having to fiddle with `esms-options` configurations for `polyfillEnable`.

In addition we also support `importShim('./dep.ts', { lang: 'ts' })` for the dynamic import form.

TypeScript is then enabled in shim mode by default and in polyfill mode whenever these lang options are passed.

Strictly speaking, TypeScript will be also processed whenever found in the graph, but the lang option ensures we always validate the graph.