### PR TITLE
feat: hard multi-version protections

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,6 +701,7 @@ Provide a `esmsInitOptions` on the global scope before `es-module-shims` is load
 * [revokeBlobURLs](#revoke-blob-urls)
 * [shimMode](#shim-mode-option)
 * [skip](#skip)
+* [version](#version)
 
 ```html
 <script>
@@ -739,6 +740,8 @@ window.esmsInitOptions = {
   meta: (meta, url) => void // default is noop
   // Hook top-level imports
   onimport: (url, options, parentUrl, source) => void // default is noop
+  // Ensure only the exact provided version of es-module-shims registered
+  version: '2.3.0' // default is empty
 }
 </script>
 <script async src="es-module-shims.js"></script>
@@ -887,6 +890,14 @@ When passing an array, relative URLs or paths ending in `/` can be provided:
 </script>
 <script async src="es-module-shims.js"></script>
 ```
+
+### Version
+
+When there is a risk of multiple versions of ES Module Shims on the same page, this is avoid by logic that will opt-out of initializing ES Module Shims if it has already been initialized.
+
+To better support initialization versions, as of version 2.3.X, we support a `version` option, which when set will skip initialization for any versions of ES Module Shims that do not match this exact version.
+
+This way, any other old versions after version 2.3.X running on the page can effectively be turned off, ensuring only the defined version of the polyfill initiates the polyfilling.
 
 ### Revoke Blob URLs
 

--- a/README.md
+++ b/README.md
@@ -741,7 +741,7 @@ window.esmsInitOptions = {
   // Hook top-level imports
   onimport: (url, options, parentUrl, source) => void // default is noop
   // Ensure only the exact provided version of es-module-shims registered
-  version: '2.3.0' // default is empty
+  version: '2.4.0' // default is empty
 }
 </script>
 <script async src="es-module-shims.js"></script>
@@ -893,11 +893,11 @@ When passing an array, relative URLs or paths ending in `/` can be provided:
 
 ### Version
 
-When there is a risk of multiple versions of ES Module Shims on the same page, this is avoid by logic that will opt-out of initializing ES Module Shims if it has already been initialized.
+When there is a risk of multiple versions of ES Module Shims on the same page, deconflicting is managed by logic that will opt-out of initializing ES Module Shims if it has already been initialized. In addition, ES Module Shims itself is frozen and locked from further mutations.
 
-To better support initialization versions, as of version 2.3.X, we support a `version` option, which when set will skip initialization for any versions of ES Module Shims that do not match this exact version.
+To better support cooporative multi-version cases, as of version 2.4.0, we support a `version` option, which when set will skip initialization if the current version of ES Module Shims does not match this exact expected version.
 
-This way, any other old versions after version 2.3.X running on the page can effectively be turned off, ensuring only the defined version of the polyfill initiates the polyfilling.
+This way, any other old versions after version 2.4.0 running on the page can effectively be turned off, ensuring only the defined version of the polyfill initiates the polyfill.
 
 ### Revoke Blob URLs
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,7 +21,7 @@ function config(isWasm, isDebug) {
       format: 'iife',
       strict: false,
       sourcemap: false,
-      banner: `/**s ES Module Shims ${isWasm ? 'Wasm ' : ''}@version ${version} */`
+      banner: `/** ES Module Shims ${isWasm ? 'Wasm ' : ''}@version ${version} */`
     },
     plugins: [
       {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,6 +35,7 @@ function config(isWasm, isDebug) {
       },
       replace({
         'self.ESMS_DEBUG': isDebug.toString(),
+        'self.VERSION': JSON.stringify(version),
         preventAssignment: true
       })
     ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,7 +21,7 @@ function config(isWasm, isDebug) {
       format: 'iife',
       strict: false,
       sourcemap: false,
-      banner: `/** ES Module Shims ${isWasm ? 'Wasm ' : ''}${version} */`
+      banner: `/**s ES Module Shims ${isWasm ? 'Wasm ' : ''}@version ${version} */`
     },
     plugins: [
       {

--- a/src/env.js
+++ b/src/env.js
@@ -1,13 +1,5 @@
 import { initHotReload } from './hot-reload.js';
 
-if (self.importShim) {
-  if (self.ESMS_DEBUG)
-    console.info(
-      `es-module-shims: skipping initialization as importShim was already registered by another polyfill instance`
-    );
-  $ret();
-}
-
 export const hasDocument = typeof document !== 'undefined';
 
 export const noop = () => {};
@@ -27,6 +19,15 @@ export const optionsScript = hasDocument ? document.querySelector('script[type=e
 
 export const esmsInitOptions = optionsScript ? JSON.parse(optionsScript.innerHTML) : {};
 Object.assign(esmsInitOptions, self.esmsInitOptions || {});
+
+const r = esmsInitOptions.version;
+if (self.importShim || (r && r !== self.VERSION)) {
+  if (self.ESMS_DEBUG)
+    console.info(
+      `es-module-shims: skipping initialization as ${r ? `configured for ${r}` : 'another instance has already registered'}`
+    );
+  $ret();
+}
 
 // shim mode is determined on initialization, no late shim mode
 export const shimMode =

--- a/src/env.js
+++ b/src/env.js
@@ -20,7 +20,10 @@ export const chain = (a, b) =>
 
 export const dynamicImport = (u, errUrl) => import(u);
 
-const optionsScript = hasDocument ? document.querySelector('script[type=esms-options]') : undefined;
+export const defineValue = (obj, prop, value) =>
+  Object.defineProperty(obj, prop, { writable: false, configurable: false, value });
+
+export const optionsScript = hasDocument ? document.querySelector('script[type=esms-options]') : undefined;
 
 export const esmsInitOptions = optionsScript ? JSON.parse(optionsScript.innerHTML) : {};
 Object.assign(esmsInitOptions, self.esmsInitOptions || {});

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -555,7 +555,7 @@ const fetchModule = async (url, fetchOpts, parent) => {
   const mapIntegrity = composedImportMap.integrity[url];
   const res = await doFetch(
     url,
-    mapIntegrity && !fetchOpts.integrity ? Object.assign({}, fetchOpts, { integrity: mapIntegrity }) : fetchOpts,
+    mapIntegrity && !fetchOpts.integrity ? { ...fetchOpts, integrity: mapIntegrity } : fetchOpts,
     parent
   );
   const r = res.url;
@@ -710,7 +710,7 @@ const linkLoad = (load, fetchOpts) => {
         if (d >= 0 || resolved.N) load.N = true;
         if (d !== -1) return;
         if (skip && skip(resolved.r) && !sourcePhase) return { l: { b: resolved.r }, s: false };
-        if (childFetchOpts.integrity) childFetchOpts = Object.assign({}, childFetchOpts, { integrity: undefined });
+        if (childFetchOpts.integrity) childFetchOpts = { ...childFetchOpts, integrity: undefined };
         const child = { l: getOrCreateLoad(resolved.r, childFetchOpts, load.r, source), s: sourcePhase };
         // assertion case -> inline the CSS / JSON URL directly
         if (source === '') child.l.b = child.l.u;

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -156,7 +156,7 @@ const instanceCache = (importShim._i = new WeakMap());
 defineValue(self, 'importShim', Object.freeze(importShim));
 const shimModeOptions = { ...esmsInitOptions, shimMode: true };
 if (optionsScript) optionsScript.innerHTML = JSON.stringify(shimModeOptions);
-else self.esmsInitOptions = shimModeOptions;
+self.esmsInitOptions = shimModeOptions;
 defineValue(self, '_d', undefined);
 
 const loadAll = async (load, seen) => {

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -23,8 +23,9 @@ import {
   nativePassthrough,
   hasDocument,
   hotReload as hotReloadEnabled,
-  defaultFetchOpts
-  defineValue
+  defaultFetchOpts,
+  defineValue,
+  optionsScript
 } from './env.js';
 import {
   supportsImportMaps,
@@ -191,6 +192,7 @@ const initPromise = featureDetectionPromise.then(() => {
   if (!shimMode && typeof WebAssembly !== 'undefined') {
     if (wasmSourcePhaseEnabled && !Object.getPrototypeOf(WebAssembly.Module).name) {
       const s = Symbol();
+      const brand = m => defineValue(m, s, 'WebAssembly.Module');
       class AbstractModuleSource {
         get [Symbol.toStringTag]() {
           if (this[s]) return this[s];
@@ -206,7 +208,7 @@ const initPromise = featureDetectionPromise.then(() => {
       );
       WebAssembly.Module.prototype = Object.setPrototypeOf(wasmModule.prototype, AbstractModuleSource.prototype);
       WebAssembly.compile = function compile(...args) {
-        return wasmCompile(...args).then(m => defineValue(m, s, 'WebAssembly.Module'));
+        return wasmCompile(...args).then(brand);
       };
       WebAssembly.compileStreaming = function compileStreaming(...args) {
         return wasmCompileStreaming(...args).then(brand);

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -103,9 +103,9 @@ export const resolveIfNotPlainOrUrl = (relUrl, parentUrl) => {
 
 export const resolveAndComposeImportMap = (json, baseUrl, parentMap) => {
   const outMap = {
-    imports: Object.assign({}, parentMap.imports),
-    scopes: Object.assign({}, parentMap.scopes),
-    integrity: Object.assign({}, parentMap.integrity)
+    imports: { ...parentMap.imports },
+    scopes: { ...parentMap.scopes },
+    integrity: { ...parentMap.integrity }
   };
 
   if (json.imports) resolveAndComposePackages(json.imports, outMap.imports, baseUrl, parentMap, null);


### PR DESCRIPTION
Adds the hard version protections suggested in https://github.com/guybedford/es-module-shims/issues/484 - freezing the `importShim` object on the global and also freezing its properties.

I would still like to verify before landing this:

1. The shim mode switch is definitely necessary. I would have thought the `ep` markers would have been conflict-avoiding here therefore this would be unnecessary.
2. The `defineValue(self, '_d', undefined)` thing - what version this is deconflicting with and why.