### PR TITLE
Fix shimMode default inside worker

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -38,7 +38,7 @@ export const shimMode =
   (hasDocument ?
     document.querySelectorAll('script[type=module-shim],script[type=importmap-shim],link[rel=modulepreload-shim]')
       .length > 0
-  // Without a document, shim mode is always true as we cannot polyfill
+    // Without a document, shim mode is always true as we cannot polyfill
   : true);
 
 export let importHook,


### PR DESCRIPTION
Fixes #524, by reintroducing the `true` default if there is no document.