### PR TITLE
fix: use Set.add instead of .push in HMR array-accept early-root tracking

### DIFF
--- a/src/hot-reload.js
+++ b/src/hot-reload.js
@@ -151,7 +151,7 @@ export const initHotReload = (topLevelLoad, importShim) => {
                 !earlyRoots.has(c) &&
                 (typeof d === 'string' ?
                   d === root && c(m)
-                : c(await Promise.all(d.map(d => (earlyRoots.push(c), importShim(toVersioned(d, getHotState(d))))))))
+                : c(await Promise.all(d.map(d => (earlyRoots.add(c), importShim(toVersioned(d, getHotState(d))))))))
             );
         });
       }, throwError);


### PR DESCRIPTION
`earlyRoots` is declared as `new Set()` in `handleInvalidations`, and the surrounding code correctly uses `earlyRoots.has(c)` on lines 138 and 151. But line 154 (the array-deps branch of `accept`) calls `earlyRoots.push(c)` — which throws `TypeError: t.push is not a function` the first time a module reloads where any parent has registered an array-form accept.

## Reproducing

A parent module registers the array-deps form of accept:

```js
import.meta.hot.accept([
  './layers.ts',
  './input.ts',
  './radio/callsign.ts',
  // ...
], () => { /* ... */ });
```

Then editing any listed dep triggers:

```
es-module-shims.js: Uncaught (in promise) TypeError: t.push is not a function
```

## Fix

```diff
-                : c(await Promise.all(d.map(d => (earlyRoots.push(c), importShim(toVersioned(d, getHotState(d))))))))
+                : c(await Promise.all(d.map(d => (earlyRoots.add(c), importShim(toVersioned(d, getHotState(d))))))))
```

One-line change in `src/hot-reload.js`.