### PR TITLE
feat: support multiple instances, fix ready listeners

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,13 +21,16 @@ function config(isWasm, isDebug) {
       format: 'iife',
       strict: false,
       sourcemap: false,
-      banner: `/* ES Module Shims ${isWasm ? 'Wasm ' : ''}${version} */`
+      banner: `/** ES Module Shims ${isWasm ? 'Wasm ' : ''}${version} */`
     },
     plugins: [
       {
         resolveId(id) {
           if (isWasm && id === '../node_modules/es-module-lexer/dist/lexer.asm.js')
             return path.resolve('node_modules/es-module-lexer/dist/lexer.js');
+        },
+        renderChunk(code) {
+          return { code: code.replace('$ret()', 'return') };
         }
       },
       replace({

--- a/src/env.js
+++ b/src/env.js
@@ -1,4 +1,11 @@
-export const hasWindow = typeof window !== 'undefined';
+if (self.importShim) {
+  if (self.ESMS_DEBUG)
+    console.info(
+      `es-module-shims: skipping initialization as importShim was already registered by another polyfill instance`
+    );
+  $ret();
+}
+
 export const hasDocument = typeof document !== 'undefined';
 
 export const noop = () => {};

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -749,11 +749,11 @@ if (hasDocument) {
   window.addEventListener('load', loadEvent);
 }
 
-async function domContentLoadedEvent () {
+async function domContentLoadedEvent() {
   await initPromise;
   domContentLoadedCheck();
 }
-async function loadEvent () {
+async function loadEvent() {
   await initPromise;
   loadCheck();
 }


### PR DESCRIPTION
This fixes bugs that can occur when there are multiple instances of es-module-shims on the same page. We add an early exist when es-module-shims has previously been registered on the page. The reason for these conflicts is the `script.ep === true` check we use to determine processed scripts. A random attribute or symbol would avoid this, but we don't need to support multi-processing.

This also fixes up some event listener handling as well - ensuring we properly unregister event listeners on the page and fixing up a case where DOMContentLoaded wasn't correctly refiring.