### PR TITLE
fix invalid syntax in typescript test

### DIFF
--- a/test/test-ts.html
+++ b/test/test-ts.html
@@ -29,7 +29,7 @@
 
 <script type="module" lang="ts">
   type test = 'hi' | boolean;
-  window.inlineTypescript as test = true;
+  window.inlineTypescript = true as test;
 </script>
 
 <script type="module" lang="ts">


### PR DESCRIPTION
this isn't actually valid typescript syntax and it's rejected by tsc among other transpilers. this causes issues when running the tests with a non-amaro type stripping implementation.