### PR TITLE
fix: detect multiple import maps under trusted types policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           '89.0',  # top-level await
           '108.0',
           '126.0', # before integrity
+          'latest', # current stable - regression coverage for the native passthrough path with all features
         ]
     name: Firefox Browser Tests
     steps:
@@ -42,13 +43,14 @@ jobs:
         with:
           node-version: 
       - name: Setup Firefox ${{ matrix.firefox }}
+        id: setup-firefox
         uses: browser-actions/setup-firefox@latest
         with:
           firefox-version: ${{ matrix.firefox }}
       - name: Chomp Test
         run: chomp test
         env:
-          CI_BROWSER: C:\Program Files\Firefox_${{ matrix.firefox }}\firefox.exe
+          CI_BROWSER: ${{ steps.setup-firefox.outputs.firefox-path }}
           CI_BROWSER_FLAGS: -headless
           CI_BROWSER_FLUSH: taskkill /F /IM firefox.exe
 
@@ -62,7 +64,8 @@ jobs:
           '859178', # Mar 2021, Import Maps
           '913920', # August 2021, JSON modules + CSS modules
           '1306171', # May 2024, just before integrity
-          '1408499', #Jan 2025, multiple import maps
+          '1408499', # Jan 2025, multiple import maps
+          'latest', # current stable - regression coverage for the native passthrough path with all features
         ]
     name: Chrome Browser Tests
     steps:
@@ -74,11 +77,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
       - name: Setup Chrome ${{ matrix.chrome }}
+        id: setup-chrome
         uses: browser-actions/setup-chrome@latest
         with:
           chrome-version: ${{ matrix.chrome }}
       - name: Chomp Test
         run: chomp test
         env:
-          CI_BROWSER: C:\hostedtoolcache\windows\setup-chrome\chrome\${{ matrix.chrome }}\x64\chrome.exe
-          CI_BROWSER_FLAGS: 
+          CI_BROWSER: ${{ steps.setup-chrome.outputs.chrome-path }}
+          CI_BROWSER_FLAGS:

