### PR TITLE
fix: hot reloading, amaro updates, TypeScript log, Firefox crash

### DIFF
--- a/chompfile.toml
+++ b/chompfile.toml
@@ -42,6 +42,7 @@ function require(mod) {
 }
 ${amaroSource}
 const amaroTransformSync = module.exports.transformSync;
+console.warn('es-module-shims: TypeScript modules are being compiled in the browser. Make sure to compile these files in production workflows. Use es-module-shims.debug.js to trace TypeScript compilations.');
 export function transform(source, url) {
   try {
     const transformed = amaroTransformSync(source, { filename: url, transform: { mode: 'strip-only', noEmptyExport: true } }).code;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "devDependencies": {
     "@rollup/plugin-replace": "^2.4.2",
-    "amaro": "0.5.2",
+    "amaro": "0.5.3",
     "es-module-lexer": "1.7.0",
     "kleur": "^4.1.4",
     "mime-types": "^2.1.33",

--- a/src/env.js
+++ b/src/env.js
@@ -22,6 +22,8 @@ Object.assign(esmsInitOptions, self.esmsInitOptions || {});
 
 export const version = self.VERSION;
 
+export const isFirefox = navigator.userAgent.indexOf('Firefox') > 0;
+
 const r = esmsInitOptions.version;
 if (self.importShim || (r && r !== version)) {
   if (self.ESMS_DEBUG)

--- a/src/env.js
+++ b/src/env.js
@@ -22,8 +22,6 @@ Object.assign(esmsInitOptions, self.esmsInitOptions || {});
 
 export const version = self.VERSION;
 
-export const isFirefox = navigator.userAgent.indexOf('Firefox') > 0;
-
 const r = esmsInitOptions.version;
 if (self.importShim || (r && r !== version)) {
   if (self.ESMS_DEBUG)

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -278,7 +278,8 @@ export const topLevelLoad = async (
   // we mock import('./x.css', { with: { type: 'css' }}) support via an inline static reexport
   // because we can't syntactically pass through to dynamic import with a second argument
   if (sourceType === 'css' || sourceType === 'json') {
-    source = `import m from'${url}'with{type:"${sourceType}"};export ${isFirefox ? 'default m' : '{m as default}'};`;
+    // Direct reexport for hot reloading skipped due to Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=1965620
+    source = `import m from'${url}'with{type:"${sourceType}"};export default m;`;
     url += '?entry';
   }
 
@@ -588,7 +589,7 @@ const fetchModule = async (url, fetchOpts, parent) => {
   } else if (jsonContentType.test(contentType))
     return {
       r,
-      s: `${hotPrefix}j=${await res.text()};export{j as default};${isFirefox ? '' : 'if(h)h.accept(m=>j=m.default)'}`,
+      s: `${hotPrefix}j=${await res.text()};export{j as default};if(h)h.accept(m=>j=m.default)`,
       t: 'json'
     };
   else if (cssContentType.test(contentType)) {

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -277,7 +277,8 @@ export const topLevelLoad = async (
   // we mock import('./x.css', { with: { type: 'css' }}) support via an inline static reexport
   // because we can't syntactically pass through to dynamic import with a second argument
   if (sourceType === 'css' || sourceType === 'json') {
-    source = `export{default}from'${url}'with{type:"${sourceType}"}`;
+    // we don't do a direct reexport here because of Firefox crash https://bugzilla.mozilla.org/show_bug.cgi?id=1965620
+    source = `import m from'${url}'with{type:"${sourceType}"};export default m;`;
     url += '?entry';
   }
 

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -600,6 +600,7 @@ const fetchModule = async (url, fetchOpts, parent) => {
   } else if (tsContentType.test(contentType) || url.endsWith('.ts') || url.endsWith('.mts')) {
     const source = await res.text();
     if (!esmsTsTransform) await initTs();
+    if (self.ESMS_DEBUG) console.info(`es-module-shims: Compiling TypeScript file ${url}`);
     const transformed = esmsTsTransform(source, url);
     // even if the TypeScript is valid JavaScript, unless it was a top-level inline source, it wasn't served with
     // a valid JS MIME here, so we must still polyfill it
@@ -865,6 +866,7 @@ const processScript = (script, ready = readyStateCompleteCnt > 0) => {
   if (ts && !script.src) {
     loadPromise = Promise.resolve(esmsTsTransform || initTs())
       .then(() => {
+        if (self.ESMS_DEBUG) console.info(`es-module-shims: Compiling TypeScript module script`, script);
         const transformed = esmsTsTransform(script.innerHTML, pageBaseUrl);
         if (transformed !== undefined) {
           onpolyfill();

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -26,8 +26,7 @@ import {
   defaultFetchOpts,
   defineValue,
   optionsScript,
-  version,
-  isFirefox
+  version
 } from './env.js';
 import {
   supportsImportMaps,

--- a/src/hot-reload.js
+++ b/src/hot-reload.js
@@ -12,7 +12,7 @@ import {
 import { topLevelLoad } from './es-module-shims.js';
 
 let invalidate;
-export const hotReload = (url) => invalidate(new URL(url, baseUrl).href);
+export const hotReload = url => invalidate(new URL(url, baseUrl).href);
 export const initHotReload = () => {
   let _importHook = importHook,
     _resolveHook = resolveHook,

--- a/test/fixtures/json-assertion.js
+++ b/test/fixtures/json-assertion.js
@@ -1,3 +1,5 @@
 import json from './json.json' with { type: 'json' };
 
-export { json as m }
+export function getJson () {
+  return json;
+}

--- a/test/fixtures/json-assertion.js
+++ b/test/fixtures/json-assertion.js
@@ -1,3 +1,6 @@
 import json from './json.json' with { type: 'json' };
 
-export { json as m }
+// Firefox crash avoidance :(
+let foo = json;
+
+export { foo as m }

--- a/test/fixtures/json-assertion.js
+++ b/test/fixtures/json-assertion.js
@@ -1,6 +1,3 @@
 import json from './json.json' with { type: 'json' };
 
-// Firefox crash avoidance :(
-let foo = json;
-
-export { foo as m }
+export { json as m }

--- a/test/hot.js
+++ b/test/hot.js
@@ -54,17 +54,17 @@ suite('Hot reloading tests', () => {
     importShim.hotReload('fixtures/sheet.css');
   });
 
-  (navigator.userAgent.indexOf('Firefox') > 0 ? test.skip : test)('JSON Hot reload', async function () {
+  test('JSON Hot reload', async function () {
     const m = await importShim('test/json-assertion.js');
-    assert.equal(m.m.json, 'module');
+    assert.equal(m.getJson().json, 'module');
     jsonSource = '{ "json": "hot" }';
     importShim.hotReload('fixtures/json.json');
     await new Promise(resolve => setTimeout(resolve, HOT_WAIT));
-    assert.equal(m.m.json, 'hot');
+    assert.equal(m.getJson().json, 'hot');
     jsonSource = '{ "json": "hot2" }';
     importShim.hotReload('fixtures/json.json');
     await new Promise(resolve => setTimeout(resolve, HOT_WAIT));
-    assert.equal(m.m.json, 'hot2');
+    assert.equal(m.getJson().json, 'hot2');
   });
 
   test('Accept invalidate', async function () {

--- a/test/hot.js
+++ b/test/hot.js
@@ -54,7 +54,7 @@ suite('Hot reloading tests', () => {
     importShim.hotReload('fixtures/sheet.css');
   });
 
-  test('JSON Hot reload', async function () {
+  (navigator.userAgent.indexOf('Firefox') > 0 ? test.skip : test)('JSON Hot reload', async function () {
     const m = await importShim('test/json-assertion.js');
     assert.equal(m.m.json, 'module');
     jsonSource = '{ "json": "hot" }';

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -42,7 +42,8 @@ suite('Polyfill tests', () => {
   });
 
   test('should support json imports', async function () {
-    const { m } = await importShim('./fixtures/json-assertion.js');
+    const { getJson } = await importShim('./fixtures/json-assertion.js');
+    const m = getJson();
     assert.equal(m.json, 'module');
     let maybeNative;
     try {

--- a/test/shim.js
+++ b/test/shim.js
@@ -80,7 +80,7 @@ suite('Basic loading tests', () => {
 
   test('should support import assertions', async function () {
     var m = await importShim('./fixtures/json-assertion.js');
-    assert.equal(m.m.json, 'module');
+    assert.equal(m.getJson().json, 'module');
   });
 
   test('should support css imports', async function () {


### PR DESCRIPTION
This PR includes some miscellaneous changes for a 2.5.0 release:

* Hot reloading bug fixes
* Amaro patch update
* TypeScript compilation logs in the debug build
* TypeScript compilation warning log to avoid production usage
* Workarounds for Firefox crash on JSON reexports (https://bugzilla.mozilla.org/show_bug.cgi?id=1965620)