### PR TITLE
Skip feature detection in shim mode

### DIFF
--- a/src/features.js
+++ b/src/features.js
@@ -8,6 +8,7 @@ import {
   wasmInstancePhaseEnabled,
   wasmSourcePhaseEnabled,
   hasDocument,
+  shimMode,
   version
 } from './env.js';
 import { maybeTrustedInnerHTML, maybeTrustedScript, policy } from './trusted-types.js';
@@ -26,6 +27,8 @@ export let supportsMultipleImportMaps = false;
 const wasmBytes = [0, 97, 115, 109, 1, 0, 0, 0];
 
 export let featureDetectionPromise = (async function () {
+  // In shim mode, feature detection results are unused — skip the iframe overhead
+  if (shimMode) return;
   if (!hasDocument)
     return Promise.all([
       import(createBlob(`import"${createBlob('{}', 'text/json')}"with{type:"json"}`)).then(

--- a/test/test-dom-order.html
+++ b/test/test-dom-order.html
@@ -15,7 +15,7 @@
 <script type="module-shim">
   new Promise(resolve => setTimeout(resolve, 3000)).then(() => {
     const orderStr = order.join(', ');
-    if (orderStr.startsWith('script (loading), interactive, dom content loaded') && orderStr.includes(', complete') && orderStr.includes(', module2') && orderStr.includes(', module1'))
+    if (orderStr.startsWith('script (loading), interactive') && orderStr.includes(', dom content loaded') && orderStr.includes(', complete') && orderStr.includes(', module2') && orderStr.includes(', module1'))
       fetch('/done');
     else
     fetch(`/error?${encodeURIComponent(order.join(', '))}`);


### PR DESCRIPTION
In shim mode, the feature detection results are unused — the shim loader processes all modules regardless of native support. Skip the iframe-based detection entirely to avoid unnecessary DOM overhead.