### PR TITLE
Backup handler for shared worker

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -394,7 +394,8 @@ const resolveDeps = (load, seen) => {
 
   // once all deps have loaded we can inline the dependency resolution blobs
   // and define this blob
-  (resolvedSource = ''), (lastIndex = 0);
+  resolvedSource = '';
+  lastIndex = 0;
 
   for (const { s: start, e: end, ss: statementStart, se: statementEnd, d: dynamicImportIndex, t, a } of imports) {
     // source phase

--- a/src/core.js
+++ b/src/core.js
@@ -327,7 +327,7 @@ export const topLevelLoad = async (
 
 const revokeObjectURLs = registryKeys => {
   let curIdx = 0;
-  const handler = self.requestIdleCallback || self.requestAnimationFrame;
+  const handler = self.requestIdleCallback || self.requestAnimationFrame || (fn => setTimeout(fn, 0));
   handler(cleanup);
   function cleanup() {
     for (const key of registryKeys.slice(curIdx, (curIdx += 100))) {

--- a/src/env.js
+++ b/src/env.js
@@ -123,7 +123,8 @@ if (Array.isArray(skip)) {
 const dispatchError = error => self.dispatchEvent(Object.assign(new Event('error'), { error }));
 
 export const throwError = err => {
-  (self.reportError || dispatchError)(err), void onerror(err);
+  (self.reportError || dispatchError)(err);
+  onerror(err);
 };
 
 export const fromParent = parent => (parent ? ` imported from ${parent}` : '');


### PR DESCRIPTION
Fixes: [#500 SharedWorker "TypeError: handler is not a function"](https://github.com/guybedford/es-module-shims/issues/500).

Added a backup handler using a timeout to defer execution since neither `requestIdleCallback` or `requestAnimationFrame` are available in a shared worker context.