### PR TITLE
fix: guard trusted types check for worker contexts

### DIFF
--- a/src/trusted-types.js
+++ b/src/trusted-types.js
@@ -1,5 +1,8 @@
 export let policy;
-if (typeof self !== 'undefined' && (typeof self.trustedTypes !== 'undefined' || typeof self.TrustedTypes !== 'undefined')) {
+if (
+  typeof self !== 'undefined' &&
+  (typeof self.trustedTypes !== 'undefined' || typeof self.TrustedTypes !== 'undefined')
+) {
   try {
     policy = (self.trustedTypes || self.TrustedTypes).createPolicy('es-module-shims', {
       createHTML: html => html,

--- a/src/trusted-types.js
+++ b/src/trusted-types.js
@@ -1,7 +1,7 @@
 export let policy;
-if (typeof window.trustedTypes !== 'undefined' || typeof window.TrustedTypes !== 'undefined') {
+if (typeof self !== 'undefined' && (typeof self.trustedTypes !== 'undefined' || typeof self.TrustedTypes !== 'undefined')) {
   try {
-    policy = (window.trustedTypes || window.TrustedTypes).createPolicy('es-module-shims', {
+    policy = (self.trustedTypes || self.TrustedTypes).createPolicy('es-module-shims', {
       createHTML: html => html,
       createScript: script => script
     });

--- a/test/shim.js
+++ b/test/shim.js
@@ -369,8 +369,6 @@ suite('Errors', function () {
     assert(err.response instanceof Response);
   });
 
-  this.timeout(10000);
-
   test('Dynamic import map shim', async function () {
     insertDynamicImportMap({
       "imports": {


### PR DESCRIPTION
Fixes #540.

Since 2.8.0, `src/trusted-types.js` accesses `window.trustedTypes` unconditionally, which throws in worker contexts where `window` is undefined. Switched to `self` (available in both window and worker scopes) with a `typeof self !== 'undefined'` guard.