### PR TITLE
fix json modules with keys named "__proto__"

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -600,7 +600,7 @@ const fetchModule = async (reqUrl, fetchOpts, parent) => {
     }
     source += `if(h)h.accept(m=>({${obj}}=m))`;
   } else if (type === 'json') {
-    source = `${hotPrefix}j=${source};export{j as default};if(h)h.accept(m=>j=m.default)`;
+    source = `${hotPrefix}j=JSON.parse(${JSON.stringify(source)});export{j as default};if(h)h.accept(m=>j=m.default)`;
   } else if (type === 'css') {
     source = `${hotPrefix}s=h&&h.data.s||new CSSStyleSheet();s.replaceSync(${JSON.stringify(
       source.replace(

--- a/test/fixtures/json-proto.js
+++ b/test/fixtures/json-proto.js
@@ -1,0 +1,5 @@
+import json from './proto.json' with { type: 'json' };
+
+export function getJson () {
+  return json;
+}

--- a/test/fixtures/proto.json
+++ b/test/fixtures/proto.json
@@ -1,0 +1,1 @@
+{ "__proto__": "module" }

--- a/test/shim.js
+++ b/test/shim.js
@@ -83,6 +83,11 @@ suite('Basic loading tests', () => {
     assert.equal(m.getJson().json, 'module');
   });
 
+  test('should support __proto__ key in json', async function () {
+    var m = await importShim('./fixtures/json-proto.js');
+    assert.equal(m.getJson().__proto__, 'module');
+  });
+
   test('should support css imports', async function () {
     var m = await importShim('./fixtures/css-assertion.js');
     assert.equal(m.default.cssRules[0].selectorText, 'body');


### PR DESCRIPTION
```js
const json = JSON.parse('{"__proto__": "a"}')
console.assert(json.__proto__ === "a")

const js = {"__proto__": "a"}
// different behavior from json!
console.assert(js.__proto__ === Object.prototype))
```