### PR TITLE
fix: remove _d override

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -20,8 +20,10 @@ export const optionsScript = hasDocument ? document.querySelector('script[type=e
 export const esmsInitOptions = optionsScript ? JSON.parse(optionsScript.innerHTML) : {};
 Object.assign(esmsInitOptions, self.esmsInitOptions || {});
 
+export const version = self.VERSION;
+
 const r = esmsInitOptions.version;
-if (self.importShim || (r && r !== self.VERSION)) {
+if (self.importShim || (r && r !== version)) {
   if (self.ESMS_DEBUG)
     console.info(
       `es-module-shims: skipping initialization as ${r ? `configured for ${r}` : 'another instance has already registered'}`

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -25,7 +25,8 @@ import {
   hotReload as hotReloadEnabled,
   defaultFetchOpts,
   defineValue,
-  optionsScript
+  optionsScript,
+  version
 } from './env.js';
 import {
   supportsImportMaps,
@@ -146,6 +147,7 @@ importShim.addImportMap = importMapIn => {
   if (!shimMode) throw new Error('Unsupported in polyfill mode.');
   composedImportMap = resolveAndComposeImportMap(importMapIn, pageBaseUrl, composedImportMap);
 };
+importShim.version = version;
 
 const registry = (importShim._r = {});
 // Wasm caches

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -157,7 +157,6 @@ defineValue(self, 'importShim', Object.freeze(importShim));
 const shimModeOptions = { ...esmsInitOptions, shimMode: true };
 if (optionsScript) optionsScript.innerHTML = JSON.stringify(shimModeOptions);
 self.esmsInitOptions = shimModeOptions;
-defineValue(self, '_d', undefined);
 
 const loadAll = async (load, seen) => {
   seen[load.u] = 1;

--- a/src/features.js
+++ b/src/features.js
@@ -1,4 +1,12 @@
-import { createBlob, noop, nonce, wasmInstancePhaseEnabled, wasmSourcePhaseEnabled, hasDocument } from './env.js';
+import {
+  createBlob,
+  noop,
+  nonce,
+  wasmInstancePhaseEnabled,
+  wasmSourcePhaseEnabled,
+  hasDocument,
+  version
+} from './env.js';
 
 // support browsers without dynamic import support (eg Firefox 6x)
 export let supportsJsonType = false;
@@ -38,12 +46,13 @@ export let featureDetectionPromise = (async function () {
         )
     ]);
 
+  const msgTag = `esms-${version}`;
   return new Promise(resolve => {
     const iframe = document.createElement('iframe');
     iframe.style.display = 'none';
     iframe.setAttribute('nonce', nonce);
     function cb({ data }) {
-      const isFeatureDetectionMessage = Array.isArray(data) && data[0] === 'esms';
+      const isFeatureDetectionMessage = Array.isArray(data) && data[0] === msgTag;
       if (!isFeatureDetectionMessage) return;
       [
         ,
@@ -73,7 +82,7 @@ export let featureDetectionPromise = (async function () {
       supportsImportMaps && wasmInstancePhaseEnabled ?
         `${wasmSourcePhaseEnabled ? 'sp.then(s=>s?' : ''}c(b(\`import"\${b(new Uint8Array(${JSON.stringify(wasmBytes)}),'application/wasm')\}"\`))${wasmSourcePhaseEnabled ? ':false)' : ''}`
       : 'false'
-    }]).then(a=>parent.postMessage(['esms'].concat(a),'*'))<${''}/script>`;
+    }]).then(a=>parent.postMessage(['${msgTag}'].concat(a),'*'))<${''}/script>`;
 
     // Safari will call onload eagerly on head injection, but we don't want the Wechat
     // path to trigger before setting srcdoc, therefore we track the timing

--- a/src/features.js
+++ b/src/features.js
@@ -46,7 +46,7 @@ export let featureDetectionPromise = (async function () {
         )
     ]);
 
-  const msgTag = `esms-${version}`;
+  const msgTag = `s${version}`;
   return new Promise(resolve => {
     const iframe = document.createElement('iframe');
     iframe.style.display = 'none';


### PR DESCRIPTION
I don't think we should be writing this global value in a way that can't be changed. I feel bad enough making `window.importShim` unwriteable.

What setting this does, is force the dynamic import check in older versions of ES Module Shims to fail - so that those old versions will think that dynamic import is not supported when in fact it is. This would not disengage the polyfill though it would in fact actually result in the polyfill polyfilling dynamic import and then using a dynamic import shim.

Therefore I cannot see how this would functionally disable an older version of ES Module Shims, short of there being very specific logic around the change in polyfill behaviours when it thinks dynamic import is not supported when it is.

//cc @frandiox I think I may need to revert this one unfortunately.