### PR TITLE
use an import instead of a global when referencing importShim from loaded modules

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -1,5 +1,4 @@
 import { self } from './self.js';
-import { initHotReload } from './hot-reload.js';
 
 export const hasDocument = typeof document !== 'undefined';
 

--- a/test/shim.js
+++ b/test/shim.js
@@ -450,7 +450,7 @@ suite('Source maps', () => {
     const moduleBlobURL = importShim._r[moduleURL].b;
     const blobContent = await fetch(moduleBlobURL).then(r => r.text());
     const sourceURL = new URL('module.ts', moduleURL).href;
-    assert(blobContent.endsWith(`//# sourceURL=${sourceURL}`));
+    assert(blobContent.includes(`//# sourceURL=${sourceURL}`));
     // Should not touch any other occurrences of `//# sourceURL=` in the code.
     assert(blobContent.includes('//# sourceURL=i-should-not-be-affected.no'));
   });
@@ -461,7 +461,7 @@ suite('Source maps', () => {
     const moduleBlobURL = importShim._r[moduleURL].b;
     const blobContent = await fetch(moduleBlobURL).then(r => r.text());
     const sourceMappingURL = new URL('./with-relative-source-mapping-url.js.map', moduleURL).href;
-    assert(blobContent.endsWith(
+    assert(blobContent.includes(
         `//# sourceMappingURL=${sourceMappingURL}\n//# sourceURL=${moduleURL}`
     ));
 
@@ -474,7 +474,7 @@ suite('Source maps', () => {
     await importShim(moduleURL);
     const moduleBlobURL = importShim._r[moduleURL].b;
     const blobContent = await fetch(moduleBlobURL).then(r => r.text());
-    assert(blobContent.endsWith(
+    assert(blobContent.includes(
         `//# sourceMappingURL=https://example.com/module.js.map\n//# sourceURL=${moduleURL}`
     ));
 
@@ -487,7 +487,7 @@ suite('Source maps', () => {
     await importShim(moduleURL);
     const moduleBlobURL = importShim._r[moduleURL].b;
     const blobContent = await fetch(moduleBlobURL).then(r => r.text());
-    assert(blobContent.endsWith(
+    assert(blobContent.includes(
         `//# sourceURL=${new URL('/with-source-url-and-source-mapping-url.js', window.location.origin)}\n//# sourceMappingURL=https://example.com/module.js.map`
     ));
 


### PR DESCRIPTION
this lays the groundwork for multiple versions/forks of es-module-shims to coexist on the same page by having transformed modules import importShim from a "registry" (`export let i,s=_=>i=_`) like `import { i as importShim } from "blob:...."` rather than relying on the global version. this PR does not change the API exposed by es-module-shims, it still defines the global in exactly the same way, it just doesn't use it as extensively internally.