### PR TITLE
remove internal import cycles

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -42,7 +42,7 @@ import {
   featureDetectionPromise
 } from './features.js';
 import * as lexer from '../node_modules/es-module-lexer/dist/lexer.asm.js';
-import { hotReload } from './hot-reload.js';
+import { hotReload, initHotReload } from './hot-reload.js';
 
 const _resolve = (id, parentUrl = pageBaseUrl) => {
   const urlResolved = resolveIfNotPlainOrUrl(id, parentUrl) || asURL(id);
@@ -123,7 +123,10 @@ if (shimMode || wasmSourcePhaseEnabled)
 // import.defer() is just a proxy for import(), since we can't actually defer
 if (shimMode || deferPhaseEnabled) importShim.defer = importShim;
 
-if (hotReloadEnabled) importShim.hotReload = hotReload;
+if (hotReloadEnabled) {
+  initHotReload(topLevelLoad, importShim);
+  importShim.hotReload = hotReload;
+}
 
 const defaultResolve = (id, parentUrl) => {
   return (
@@ -260,7 +263,7 @@ let importMapPromise = initPromise;
 let firstPolyfillLoad = true;
 let legacyAcceptingImportMaps = true;
 
-export const topLevelLoad = async (
+export async function topLevelLoad(
   url,
   parentUrl,
   fetchOpts,
@@ -268,7 +271,7 @@ export const topLevelLoad = async (
   nativelyLoaded,
   lastStaticLoadPromise,
   sourceType
-) => {
+) {
   await initPromise;
   await importMapPromise;
   url = (await resolve(url, parentUrl)).r;
@@ -319,7 +322,7 @@ export const topLevelLoad = async (
   if (load.s) (await dynamicImport(load.s, load.u)).u$_(module);
   revokeObjectURLs(Object.keys(seen));
   return module;
-};
+}
 
 const revokeObjectURLs = registryKeys => {
   let curIdx = 0;

--- a/src/env.js
+++ b/src/env.js
@@ -69,7 +69,11 @@ export const {
   nativePassthrough = !hasCustomizationHooks && !hotReload
 } = esmsInitOptions;
 
-if (hotReload) [importHook, resolveHook, metaHook] = initHotReload();
+export const setHooks = (importHook_, resolveHook_, metaHook_) => (
+  (importHook = importHook_),
+  (resolveHook = resolveHook_),
+  (metaHook = metaHook_)
+);
 
 export const mapOverrides = esmsInitOptions.mapOverrides;
 

--- a/src/hot-reload.js
+++ b/src/hot-reload.js
@@ -1,5 +1,4 @@
 import { self } from './self.js';
-import { topLevelLoad } from './core.js';
 import {
   baseUrl,
   defaultFetchOpts,
@@ -8,12 +7,13 @@ import {
   metaHook,
   chain,
   resolveHook,
-  throwError
+  throwError,
+  setHooks
 } from './env.js';
 
 let invalidate;
 export const hotReload = url => invalidate(new URL(url, baseUrl).href);
-export const initHotReload = () => {
+export const initHotReload = (topLevelLoad, importShim) => {
   let _importHook = importHook,
     _resolveHook = resolveHook,
     _metaHook = metaHook;
@@ -159,12 +159,12 @@ export const initHotReload = () => {
     curInvalidationRoots = new Set();
   };
 
-  return [
+  setHooks(
     _importHook ? chain(_importHook, hotImportHook) : hotImportHook,
     _resolveHook ?
       (id, parent, defaultResolve) =>
         hotResolveHook(id, parent, (id, parent) => _resolveHook(id, parent, defaultResolve))
     : hotResolveHook,
     _metaHook ? chain(_metaHook, hotMetaHook) : hotMetaHook
-  ];
+  );
 };


### PR DESCRIPTION
the hot reload feature (i think) introduced some import cycles. this takes them back out.