### PR TITLE
add packageManager to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,6 @@
   "bugs": {
     "url": "https://github.com/guybedford/es-module-shims/issues"
   },
-  "homepage": "https://github.com/guybedford/es-module-shims#readme"
+  "homepage": "https://github.com/guybedford/es-module-shims#readme",
+  "packageManager": "npm@10.8.1+sha1.1f1cb1305cd9246b9efe07d8629874df23157a2f"
 }


### PR DESCRIPTION
if this isn't present corepack tries to add it every time i run a package manager (this behavior is changing in an upcoming release iirc but it's still good practice to have packageManager set)