### PR TITLE
feat: support polyfillDisable

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,7 +686,8 @@ const worker = new Worker(getWorkerScriptURL('myEsModule.js'));
 
 Provide a `esmsInitOptions` on the global scope before `es-module-shims` is loaded to configure various aspects of the module loading process:
 
-* [polyfillEnable](#polyfill-enable)
+* [polyfillEnable](#polyfill-enable-option)
+* [polyfillDisable](#polyfill-disable-option)
 * [enforceIntegrity](#enforce-integrity)
 * [fetch](#fetch-hook)
 * [mapOverrides](#overriding-import-map-entries)
@@ -709,6 +710,8 @@ window.esmsInitOptions = {
   shimMode: true, // default false
   // Enable newer modules features
   polyfillEnable: ['wasm-module-sources'], // default empty
+  // Disable features that are unused
+  polyfillDisable: ['css-modules'], // default empty
   // Custom CSP nonce
   nonce: 'n0nce', // default is automatic detection
   // Don't retrigger load events on module scripts (DOMContentLoaded, domready, window 'onload')
@@ -802,6 +805,26 @@ The reason the `polyfillEnable` option is needed is because ES Module Shims impl
 If the application code then tries to use modern features like CSS modules beyond this baseline it won't support those features. As a result all modules features which are considered newer or beyond the recommended baseline require explicit enabling. This common baseline itself will change to track the common future modules baseline supported by this project for each release cycle.
 
 This option can also be set to `true` to entirely disable the native passthrough system and ensure all sources are fetched and analyzed through ES Module Shims. This will still avoid duplicate execution since module graphs are still only reexecuted when they use unsupported native features, but there is a small extra cost in doing the analysis.
+
+### Pollyfill Disable Option
+
+Conversely to `polyfillEnable` it can be beneficial to dissable unused features where excluding those features from the baseline allows avoiding unnecessary feature detections or unnecessary analysis of module graphs.
+
+This option effectively lowers the baseline support allowing wider passthrough cases.
+
+The supported options currently are just `css-modules` and `json-modules`.
+
+For example:
+
+```html
+<script type="esms-options">
+{
+  "polyfillDisable": ["css-modules", "json-modules"]
+}
+</script>
+```
+
+will disable the CSS and JSON feature detections, and lower the baseline passthrough modules support from Chrome 123, Firefox 138 and Safari 17.2 down to Chrome 64, Safari 11.1 and Firefox 67.
 
 ### Enforce Integrity
 

--- a/src/core.js
+++ b/src/core.js
@@ -15,6 +15,8 @@ import {
   noLoadEventRetriggers,
   wasmInstancePhaseEnabled,
   wasmSourcePhaseEnabled,
+  cssModulesEnabled,
+  jsonModulesEnabled,
   deferPhaseEnabled,
   onpolyfill,
   enforceIntegrity,
@@ -183,8 +185,8 @@ const initPromise = featureDetectionPromise.then(() => {
   baselinePassthrough =
     esmsInitOptions.polyfillEnable !== true &&
     supportsImportMaps &&
-    supportsJsonType &&
-    supportsCssType &&
+    (!jsonModulesEnabled || supportsJsonType) &&
+    (!cssModulesEnabled || supportsCssType) &&
     (!wasmInstancePhaseEnabled || supportsWasmInstancePhase) &&
     (!wasmSourcePhaseEnabled || supportsWasmSourcePhase) &&
     !deferPhaseEnabled &&
@@ -617,7 +619,6 @@ const fetchModule = async (url, fetchOpts, parent) => {
 };
 
 const isUnsupportedType = type => {
-  if (type === 'wasm' && !wasmInstancePhaseEnabled && !wasmSourcePhaseEnabled) throw featErr(`wasm-modules`);
   return (
     (type === 'css' && !supportsCssType) ||
     (type === 'json' && !supportsJsonType) ||

--- a/src/env.js
+++ b/src/env.js
@@ -78,12 +78,16 @@ if (!nonce && hasDocument) {
 export const onerror = globalHook(esmsInitOptions.onerror || console.error.bind(console));
 
 const enable = Array.isArray(esmsInitOptions.polyfillEnable) ? esmsInitOptions.polyfillEnable : [];
+const disable = Array.isArray(esmsInitOptions.polyfillDisable) ? esmsInitOptions.polyfillDisable : [];
+
 const enableAll = esmsInitOptions.polyfillEnable === 'all' || enable.includes('all');
 export const wasmInstancePhaseEnabled =
   enable.includes('wasm-modules') || enable.includes('wasm-module-instances') || enableAll;
 export const wasmSourcePhaseEnabled =
   enable.includes('wasm-modules') || enable.includes('wasm-module-sources') || enableAll;
 export const deferPhaseEnabled = enable.includes('import-defer') || enableAll;
+export const cssModulesEnabled = !disable.includes('css-modules');
+export const jsonModulesEnabled = !disable.includes('json-modules');
 
 export const onpolyfill =
   esmsInitOptions.onpolyfill ?

--- a/src/features.js
+++ b/src/features.js
@@ -2,6 +2,8 @@ import {
   createBlob,
   noop,
   nonce,
+  cssModulesEnabled,
+  jsonModulesEnabled,
   wasmInstancePhaseEnabled,
   wasmSourcePhaseEnabled,
   hasDocument,
@@ -71,13 +73,13 @@ export let featureDetectionPromise = (async function () {
 
     // Feature checking with careful avoidance of unnecessary work - all gated on initial import map supports check. CSS gates on JSON feature check, Wasm instance phase gates on wasm source phase check.
     const importMapTest = `<script nonce=${nonce || ''}>b=(s,type='text/javascript')=>URL.createObjectURL(new Blob([s],{type}));c=u=>import(u).then(()=>true,()=>false);i=innerText=>document.head.appendChild(Object.assign(document.createElement('script'),{type:'importmap',nonce:"${nonce}",innerText}));i(\`{"imports":{"x":"\${b('')}"}}\`);i(\`{"imports":{"y":"\${b('')}"}}\`);cm=${
-      supportsImportMaps ? `c(b(\`import"\${b('{}','text/json')}"with{type:"json"}\`))` : 'false'
+      supportsImportMaps && jsonModulesEnabled ? `c(b(\`import"\${b('{}','text/json')}"with{type:"json"}\`))` : 'false'
     };sp=${
       supportsImportMaps && wasmSourcePhaseEnabled ?
         `c(b(\`import source x from "\${b(new Uint8Array(${JSON.stringify(wasmBytes)}),'application/wasm')\}"\`))`
       : 'false'
     };Promise.all([${supportsImportMaps ? 'true' : "c('x')"},${supportsImportMaps ? "c('y')" : false},cm,${
-      supportsImportMaps ? `cm.then(s=>s?c(b(\`import"\${b('','text/css')\}"with{type:"css"}\`)):false)` : 'false'
+      supportsImportMaps && cssModulesEnabled ? `cm.then(s=>s?c(b(\`import"\${b('','text/css')\}"with{type:"css"}\`)):false)` : 'false'
     },sp,${
       supportsImportMaps && wasmInstancePhaseEnabled ?
         `${wasmSourcePhaseEnabled ? 'sp.then(s=>s?' : ''}c(b(\`import"\${b(new Uint8Array(${JSON.stringify(wasmBytes)}),'application/wasm')\}"\`))${wasmSourcePhaseEnabled ? ':false)' : ''}`


### PR DESCRIPTION
This adds a new `polyfillDisable` option for disabling the `css-modules` and `json-modules` features which were recently brought into the baseline.

Resolves https://github.com/guybedford/es-module-shims/issues/493.