### PR TITLE
Synthetic events fixes

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -762,8 +762,7 @@ const domContentLoadedCheck = m => {
     if (domContentLoaded) return;
     domContentLoaded = true;
     domContentLoadedCnt--;
-  }
-  if (--domContentLoadedCnt === 0 && !noLoadEventRetriggers && (shimMode || !baselineSupport)) {
+  } else if (--domContentLoadedCnt === 0 && !noLoadEventRetriggers && (shimMode || !baselineSupport)) {
     if (self.ESMS_DEBUG) console.info(`es-module-shims: DOMContentLoaded refire`);
     document.removeEventListener('DOMContentLoaded', domContentLoadedEvent);
     document.dispatchEvent(new Event('DOMContentLoaded'));

--- a/src/core.js
+++ b/src/core.js
@@ -305,7 +305,7 @@ export async function topLevelLoad(
         console.info(
           `es-module-shims: early exit after graph analysis of ${url} - graph ran natively without needing polyfill`
         );
-      return;
+      return null;
     }
     if (source) {
       return await dynamicImport(createBlob(source), source);

--- a/test/fixtures/module-dynamic.js
+++ b/test/fixtures/module-dynamic.js
@@ -1,5 +1,5 @@
 console.log("Dynamically imported module imported");
 document.getElementById("dynamic").innerText = "loaded";
 
-if (window.domContentLoaded)
+if (window.loaded && window.domContentLoaded)
   fetch('/done');

--- a/test/test-double-polyfill.html
+++ b/test/test-double-polyfill.html
@@ -22,6 +22,9 @@
 
     <script type="module">
         import "statically-imported-module";
+        window.addEventListener('load', () => {
+          window.loaded = true;
+        });
         document.addEventListener('DOMContentLoaded', () => {
           window.domContentLoaded = true;
         });


### PR DESCRIPTION
Repost of https://github.com/guybedford/es-module-shims/pull/506 with further fixes.

I think there was another bug with DOMContentLoaded where the `undefined` case was still falling through to the normal check. 

//cc @frandiox would value your review before landing still.