--- a/src/features.js
+++ b/src/features.js
@@ -75,11 +75,9 @@ export let featureDetectionPromise = (async function () {
     // Feature checking with careful avoidance of unnecessary work - all gated on initial import map supports check. CSS gates on JSON feature check, Wasm instance phase gates on wasm source phase check.
     const importMapTest = `<script nonce=${nonce || ''}>${
       policy ? 't=(window.trustedTypes||window.TrustedTypes).createPolicy("es-module-shims",{createScript:s=>s});' : ''
-    }b=(s,type='text/javascript')=>URL.createObjectURL(new Blob([s],{type}));c=u=>import(u).then(()=>true,()=>false);i=innerText=>${
-      policy ? 't.createScript(innerText=>' : ''
-    }document.head.appendChild(Object.assign(document.createElement('script'),{type:'importmap',nonce:"${nonce}",innerText}))${
-      policy ? ')' : ''
-    };i(\`{"imports":{"x":"\${b('')}"}}\`);i(\`{"imports":{"y":"\${b('')}"}}\`);cm=${
+    }b=(s,type='text/javascript')=>URL.createObjectURL(new Blob([s],{type}));c=u=>import(u).then(()=>true,()=>false);i=innerText=>document.head.appendChild(Object.assign(document.createElement('script'),{type:'importmap',nonce:"${nonce}",text:${
+      policy ? 't.createScript(innerText)' : 'innerText'
+    }}));i(\`{"imports":{"x":"\${b('')}"}}\`);i(\`{"imports":{"y":"\${b('')}"}}\`);cm=${
       supportsImportMaps && jsonModulesEnabled ? `c(b(\`import"\${b('{}','text/json')}"with{type:"json"}\`))` : 'false'
     };sp=${
       supportsImportMaps && wasmSourcePhaseEnabled ?

--- a/test/fixtures/chain-child.js
+++ b/test/fixtures/chain-child.js
@@ -1,0 +1,1 @@
+window.chainChildCnt = (window.chainChildCnt || 0) + 1;

--- a/test/fixtures/chain-parent.js
+++ b/test/fixtures/chain-parent.js
@@ -1,0 +1,2 @@
+import 'chain-child';
+window.chainParentCnt = (window.chainParentCnt || 0) + 1;

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -109,6 +109,13 @@ suite('Polyfill tests', () => {
     assert.equal(window.cnt, 1);
   });
 
+  test('Polyfill engagement with bare specifier dependency chain from second import map', async function () {
+    if (window.chainParentCnt > 1 || window.chainChildCnt > 1)
+      throw new Error(`Polyfill engaged despite native multiple import maps support`);
+    assert.equal(window.chainParentCnt, 1);
+    assert.equal(window.chainChildCnt, 1);
+  });
+
   test('DOMContentLoaded fires at least once', async function () {
     assert.ok(window.domLoad === 1 || window.domLoad === 2);
   });

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -110,6 +110,7 @@ suite('Polyfill tests', () => {
   });
 
   test('Polyfill engagement with bare specifier dependency chain from second import map', async function () {
+    await importShim('chain-parent');
     if (window.chainParentCnt > 1 || window.chainChildCnt > 1)
       throw new Error(`Polyfill engaged despite native multiple import maps support`);
     assert.equal(window.chainParentCnt, 1);

--- a/test/test-csp.html
+++ b/test/test-csp.html
@@ -21,7 +21,9 @@
 <script type="importmap" nonce="asdf">
 {
   "imports": {
-    "global1": "data:text/javascript,throw new Error('Polyfill should not support multiple import maps');"
+    "global1": "data:text/javascript,throw new Error('Polyfill should not support multiple import maps');",
+    "chain-parent": "/test/fixtures/chain-parent.js",
+    "chain-child": "/test/fixtures/chain-child.js"
   }
 }
 </script>
@@ -43,6 +45,9 @@
 
 <script type="module" nonce="asdf">
   import 'once';
+</script>
+<script type="module" nonce="asdf">
+  import 'chain-parent';
 </script>
 
 <script type="module" src="../src/es-module-shims.js" nonce="asdf"></script>

--- a/test/test-polyfill-wasm.html
+++ b/test/test-polyfill-wasm.html
@@ -18,7 +18,9 @@
 <script type="importmap">
 {
   "imports": {
-    "global1": "data:text/javascript,throw new Error('Polyfill should not support multiple import maps');"
+    "global1": "data:text/javascript,throw new Error('Polyfill should not support multiple import maps');",
+    "chain-parent": "/test/fixtures/chain-parent.js",
+    "chain-child": "/test/fixtures/chain-child.js"
   }
 }
 </script>
@@ -35,6 +37,9 @@
 
 <script type="module">
   import 'once';
+</script>
+<script type="module">
+  import 'chain-parent';
 </script>
 
 <script type="module" src="../dist/es-module-shims.wasm.js"></script>

--- a/test/test-polyfill.html
+++ b/test/test-polyfill.html
@@ -17,12 +17,17 @@
 <script type="importmap">
 {
   "imports": {
-    "global1": "/test/fixtures/es-modules/global1.js"
+    "global1": "/test/fixtures/es-modules/global1.js",
+    "chain-parent": "/test/fixtures/chain-parent.js",
+    "chain-child": "/test/fixtures/chain-child.js"
   }
 }
 </script>
 <script type="module">
   import 'once';
+</script>
+<script type="module">
+  import 'chain-parent';
 </script>
 
 <script>


### PR DESCRIPTION
Fixes #539.

## Root cause

The trusted-types path added in #536 wrapped the wrong thing. In `src/features.js` the iframe-injected `i` helper was generated as:

```js
i = innerText => t.createScript(innerText => document.head.appendChild(...))
```

`t.createScript()` only stringifies its argument, so the inner arrow function (containing `appendChild`) was never invoked. **No import maps were ever registered in the detection iframe.**

Because the trusted-types policy is created unconditionally whenever `window.trustedTypes` is exposed (which it is in modern Chrome regardless of CSP), this affected every Chrome user — `c('y')` always failed → `supportsMultipleImportMaps` always reported `false`.

## User-visible effect

For any module reachable only via a second import map, the polyfill engaged even when the browser supported multiple import maps natively, causing the module to execute twice (#539).

## Fix

Wrap the import map JSON content in `t.createScript()` at the actual script-text sink:

```js
i = innerText => document.head.appendChild(Object.assign(
  document.createElement('script'),
  { type: 'importmap', nonce: "...", text: t.createScript(innerText) /* or just innerText with no policy */ }
))
```

## Test

`test/polyfill.js` adds an engagement test using a static `import 'chain-parent'` where `chain-parent.js` itself does `import 'chain-child'`, both bare specifiers mapped only via the second import map. Asserts neither counter exceeds 1.