### PR TITLE
fix line ending issue with sri test

### DIFF
--- a/test/fixtures/es-modules/es6-dep.js
+++ b/test/fixtures/es-modules/es6-dep.js
@@ -1,1 +1,1 @@
-export var p = 'p';
+/* no line endings or git will break on windows vs linux */ export var p = 'p';

--- a/test/test-shim.html
+++ b/test/test-shim.html
@@ -19,7 +19,7 @@
     }
   },
   "integrity": {
-    "./fixtures/es-modules/es6-dep.js": "sha384-WBlJ+EO4b/8SuvC2RFiCt9z42esd35mcYuzHGIlqiltBvS6X11jqp06aksdZWflh"
+    "./fixtures/es-modules/es6-dep.js": "sha384-i34R3J2dGMsmlHW3LSvmwvHIEuq554P2uWvhul+KnxNAG4bdWTqMphwHxkVJgsHT"
   }
 }
 </script>


### PR DESCRIPTION
avoids git rewriting \n to \r\n and vice versa by just making the file a single line with no trailing \n so the tests can run on windows and everything else at the same time