### PR TITLE
move globalThis.importShim definition out of core.js

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -181,6 +181,7 @@ let firstImportMap = null;
 // To support polyfilling multiple import maps, we separately track the composed import map from the first import map
 let composedImportMap = { imports: {}, scopes: {}, integrity: {} };
 let baselineSupport;
+let registryUrl;
 
 const initPromise = featureDetectionPromise.then(() => {
   baselineSupport =
@@ -234,7 +235,10 @@ const initPromise = featureDetectionPromise.then(() => {
     }
     processScriptsAndPreloads();
   }
-  return lexer.init;
+  return Promise.all([
+    dynamicImport((registryUrl = createBlob('export let i,s=_=>i=_'))).then(m => m.s(importShim)),
+    lexer.init
+  ]);
 });
 
 const attachMutationObserver = () => {
@@ -397,12 +401,15 @@ const resolveDeps = (load, seen) => {
   resolvedSource = '';
   lastIndex = 0;
 
+  // don't rely on the global
+  resolvedSource += `import{i as importShim}from'${registryUrl}';`;
+
   for (const { s: start, e: end, ss: statementStart, se: statementEnd, d: dynamicImportIndex, t, a } of imports) {
     // source phase
     if (t === 4) {
       let { l: depLoad } = load.d[depIndex++];
       pushStringTo(load, statementStart, dynamicImportEndStack);
-      resolvedSource += `${source.slice(statementStart, start - 1).replace('source', '')}/*${source.slice(start - 1, end + 1)}*/'${createBlob(`export default importShim._s[${urlJsString(depLoad.r)}]`)}'`;
+      resolvedSource += `${source.slice(statementStart, start - 1).replace('source', '')}/*${source.slice(start - 1, end + 1)}*/'${createBlob(`import{i}from'${registryUrl}';export default i._s[${urlJsString(depLoad.r)}]`)}'`;
       lastIndex = end + 1;
     }
     // dependency source replacements

--- a/src/core.js
+++ b/src/core.js
@@ -21,14 +21,12 @@ import {
   onpolyfill,
   enforceIntegrity,
   fromParent,
-  esmsInitOptions,
   nativePassthrough,
   hasDocument,
   hotReload as hotReloadEnabled,
   hasCustomizationHooks,
   defaultFetchOpts,
   defineValue,
-  optionsScript,
   version
 } from './env.js';
 import {
@@ -77,7 +75,7 @@ const resolve = (id, parentUrl) => {
 };
 
 // import()
-async function importShim(id, opts, parentUrl) {
+export async function importShim(id, opts, parentUrl) {
   if (typeof opts === 'string') {
     parentUrl = opts;
     opts = undefined;
@@ -157,11 +155,7 @@ const registry = (importShim._r = {});
 const sourceCache = (importShim._s = {});
 const instanceCache = (importShim._i = new WeakMap());
 
-// Ensure this version is the only version
-defineValue(self, 'importShim', Object.freeze(importShim));
-const shimModeOptions = { ...esmsInitOptions, shimMode: true };
-if (optionsScript) optionsScript.innerHTML = JSON.stringify(shimModeOptions);
-self.esmsInitOptions = shimModeOptions;
+Object.freeze(importShim);
 
 const loadAll = async (load, seen) => {
   seen[load.u] = 1;

--- a/src/env.js
+++ b/src/env.js
@@ -22,15 +22,6 @@ Object.assign(esmsInitOptions, self.esmsInitOptions || {});
 
 export const version = self.VERSION;
 
-const r = esmsInitOptions.version;
-if (self.importShim || (r && r !== version)) {
-  if (self.ESMS_DEBUG)
-    console.info(
-      `es-module-shims: skipping initialization as ${r ? `configured for ${r}` : 'another instance has already registered'}`
-    );
-  $ret();
-}
-
 // shim mode is determined on initialization, no late shim mode
 export const shimMode =
   esmsInitOptions.shimMode ||

--- a/src/es-module-shims.js
+++ b/src/es-module-shims.js
@@ -1,1 +1,9 @@
-import './core.js';
+import { self } from './self.js';
+import { esmsInitOptions, defineValue, optionsScript } from './env.js';
+import './version-check.js';
+import { importShim } from './core.js';
+
+defineValue(self, 'importShim', importShim);
+const shimModeOptions = { ...esmsInitOptions, shimMode: true };
+if (optionsScript) optionsScript.innerHTML = JSON.stringify(shimModeOptions);
+self.esmsInitOptions = shimModeOptions;

--- a/src/version-check.js
+++ b/src/version-check.js
@@ -1,0 +1,10 @@
+import { esmsInitOptions, version } from './env.js';
+
+const r = esmsInitOptions.version;
+if (self.importShim || (r && r !== version)) {
+  if (self.ESMS_DEBUG)
+    console.info(
+      `es-module-shims: skipping initialization as ${r ? `configured for ${r}` : 'another instance has already registered'}`
+    );
+  $ret();
+}


### PR DESCRIPTION
relies on https://github.com/guybedford/es-module-shims/pull/516

moves the global registration code out of core.js so it's easier to add new entrypoints that don't modify the global scope