### PR TITLE
feat: support unwrapped WebAssembly.Global exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,7 +644,8 @@ When enabled, [native passthrough](#native-passthrough) will be automatically di
 * `hot.accept(dep, cb)`: Accept a hot update of a dependency specifier string.
 * `hot.accept(deps, cb)`: Accept a hot update of a list of dependency specifier strings.
 * `hot.dispose(cb)`: Provide a dispose function for when this module is expected to be accepted by others.
-* 
+* `hot.data`: Shared data object between hot reload instances.
+* `hot.invalidate()`: Fully invalidate the current module, without accepting. Can be called within accept itself.
 
 To trigger a hot reload, call the `importShim.hotReload(url)` API with the URL of the module that has changed. All of CSS, JSON, Wasm and TypeScript imports are supported in hot reloading.
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ ES Module Shims is designed for production performance. A [comprehensive benchma
 
 Benchmark summary:
 
-* [ES Module Shims Chrome Passthrough](bench/README.md#chrome-passthrough-performance) (for [94% of users](https://caniuse.com/import-maps)) results in ~5ms extra initialization time over native for ES Module Shims fetching, execution and initialization, and on a slow connection the additional non-blocking bandwidth cost of its 10KB compressed download as expected.
+* [ES Module Shims Chrome Passthrough](bench/README.md#chrome-passthrough-performance) (for [94% of users](https://caniuse.com/import-maps)) results in ~5ms extra initialization time over native for ES Module Shims fetching, execution and initialization, and on a slow connection the additional non-blocking bandwidth cost of its 13KB compressed download as expected.
 * [ES Module Shims Polyfilling](bench/README.md#native-v-polyfill-performance) (for the remaining [3% of users](https://caniuse.com/import-maps)) is on average 1.4x - 1.5x slower than native module loading, and up to 1.8x slower on slow networks (most likely due to the browser preloader), both for cached and uncached loads, and this result scales linearly up to 10MB and 20k modules loaded executing on the fastest connection in just over 2 seconds in Firefox.
 * [Very large import maps](bench/README.md#large-import-maps-performance) (100s of entries) cost only a few extra milliseconds upfront for the additional loading cost.
 

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -745,6 +745,7 @@ let lastStaticLoadPromise = Promise.resolve();
 let domContentLoaded = false;
 let domContentLoadedCnt = 1;
 const domContentLoadedCheck = () => {
+  console.log(domContentLoadedCnt - 1);
   if (--domContentLoadedCnt === 0 && !noLoadEventRetriggers && (shimMode || !baselinePassthrough)) {
     if (self.ESMS_DEBUG) console.info(`es-module-shims: DOMContentLoaded refire`);
     document.removeEventListener('DOMContentLoaded', domContentLoadedEvent);
@@ -755,7 +756,7 @@ let loadCnt = 1;
 const loadCheck = () => {
   if (--loadCnt === 0 && !noLoadEventRetriggers && (shimMode || !baselinePassthrough)) {
     if (self.ESMS_DEBUG) console.info(`es-module-shims: load refire`);
-    window.removeEventListener('DOMContentLoaded', loadEvent);
+    window.removeEventListener('load', loadEvent);
     window.dispatchEvent(new Event('load'));
   }
 };
@@ -766,6 +767,7 @@ const domContentLoadedEvent = async () => {
 };
 const loadEvent = async () => {
   await initPromise;
+  if (!domContentLoaded) domContentLoadedCheck();
   loadCheck();
 };
 

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -744,7 +744,12 @@ let lastStaticLoadPromise = Promise.resolve();
 
 let domContentLoaded = false;
 let domContentLoadedCnt = 1;
-const domContentLoadedCheck = () => {
+const domContentLoadedCheck = m => {
+  if (m === undefined) {
+    if (domContentLoaded) return;
+    domContentLoaded = true;
+    domContentLoadedCnt--;
+  }
   if (--domContentLoadedCnt === 0 && !noLoadEventRetriggers && (shimMode || !baselinePassthrough)) {
     if (self.ESMS_DEBUG) console.info(`es-module-shims: DOMContentLoaded refire`);
     document.removeEventListener('DOMContentLoaded', domContentLoadedEvent);
@@ -761,16 +766,12 @@ const loadCheck = () => {
 };
 
 const domContentLoadedEvent = async () => {
-  domContentLoaded = true;
   await initPromise;
   domContentLoadedCheck();
 };
 const loadEvent = async () => {
   await initPromise;
-  if (!domContentLoaded) {
-    domContentLoadedCheck();
-    domContentLoaded = true;
-  }
+  domContentLoadedCheck();
   loadCheck();
 };
 
@@ -791,10 +792,7 @@ const readyListener = async () => {
 let readyStateCompleteCnt = 1;
 const readyStateCompleteCheck = () => {
   if (--readyStateCompleteCnt === 0) {
-    if (!domContentLoaded) {
-      domContentLoaded = true;
-      domContentLoadedCheck();
-    }
+    domContentLoadedCheck();
     if (!noLoadEventRetriggers && (shimMode || !baselinePassthrough)) {
       if (self.ESMS_DEBUG) console.info(`es-module-shims: readystatechange complete refire`);
       document.removeEventListener('readystatechange', readyListener);

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -155,7 +155,9 @@ importShim.addImportMap = importMapIn => {
 };
 
 const registry = (importShim._r = {});
+// Wasm caches
 const sourceCache = (importShim._s = {});
+const instanceCache = (importShim._i = new WeakMap());
 
 const loadAll = async (load, seen) => {
   seen[load.u] = 1;
@@ -187,35 +189,32 @@ const initPromise = featureDetectionPromise.then(() => {
     !deferPhaseEnabled &&
     (!multipleImportMaps || supportsMultipleImportMaps) &&
     !importMapSrc;
-  if (
-    !shimMode &&
-    wasmSourcePhaseEnabled &&
-    typeof WebAssembly !== 'undefined' &&
-    !Object.getPrototypeOf(WebAssembly.Module).name
-  ) {
-    const s = Symbol();
-    const brand = m =>
-      Object.defineProperty(m, s, { writable: false, configurable: false, value: 'WebAssembly.Module' });
-    class AbstractModuleSource {
-      get [Symbol.toStringTag]() {
-        if (this[s]) return this[s];
-        throw new TypeError('Not an AbstractModuleSource');
+  if (!shimMode && typeof WebAssembly !== 'undefined') {
+    if (wasmSourcePhaseEnabled && !Object.getPrototypeOf(WebAssembly.Module).name) {
+      const s = Symbol();
+      const brand = m =>
+        Object.defineProperty(m, s, { writable: false, configurable: false, value: 'WebAssembly.Module' });
+      class AbstractModuleSource {
+        get [Symbol.toStringTag]() {
+          if (this[s]) return this[s];
+          throw new TypeError('Not an AbstractModuleSource');
+        }
       }
+      const { Module: wasmModule, compile: wasmCompile, compileStreaming: wasmCompileStreaming } = WebAssembly;
+      WebAssembly.Module = Object.setPrototypeOf(
+        Object.assign(function Module(...args) {
+          return brand(new wasmModule(...args));
+        }, wasmModule),
+        AbstractModuleSource
+      );
+      WebAssembly.Module.prototype = Object.setPrototypeOf(wasmModule.prototype, AbstractModuleSource.prototype);
+      WebAssembly.compile = function compile(...args) {
+        return wasmCompile(...args).then(brand);
+      };
+      WebAssembly.compileStreaming = function compileStreaming(...args) {
+        return wasmCompileStreaming(...args).then(brand);
+      };
     }
-    const { Module: wasmModule, compile: wasmCompile, compileStreaming: wasmCompileStreaming } = WebAssembly;
-    WebAssembly.Module = Object.setPrototypeOf(
-      Object.assign(function Module(...args) {
-        return brand(new wasmModule(...args));
-      }, wasmModule),
-      AbstractModuleSource
-    );
-    WebAssembly.Module.prototype = Object.setPrototypeOf(wasmModule.prototype, AbstractModuleSource.prototype);
-    WebAssembly.compile = function compile(...args) {
-      return wasmCompile(...args).then(brand);
-    };
-    WebAssembly.compileStreaming = function compileStreaming(...args) {
-      return wasmCompileStreaming(...args).then(brand);
-    };
   }
   if (hasDocument) {
     if (!supportsImportMaps) {
@@ -556,22 +555,24 @@ const fetchModule = async (url, fetchOpts, parent) => {
   const contentType = res.headers.get('content-type');
   if (jsContentType.test(contentType)) return { r, s: await res.text(), t: 'js' };
   else if (wasmContentType.test(contentType)) {
-    const module = await (sourceCache[r] || (sourceCache[r] = WebAssembly.compileStreaming(res)));
-    const exports = WebAssembly.Module.exports(module);
-    sourceCache[r] = module;
-    let s = '',
+    const wasmModule = await (sourceCache[r] || (sourceCache[r] = WebAssembly.compileStreaming(res)));
+    const exports = WebAssembly.Module.exports(wasmModule);
+    sourceCache[r] = wasmModule;
+    const rStr = urlJsString(r);
+    let s = `import*as $_ns from${rStr};`,
       i = 0,
       obj = '';
-    for (const impt of WebAssembly.Module.imports(module)) {
-      const specifier = urlJsString(impt.module);
-      s += `import*as impt${i} from ${specifier};\n`;
-      obj += `${specifier}:impt${i++},`;
+    for (const { module, kind } of WebAssembly.Module.imports(wasmModule)) {
+      const specifier = urlJsString(module);
+      s += `import*as impt${i} from${specifier};\n`;
+      obj += `${specifier}:${kind === 'global' ? `importShim._i.get(impt${i})||impt${i++}` : `impt${i++}`},`;
     }
-    s += `${hotPrefix}i=await WebAssembly.instantiate(importShim._s[${urlJsString(r)}],{${obj}});`;
+    s += `${hotPrefix}i=await WebAssembly.instantiate(importShim._s[${rStr}],{${obj}});importShim._i.set($_ns,i);`;
     obj = '';
-    for (const expt of exports) {
-      s += `export let ${expt.name}=i.exports['${expt.name}'];`;
-      obj += `${expt.name},`;
+    for (const { name, kind } of exports) {
+      s += `export let ${name}=i.exports['${name}'];`;
+      if (kind === 'global') s += `try{${name}=${name}.value}catch{${name}=undefined}`;
+      obj += `${name},`;
     }
     s += `if(h)h.accept(m=>({${obj}}=m))`;
     return { r, s, t: 'wasm' };

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -745,7 +745,6 @@ let lastStaticLoadPromise = Promise.resolve();
 let domContentLoaded = false;
 let domContentLoadedCnt = 1;
 const domContentLoadedCheck = () => {
-  console.log(domContentLoadedCnt - 1);
   if (--domContentLoadedCnt === 0 && !noLoadEventRetriggers && (shimMode || !baselinePassthrough)) {
     if (self.ESMS_DEBUG) console.info(`es-module-shims: DOMContentLoaded refire`);
     document.removeEventListener('DOMContentLoaded', domContentLoadedEvent);
@@ -762,12 +761,16 @@ const loadCheck = () => {
 };
 
 const domContentLoadedEvent = async () => {
+  domContentLoaded = true;
   await initPromise;
   domContentLoadedCheck();
 };
 const loadEvent = async () => {
   await initPromise;
-  if (!domContentLoaded) domContentLoadedCheck();
+  if (!domContentLoaded) {
+    domContentLoadedCheck();
+    domContentLoaded = true;
+  }
   loadCheck();
 };
 

--- a/test/fixtures/module-dynamic.js
+++ b/test/fixtures/module-dynamic.js
@@ -1,0 +1,5 @@
+console.log("Dynamically imported module imported");
+document.getElementById("dynamic").innerText = "loaded";
+
+if (window.domContentLoaded)
+  fetch('/done');

--- a/test/fixtures/module-static.js
+++ b/test/fixtures/module-static.js
@@ -1,0 +1,2 @@
+console.log("Statically imported module imported");
+document.getElementById("static").innerText = "loaded";

--- a/test/test-double-polyfill.html
+++ b/test/test-double-polyfill.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <script async src="../dist/es-module-shims.js"></script>
-    <script async src="../dist/es-module-shims.js"></script>
+    <script async src="../dist/es-module-shims.debug.js"></script>
+    <script async src="../dist/es-module-shims.debug.js"></script>
 
     <script type="module">
       console.log('Logging from a module script before the importmap tag to break older browsers');

--- a/test/test-double-polyfill.html
+++ b/test/test-double-polyfill.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <script async src="../dist/es-module-shims.js"></script>
+    <script async src="../dist/es-module-shims.js"></script>
+
+    <script type="module">
+      console.log('Logging from a module script before the importmap tag to break older browsers');
+    </script>
+
+    <script type="importmap">
+      {
+        "imports": {
+          "statically-imported-module": "./fixtures/module-static.js",
+          "dynamically-imported-module": "./fixtures/module-dynamic.js"
+        }
+      }
+    </script>
+
+    <script type="module">
+        import "statically-imported-module";
+        document.addEventListener('DOMContentLoaded', () => {
+          window.domContentLoaded = true;
+        });
+        import("dynamically-imported-module");
+    </script>
+  </head>
+  <body>
+    <h2 style="text-align: center;">Statically imported module: <span id="static">not loaded</span></h2>
+    <h2 style="text-align: center;">Dynamically imported module: <span id="dynamic">not loaded</span></h2>
+  </body>
+</html>

--- a/test/test-sp-exported-names.tentative.html
+++ b/test/test-sp-exported-names.tentative.html
@@ -10,7 +10,7 @@ assert_array_equals(Object.getOwnPropertyNames(mod).sort(),
                     ["func", "glob", "mem", "tab"]);
 assert_true(mod.func instanceof Function);
 assert_true(mod.mem instanceof WebAssembly.Memory);
-assert_true(mod.glob instanceof WebAssembly.Global);
+assert_true(typeof mod.glob === 'number');
 assert_true(mod.tab instanceof WebAssembly.Table);
 assert_throws_js(TypeError, () => { mod.func = 2; });
 done();

--- a/test/test-sp-wasm-js-cycle.tentative.html
+++ b/test/test-sp-wasm-js-cycle.tentative.html
@@ -10,8 +10,8 @@ import * as js from "./resources/wasm-js-cycle.js";
 
 js.mutateBindings();
 
-assert_true(wasm.wasmGlob instanceof WebAssembly.Global);
-assert_equals(wasm.wasmGlob.valueOf(), 24);
+assert_true(typeof wasm.wasmGlob === 'number');
+assert_equals(wasm.wasmGlob, 24);
 
 assert_true(wasm.wasmFunc instanceof Function);
 assert_equals(wasm.wasmFunc(), 43);


### PR DESCRIPTION
This implements https://github.com/nodejs/node/pull/57525 in supporting `WebAssembly.Global` unwrapping on exports while retaining complete interop on imports through the weakmap namespace / instance relation.

This PR doesn't polyfill the weakmap as `WebAssembly.namespaceInstance()` currently although that would be an easy addition in future.