### PR TITLE
add fallback when document and location are both undefined

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -100,13 +100,14 @@ export const onpolyfill =
     };
 
 export const baseUrl =
-  hasDocument ?
-    document.baseURI
-  : `${location.protocol}//${location.host}${
+  hasDocument ? document.baseURI
+  : typeof location !== 'undefined' ?
+    `${location.protocol}//${location.host}${
       location.pathname.includes('/') ?
         location.pathname.slice(0, location.pathname.lastIndexOf('/') + 1)
       : location.pathname
-    }`;
+    }`
+  : 'about:blank';
 
 export const createBlob = (source, type = 'text/javascript') => URL.createObjectURL(new Blob([source], { type }));
 export let { skip } = esmsInitOptions;


### PR DESCRIPTION
right now when loading es-module-shims in deno with no `--location` flag provided or node¹ it throws an error because it expects location to always be defined. this adds a fallback to `about:blank` which may not be ideal it's just the first thing i thought of lol

¹ though node doesn't support blob url imports yet so it's not super relevant there