### PR TITLE
feat: add boolean return support to hotReload(), add to types

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ In addition CSS files need to be served with a valid CSS content type.
 
 Implements the [WebAssembly ESM Integration](https://github.com/WebAssembly/esm-integration) spec, including support for source phase imports.
 
-In shim mode, Wasm modules are always supported. In polyfill mode, Wasm modules require the `polyfillEnable: ['wasm-module-sources']` (or `'wasm-modules-instances'` for instance imports) [init option](#polyfill-enable-option).
+In shim mode, Wasm modules are always supported. In polyfill mode, Wasm modules require the `polyfillEnable: ['wasm-module-sources']` (or `'wasm-module-instances'` for instance imports) [init option](#polyfill-enable-option).
 
 WebAssembly module exports are made available as module exports and WebAssembly module imports will be resolved using the browser module loader.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,10 +5,36 @@ interface ESMSInitOptions {
   shimMode?: boolean;
 
   /**
-   * Enable polyfill features.
-   * Currently supports ['css-modules', 'json-modules', 'wasm-modules', 'source-phase']
+   * Enable hot reloading
    */
-  polyfillEnable?: Array<'css-modules' | 'json-modules' | 'wasm-modules' | 'source-phase'>
+  hotReload?: boolean;
+
+  /**
+   * Set the hot reload refresh interval in ms
+   */
+  hotReloadInterval?: number;
+
+  /**
+   * Enable polyfill features.
+   * 
+   * Currently supports:
+   * - 'wasm-modules': Both 'wasm-module-sources' and 'wasm-module-instances'
+   * - 'wasm-module-sources': Support for Wasm source phase imports (import source mod from './mod.wasm')
+   * - 'wasm-module-instances': Support for Wasm instance phase imports (import * as mod from './mod.wasm')
+   * - 'import-defer': Support for import defer syntax (import defer * as ns from './foo.js')
+   */
+  polyfillEnable?: Array<'wasm-modules' | 'wasm-module-instances' | 'wasm-module-sources' | 'import-defer'>;
+
+  /**
+   * Version
+   * 
+   * Useful when there are multiple instances of ES Module Shims for whatever reason
+   * interacting in an application.
+   * 
+   * When set, ES Module Shims will early exit if its own version is not the expected version.
+   * Note that this feature is only supported from version 2.4.0 upwards.
+   */
+  version?: string;
 
   /**
    * #### Enforce Integrity
@@ -210,6 +236,8 @@ declare namespace importShim {
   const resolve: (id: string, parentURL?: string) => string;
   const addImportMap: (importMap: Partial<ImportMap>) => void;
   const getImportMap: () => ImportMap;
+  const hotReload: ((url: string) => boolean) | undefined;
+  const version: string;
 }
 
 interface Window {

--- a/src/hot-reload.js
+++ b/src/hot-reload.js
@@ -1,15 +1,15 @@
+import { topLevelLoad } from './core.js';
 import {
+  baseUrl,
+  chain
+  defaultFetchOpts,
   hotReloadInterval,
   importHook,
-  resolveHook,
   metaHook,
-  baseUrl,
   noop,
-  defaultFetchOpts,
+  resolveHook,
   throwError,
-  chain
 } from './env.js';
-import { topLevelLoad } from './core.js';
 
 let invalidate;
 export const hotReload = url => invalidate(new URL(url, baseUrl).href);
@@ -103,25 +103,24 @@ export const initHotReload = () => {
     });
 
   invalidate = (url, fromUrl, seen = []) => {
-    if (!seen.includes(url)) {
+      const hotState = hotRegistry[url];
+      if (!hotState || seen.includes(url)) return false;
       seen.push(url);
       if (self.ESMS_DEBUG) console.info(`es-module-shims: hot reload ${url}`);
-      const hotState = hotRegistry[url];
-      if (hotState) {
-        hotState.A = false;
-        if (
-          fromUrl &&
-          hotState.a &&
-          hotState.a.some(([d]) => d && (typeof d === 'string' ? d === fromUrl : d.includes(fromUrl)))
-        ) {
-          curInvalidationRoots.add(fromUrl);
-        } else {
-          if (hotState.e || hotState.a) curInvalidationRoots.add(url);
-          hotState.v++;
-          if (!hotState.a) for (const parent of hotState.p) invalidate(parent, url, seen);
-        }
+      hotState.A = false;
+      if (
+        fromUrl &&
+        hotState.a &&
+        hotState.a.some(([d]) => d && (typeof d === 'string' ? d === fromUrl : d.includes(fromUrl)))
+      ) {
+        curInvalidationRoots.add(fromUrl);
+      } else {
+        if (hotState.e || hotState.a) curInvalidationRoots.add(url);
+        hotState.v++;
+        if (!hotState.a) for (const parent of hotState.p) invalidate(parent, url, seen);
       }
       if (!curInvalidationInterval) curInvalidationInterval = setTimeout(handleInvalidations, hotReloadInterval);
+      return true;
     }
   };
 


### PR DESCRIPTION
This allows `importShim.hotReload(url)` when hot reloading is enabled to return true or false whether it was able to initiate a hot reload operation for a given source (i.e. that it was in the graph).

Also updates the types for hot reloading and fixes a typo in the readme.