### PR TITLE
feat: support CSS module imports by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,22 +188,20 @@ If the polyfill is analyzing or applying to a module script that doesn't need to
 
 ### Polyfill Features
 
-If using more modern features like CSS Modules or JSON Modules, these need to be manually enabled via the [`polyfillEnable` init option](#polyfill-enable-option) to raise the native baseline from just checking import maps to also checking that browsers support these features:
+If using more modern features like [Import Defer](#import-defer) or [Wasm Modules](#wasm-modules), these need to be manually enabled via the [`polyfillEnable` init option](#polyfill-enable-option) to raise the native baseline from just checking import maps to also checking that browsers support these features:
 
 ```html
 <script>
-window.esmsInitOptions = { polyfillEnable: ['css-modules', 'wasm-modules'] }
+window.esmsInitOptions = { polyfillEnable: ['wasm-module-sources', 'import-defer'] }
 </script>
 ```
 
-The above polyfill options correspond to `polyfillEnable: 'all'`.
-
-Alternatively options can be set via the `esms-options` script type:
+Alternatively options can be set via the `esms-options` script type JSON:
 
 ```html
 <script type="esms-options">
 {
-  "polyfillEnable": "all"
+  "polyfillEnable": ["wasm-module-sources", "import-defer"]
 }
 </script>
 ```
@@ -503,9 +501,9 @@ In addition JSON modules need to be served with a valid JSON content type.
 
 > Stability: WhatWG Standard, Single Browser Implementer
 
-In shim mode, CSS modules are always supported. In polyfill mode, CSS modules require the `polyfillEnable: ['css-modules']` [init option](#polyfill-enable-option).
+CSS imports are fully supported in both polyfill and shim mode with native passthrough applying in Chrome.
 
-CSS Modules are currently supported in Chrome when using them via an import assertion:
+Use them by adding the `type: 'css'` import assertion when importing a CSS file:
 
 ```html
 <script type="module">
@@ -513,7 +511,7 @@ import sheet from 'https://site.com/sheet.css' with { type: 'css' };
 </script>
 ```
 
-In addition CSS modules need to be served with a valid CSS content type.
+In addition CSS files need to be served with a valid CSS content type.
 
 ### Wasm Modules
 
@@ -521,13 +519,11 @@ In addition CSS modules need to be served with a valid CSS content type.
 
 Implements the [WebAssembly ESM Integration](https://github.com/WebAssembly/esm-integration) spec, including support for source phase imports.
 
-In shim mode, Wasm modules are always supported. In polyfill mode, Wasm modules require the `polyfillEnable: ['wasm-modules']` [init option](#polyfill-enable-option).
+In shim mode, Wasm modules are always supported. In polyfill mode, Wasm modules require the `polyfillEnable: ['wasm-module-sources']` (or `'wasm-modules-instances'` for instance imports) [init option](#polyfill-enable-option).
 
 WebAssembly module exports are made available as module exports and WebAssembly module imports will be resolved using the browser module loader.
 
-By default Wasm support will look for both source phase syntax as well as instance Wasm imports, resulting in full analysis of the module graph when either is unsupported.
-
-If only using Wasm modules in the source phase set `polyfillEnable: ['wasm-module-sources']` [init option](#polyfill-enable-option) to ensure full native passthrough without the extra code analysis when Chrome ships the source phase.
+If only using Wasm modules in both the instance and source phase set `polyfillEnable: ['wasm-modules']` [init option](#polyfill-enable-option) to enable both modes.
 
 When enabling the source phase feature either way, `WebAssembly.Module` is also polyfilled to extend from `AbstractModuleSource` per the source phase proposal.
 
@@ -548,7 +544,7 @@ const instance = await WebAssembly.instantiate(mod, { /* ...imports */ });
 </script>
 ```
 
-If using CSP, make sure to add `'unsafe-wasm-eval'` to `script-src` which is needed when the shim or polyfill engages, note this policy is much much safer than eval due to the Wasm secure sandbox. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_webassembly_execution.
+If using CSP, make sure to add `'unsafe-wasm-eval'` to `script-src` which is needed when the shim or polyfill engages, note this policy is safer than normal eval due to the Wasm secure sandbox. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_webassembly_execution.
 
 ### Import Defer
 
@@ -677,7 +673,7 @@ window.esmsInitOptions = {
   // Enable Shim Mode
   shimMode: true, // default false
   // Enable newer modules features
-  polyfillEnable: ['css-modules'], // default empty
+  polyfillEnable: ['wasm-module-sources'], // default empty
   // Custom CSP nonce
   nonce: 'n0nce', // default is automatic detection
   // Don't retrigger load events on module scripts (DOMContentLoaded, domready, window 'onload')
@@ -716,7 +712,7 @@ window.esmsInitOptions = {
 <script type="esms-options">
 {
   "shimMode": true,
-  "polyfillEnable": ["css-modules"],
+  "polyfillEnable": ["wasm-module-sources"],
   "nonce": "n0nce",
   "onpolyfill": "polyfill"
 }
@@ -745,14 +741,14 @@ DOM `load` events are fired for all `"module-shim"` scripts both for success and
 
 The `polyfillEnable` option allows enabling polyfill features which are newer and would otherwise result in unnecessary polyfilling in modern browsers that haven't yet updated.
 
-This options supports `"css-modules"`, `"wasm-modules"`, `"wasm-module-sources"`, `"wasm-module-instances"` and `"import-defer"`.
+This options supports `"wasm-modules"`, `"wasm-module-sources"`, `"wasm-module-instances"` and `"import-defer"`.
 
-In adddition, the `"all"` option will enable all features and the `"latest"` option will implement the latest edge of browser features (currently only `"css-modules"`).
+In adddition, the `"all"` option will enable all features.
 
 ```html
 <script type="esms-options">
 {
-  "polyfillEnable": ["latest"]
+  "polyfillEnable": ["all"]
 }
 </script>
 ```

--- a/src/env.js
+++ b/src/env.js
@@ -47,8 +47,6 @@ function globalHook(name) {
 
 const enable = Array.isArray(esmsInitOptions.polyfillEnable) ? esmsInitOptions.polyfillEnable : [];
 const enableAll = esmsInitOptions.polyfillEnable === 'all' || enable.includes('all');
-const enableLatest = esmsInitOptions.polyfillEnable === 'latest' || enable.includes('latest');
-export const cssModulesEnabled = enable.includes('css-modules') || enableAll || enableLatest;
 export const wasmInstancePhaseEnabled =
   enable.includes('wasm-modules') || enable.includes('wasm-module-instances') || enableAll;
 export const wasmSourcePhaseEnabled =

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -13,7 +13,6 @@ import {
   skip,
   revokeBlobURLs,
   noLoadEventRetriggers,
-  cssModulesEnabled,
   wasmInstancePhaseEnabled,
   wasmSourcePhaseEnabled,
   deferPhaseEnabled,
@@ -176,7 +175,7 @@ const initPromise = featureDetectionPromise.then(() => {
     esmsInitOptions.polyfillEnable !== true &&
     supportsImportMaps &&
     supportsJsonType &&
-    (!cssModulesEnabled || supportsCssType) &&
+    supportsCssType &&
     (!wasmInstancePhaseEnabled || supportsWasmInstancePhase) &&
     (!wasmSourcePhaseEnabled || supportsWasmSourcePhase) &&
     !deferPhaseEnabled &&
@@ -596,11 +595,7 @@ async function fetchModule(url, fetchOpts, parent) {
 }
 
 function isUnsupportedType(type) {
-  if (
-    (type === 'css' && !cssModulesEnabled) ||
-    (type === 'wasm' && !wasmInstancePhaseEnabled && !wasmSourcePhaseEnabled)
-  )
-    throw featErr(`${type}-modules`);
+  if (type === 'wasm' && !wasmInstancePhaseEnabled && !wasmSourcePhaseEnabled) throw featErr(`wasm-modules`);
   return (
     (type === 'css' && !supportsCssType) ||
     (type === 'json' && !supportsJsonType) ||
@@ -690,7 +685,6 @@ function linkLoad(load, fetchOpts) {
             if (supportsJsonType) source = '';
             else load.n = true;
           } else if (assertion.includes('css')) {
-            if (!cssModulesEnabled) throw featErr('css-modules');
             if (supportsCssType) source = '';
             else load.n = true;
           }

--- a/src/features.js
+++ b/src/features.js
@@ -1,12 +1,4 @@
-import {
-  createBlob,
-  noop,
-  nonce,
-  cssModulesEnabled,
-  wasmInstancePhaseEnabled,
-  wasmSourcePhaseEnabled,
-  hasDocument
-} from './env.js';
+import { createBlob, noop, nonce, wasmInstancePhaseEnabled, wasmSourcePhaseEnabled, hasDocument } from './env.js';
 
 // support browsers without dynamic import support (eg Firefox 6x)
 export let supportsJsonType = false;
@@ -24,16 +16,16 @@ const wasmBytes = [0, 97, 115, 109, 1, 0, 0, 0];
 export let featureDetectionPromise = (async function () {
   if (!hasDocument)
     return Promise.all([
-      cssModulesEnabled &&
-        import(createBlob(`import"${createBlob('', 'text/css')}"with{type:"css"}`)).then(
-          () => (supportsCssType = true),
-          noop
+      import(createBlob(`import"${createBlob('{}', 'text/json')}"with{type:"json"}`)).then(
+        () => (
+          (supportsJsonType = true),
+          import(createBlob(`import"${createBlob('', 'text/css')}"with{type:"css"}`)).then(
+            () => (supportsCssType = true),
+            noop
+          )
         ),
-      jsonModulesEnabled &&
-        import(createBlob(`import"${createBlob('{}', 'text/json')}"with{type:"json"}`)).then(
-          () => (supportsJsonType = true),
-          noop
-        ),
+        noop
+      ),
       wasmInstancePhaseEnabled &&
         import(createBlob(`import"${createBlob(new Uint8Array(wasmBytes), 'application/wasm')}"`)).then(
           () => (supportsWasmInstancePhase = true),
@@ -76,9 +68,7 @@ export let featureDetectionPromise = (async function () {
         `c(b(\`import source x from "\${b(new Uint8Array(${JSON.stringify(wasmBytes)}),'application/wasm')\}"\`))`
       : 'false'
     };Promise.all([${supportsImportMaps ? 'true' : "c('x')"},${supportsImportMaps ? "c('y')" : false},cm,${
-      supportsImportMaps && cssModulesEnabled ?
-        `cm.then(s=>s?c(b(\`import"\${b('','text/css')\}"with{type:"css"}\`)):false)`
-      : 'false'
+      supportsImportMaps ? `cm.then(s=>s?c(b(\`import"\${b('','text/css')\}"with{type:"css"}\`)):false)` : 'false'
     },sp,${
       supportsImportMaps && wasmInstancePhaseEnabled ?
         `${wasmSourcePhaseEnabled ? 'sp.then(s=>s?' : ''}c(b(\`import"\${b(new Uint8Array(${JSON.stringify(wasmBytes)}),'application/wasm')\}"\`))${wasmSourcePhaseEnabled ? ':false)' : ''}`

--- a/test/test-csp.html
+++ b/test/test-csp.html
@@ -28,7 +28,7 @@
 <script nonce="asdf">
   window.noEval = true;
   window.esmsInitOptions = {
-    polyfillEnable: ['css-modules', 'wasm-modules', 'source-phase', 'import-defer']
+    polyfillEnable: ['wasm-modules', 'import-defer']
   };
   window.domLoad = 0;
   document.addEventListener('DOMContentLoaded', () => {

--- a/test/test-polyfill-wasm.html
+++ b/test/test-polyfill-wasm.html
@@ -25,7 +25,7 @@
 
 <script>
   window.esmsInitOptions = {
-    polyfillEnable: ['css-modules', 'wasm-modules', 'source-phase', 'import-defer']
+    polyfillEnable: ['wasm-modules', 'import-defer']
   };
   window.domLoad = 0;
   document.addEventListener('DOMContentLoaded', () => {

--- a/test/test-polyfill.html
+++ b/test/test-polyfill.html
@@ -27,7 +27,7 @@
 
 <script>
   window.esmsInitOptions = {
-    polyfillEnable: ['css-modules', 'wasm-modules', 'import-defer'],
+    polyfillEnable: ['wasm-modules', 'import-defer'],
   };
   window.domLoad = 0;
   document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
CSS import attributes, even though only in Chrome, are already at over 70% usage. It makes sense to enable them by default at this point.

This deprecates the `css-modules` option, just like https://github.com/guybedford/es-module-shims/pull/478 did for `json-modules` and now makes css modules part of the baseline.

Hopefully Safari and Firefox support will be coming further here, but in the mean time, this polyfill can help.